### PR TITLE
[WIP] Include manual in esdoc

### DIFF
--- a/esdoc.json
+++ b/esdoc.json
@@ -1,6 +1,14 @@
 {
   "source": "./src",
   "destination": "./esdoc",
+  "index": "./docs/index.md",
+  "manual": {
+    "installation": "./docs/installation.md",
+    "usage": "./docs/api.md",
+    "example": "./docs/tutorial.md",
+    "faq": "./docs/limitations.md",
+    "changelog": "./CHANGELOG.md"
+  },
   "test": {
     "type": "mocha",
     "source": "./test"


### PR DESCRIPTION
As @h13i32maru suggested [in a comment](https://github.com/Kinto/kinto.js/pull/192#issuecomment-147077006), esdoc can include a manual section.

This is my intent to use it. However, I couldn't get find a proper solution to the following problems:

* [ ] esdoc expect a restricted set of pages (overview, installation, usage, example, faq, changelog). Where hacking and extending do not fit. 
* [ ] the relative links in the original docs are not resolved (eg. `[API usage](api.md)`)
* [ ] having both readthedocs and esdoc seems complicated in terms of absolute links too (e.g. `[detailed API docs](https://doc.esdoc.org/github.com/Kinto/kinto.js/)`)

Feel free to close this PR if it has dead-end... 