### PR TITLE
Fixes #169 - Instantiate Api only once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,12 @@ export default class Kinto {
       remote: DEFAULT_REMOTE,
     };
     this._options = Object.assign(defaults, options);
+    this._api = new Api(this._options.remote, {
+      headers:     this._options.headers,
+      events:      this._options.events,
+      requestMode: this._options.requestMode,
+    });
+
     // public properties
     this.events = this._options.events;
   }
@@ -84,14 +90,8 @@ export default class Kinto {
       throw new Error("missing collection name");
     }
 
-    const remote = this._options.remote;
-    const api = new Api(remote, {
-      headers:     this._options.headers,
-      events:      this._options.events,
-      requestMode: this._options.requestMode,
-    });
     const bucket = this._options.bucket;
-    return new Collection(bucket, collName, api, {
+    return new Collection(bucket, collName, this._api, {
       events:              this._options.events,
       adapter:             this._options.adapter,
       dbPrefix:            this._options.dbPrefix,

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -90,6 +90,11 @@ describe("Integration tests", () => {
           .then(_ => tasks.api.serverSettings)
           .should.become({"cliquet.batch_max_requests": 25});
       });
+      it("should share server settings across collections", function() {
+        return tasks.sync()
+          .then(_ => kinto.collection("articles").api.serverSettings)
+          .should.become({"cliquet.batch_max_requests": 25});
+      });
     });
 
     describe("Synchronization", () => {


### PR DESCRIPTION
Looks like the Api object only depends on Kinto-level options, not on Collection-level options.

So is this safe this way? @n1k0 

(didn't run tests yet)