### PR TITLE
Remove mentions of Cliquet

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,7 @@ const db = new Kinto(options);
 `options` is an object defining the following option values:
 
 - `remote`: The remote Kinto server endpoint root URL (eg. `"https://server/v1"`). Not that you *must* define a URL matching the version of the protocol the client supports, otherwise you'll get an error;
-- `headers`: The default headers to pass for every HTTP request performed to the Cliquet server (eg. `{"Authorization": "Basic bWF0Og=="}`);
+- `headers`: The default headers to pass for every HTTP request performed to the Kinto server (eg. `{"Authorization": "Basic bWF0Og=="}`);
 - `adapter`: The persistence layer adapter to use for saving data locally (default: `Kinto.adapters.IDB`); alternatively, a `Kinto.adapters.LocalStorage` adapter is also provided; last, if you plan on writing your own adapter, you can read more about how to do so in the [Extending Kinto.js](extending.md) section.
 - `requestMode`: The HTTP [CORS](https://fetch.spec.whatwg.org/#concept-request-mode) mode. Default: `cors`.
 
@@ -295,7 +295,7 @@ Here we're solving encountered conflicts by picking all remote versions. After c
 
 ## Handling server backoff
 
-If the Kinto server instance is under heavy load or maintenance, their admins can [send a Backoff header](http://cliquet.readthedocs.org/en/latest/api/backoff.html) and it's the responsibily for clients to hold on performing more requests for a given amount of time, expressed in seconds.
+If the Kinto server instance is under heavy load or maintenance, their admins can [send a Backoff header](http://kinto.readthedocs.org/en/latest/api/cliquet/backoff.html) and it's the responsibily for clients to hold on performing more requests for a given amount of time, expressed in seconds.
 
 When this happens, Kinto.js will reject calls to `#sync()` with an appropriate error message specifying the number of seconds you need to wait before calling it again.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -59,7 +59,7 @@ For now only a few standard fields are indexed by default in IndexedDB collectio
 Here's what's planned for future versions, outside of fixing the known limitations listed above:
 
 - Adding a **client-side crypto layer** to the API in order to bring secure & privacy-safe remote storage of user data;
-- Adding support for [**sharing & permissions**](http://kinto.readthedocs.org/en/latest/permissions.html);
+- Adding support for [**sharing & permissions**](http://kinto.readthedocs.org/en/latest/api/permissions.html);
 - Allowing to use **other local storage backend than IndexedDB** (localStorage, WebSQL) in the form of alternative drivers/adapters;
 - Providing an **admin Web UI** allowing easy management of your Kinto buckets and collections.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -8,7 +8,7 @@ Kinto.js doesn't track modification history in a form of a revision tree. Instea
 
 This allows covering 80% of common synchronization use cases, while being super-lightweight implementation wise.
 
-You can read more about the rationale [here](http://cliquet.readthedocs.org/en/latest/rationale.html).
+You can read more about Kinto features [here](http://kinto.readthedocs.org).
 
 ### No automatic confict handling
 
@@ -59,7 +59,7 @@ For now only a few standard fields are indexed by default in IndexedDB collectio
 Here's what's planned for future versions, outside of fixing the known limitations listed above:
 
 - Adding a **client-side crypto layer** to the API in order to bring secure & privacy-safe remote storage of user data;
-- Adding support for [**sharing & permissions**](http://cliquet.readthedocs.org/en/latest/reference/permission.html);
+- Adding support for [**sharing & permissions**](http://kinto.readthedocs.org/en/latest/permissions.html);
 - Allowing to use **other local storage backend than IndexedDB** (localStorage, WebSQL) in the form of alternative drivers/adapters;
 - Providing an **admin Web UI** allowing easy management of your Kinto buckets and collections.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kinto",
   "version": "1.0.0-rc.3",
-  "description": "JavaScript client for Cliquet.",
+  "description": "JavaScript client for Kinto.",
   "main": "lib/index.js",
   "scripts": {
     "build": "babel -d lib/ src/",


### PR DESCRIPTION
**Wait for https://github.com/Kinto/kinto/pull/156** (or some links will be broken)

Since *Cliquet* is only a building block of the Kinto server, it should not be mentionned at all in Kinto.js docs.
We noticed that this introduces a huge confusion between Cliquet and Kinto, and we'll be working on that clarification.

A first step is to remove every explicit mention of Cliquet in Kinto.js docs.