### PR TITLE
Remove the Backoff header handling exclusion for 304 responses 

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -106,11 +106,6 @@ export default class HTTP {
   }
 
   _checkForBackoffHeader(status, headers) {
-    // XXX Temporary fix
-    // see https://github.com/mozilla-services/kinto/issues/148
-    if (status === 304) {
-      return;
-    }
     var backoffMs;
     const backoffSeconds = parseInt(headers.get("Backoff"), 10);
     if (backoffSeconds > 0) {


### PR DESCRIPTION
Refs #68, #82; for now backoff header handling is not performed when we receive 304 responses, because of https://github.com/mozilla-services/kinto/issues/148.

Once this issue is fixed and a new Kinto release is issues, we should remove that exclusion.