### PR TITLE
Upgraded Kinto to 1.4.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - export PATH=$HOME/.local/bin:$PATH
 - pip install --user `whoami` virtualenv
 - virtualenv .env
-- .env/bin/pip install kinto==1.3.1
+- .env/bin/pip install kinto==1.4.0
 - export KINTO_PSERVE_EXECUTABLE=.env/bin/pserve
 env:
 - ACTION=test


### PR DESCRIPTION
We should run our integration tests against the very [latest stable](https://github.com/Kinto/kinto/releases/tag/1.4.0) release of Kinto.

r=? @Natim @leplatrem @ametaireau 