### PR TITLE
Fix test failing when KINTO_PSERVE_EXECUTABLE is not set in the env.

### DIFF
--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -22,7 +22,11 @@ describe("Integration tests", () => {
   var sandbox, server, tasks;
   const MAX_ATTEMPTS = 50;
 
-  function startServer(env={}) {
+  function startServer(env) {
+    // Add the provided environment variables to the child process environment.
+    // Keeping parent's environment is needed so that pserve's executable 
+    // can be found (with PATH) if KINTO_PSERVE_EXECUTABLE env variable was not provided.
+    env = Object.assign({}, process.env, env);
     server = spawn(PSERVE_EXECUTABLE, [KINTO_CONFIG], {env});
     server.stderr.on("data", function(data) {
       // Uncomment the line below to have server logs printed.


### PR DESCRIPTION
During the integration test, kinto was spawn with a virgin environment (or an environment containing only the provided variables).
While this ensured that any tester where given the same 'pure' kinto instance, it also (a) prevented them to test it in a custom configuration, (b) force them to set the `KINTO_PSERVE_EXECUTABLE` env variable as `pserve` could not be found anymore using the `PATH` environment variable.

This fix makes sure the provided env argument extends the parent environment instead of overwriting it.

This is linked to #130 and raised some discussion with @ametaireau. Keeping a virgin environment for Kinto may be wanted. In particular, the environment is used by the tests to communicate with the Kinto instance and, as a result, will raise uncontrolled behaviour if a user sets by himself some environment variables such as `CLIQUET_EOS` or `CLIQUET_BACKOFF`.
Another working solution can be to only relay the `PATH` of parent's env (which is required to find the `pserve` executable).