### PR TITLE
Upgraded Kinto to 1.5.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - export PATH=$HOME/.local/bin:$PATH
 - pip install --user `whoami` virtualenv
 - virtualenv .env
-- .env/bin/pip install kinto==1.4.0
+- .env/bin/pip install kinto==1.5.0
 - export KINTO_PSERVE_EXECUTABLE=.env/bin/pserve
 env:
 - ACTION=test


### PR DESCRIPTION
This is most likely to fix our broken builds, because Kinto 1.4.0 has troubles starting from our test env, while 1.5.0 seems to have fixed the situation.