### PR TITLE
Exposed open() and close() methods to the BaseAdapter interface.

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -4,7 +4,7 @@
 
 By default, Kinto.js performs all local persistence operations using IndexedDB; though if you want to create and use you own, that's definitely possible.
 
-Simply create a class extending from [`Kinto.adapters.BaseAdapter`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/adapters/base.js~BaseAdapter.html), which rather acts as an interface than anything else here:
+Simply create a class extending from [`Kinto.adapters.BaseAdapter`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/adapters/base.js~BaseAdapter.html), which acts as an abstract class:
 
 ```js
 class MyAdapter extends Kinto.adapters.BaseAdapter {
@@ -13,17 +13,29 @@ class MyAdapter extends Kinto.adapters.BaseAdapter {
     this.dbname = dbname;
   }
 
+  open() {
+    // open a database connection
+    return super.open();
+  }
+
+  close() {
+    // close a database connection
+    return super.close();
+  }
+
   create(record) {
-    …
+    // add a record to the database
   }
 
   update(record) {
-    …
+    // update a record from the database
   }
 
   …
 }
 ```
+
+Note that `#open()` and `#close()` are implemented and are simply resolving by default.
 
 Then create the Kinto object passing a reference to your adapter class:
 

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -33,6 +33,7 @@ export default class IDB extends BaseAdapter {
   /**
    * Ensures a connection to the IndexedDB database has been opened.
    *
+   * @override
    * @return {Promise}
    */
   open() {
@@ -70,6 +71,20 @@ export default class IDB extends BaseAdapter {
   }
 
   /**
+   * Closes current connection to the database.
+   *
+   * @override
+   * @return {Promise}
+   */
+  close() {
+    if (this._db) {
+      this._db.close(); // indexedDB.close is synchronous
+      this._db = null;
+    }
+    return super.close();
+  }
+
+  /**
    * Returns a transaction and a store objects for this collection.
    *
    * To determine if a transaction has completed successfully, we should rather
@@ -93,6 +108,7 @@ export default class IDB extends BaseAdapter {
   /**
    * Deletes every records in the current collection.
    *
+   * @override
    * @return {Promise}
    */
   clear() {
@@ -111,6 +127,7 @@ export default class IDB extends BaseAdapter {
    *
    * Note: An id value is required.
    *
+   * @override
    * @param  {Object} record The record object, including an id.
    * @return {Promise}
    */
@@ -128,6 +145,7 @@ export default class IDB extends BaseAdapter {
   /**
    * Updates a record from the IndexedDB database.
    *
+   * @override
    * @param  {Object} record
    * @return {Promise}
    */
@@ -145,6 +163,7 @@ export default class IDB extends BaseAdapter {
   /**
    * Retrieve a record by its primary key from the IndexedDB database.
    *
+   * @override
    * @param  {String} id The record id.
    * @return {Promise}
    */
@@ -162,6 +181,7 @@ export default class IDB extends BaseAdapter {
   /**
    * Deletes a record from the IndexedDB database.
    *
+   * @override
    * @param  {String} id The record id.
    * @return {Promise}
    */
@@ -179,6 +199,7 @@ export default class IDB extends BaseAdapter {
   /**
    * Lists all records from the IndexedDB database.
    *
+   * @override
    * @return {Promise}
    */
   list() {
@@ -203,6 +224,7 @@ export default class IDB extends BaseAdapter {
   /**
    * Store the lastModified value into metadata store.
    *
+   * @override
    * @param  {Number}  lastModified
    * @return {Promise}
    */
@@ -221,6 +243,7 @@ export default class IDB extends BaseAdapter {
   /**
    * Retrieve saved lastModified value.
    *
+   * @override
    * @return {Promise}
    */
   getLastModified() {

--- a/src/adapters/LocalStorage.js
+++ b/src/adapters/LocalStorage.js
@@ -56,8 +56,31 @@ export default class LocalStorage extends BaseAdapter {
   }
 
   /**
+   * Opens a connection to the database. Doesn't do anything as LocalStorage
+   * database doesn't have to be opened.
+   *
+   * @override
+   * @return {Promise}
+   */
+  open() {
+    return super.open();
+  }
+
+  /**
+   * Closes current connection to the database. Doesn't do anything as LocalStorage
+   * database can't be closed.
+   *
+   * @override
+   * @return {Promise}
+   */
+  close() {
+    return super.close();
+  }
+
+  /**
    * Deletes every records in the current collection.
    *
+   * @override
    * @return {Promise}
    */
   clear() {
@@ -74,6 +97,7 @@ export default class LocalStorage extends BaseAdapter {
    *
    * Note: An id value is required.
    *
+   * @override
    * @param  {Object} record The record object, including an id.
    * @return {Promise}
    */
@@ -93,6 +117,7 @@ export default class LocalStorage extends BaseAdapter {
   /**
    * Updates a record from the localStorage datastore.
    *
+   * @override
    * @param  {Object} record
    * @return {Promise}
    */
@@ -111,6 +136,7 @@ export default class LocalStorage extends BaseAdapter {
   /**
    * Retrieve a record by its primary key from the localStorage datastore.
    *
+   * @override
    * @param  {String} id The record id.
    * @return {Promise}
    */
@@ -126,6 +152,7 @@ export default class LocalStorage extends BaseAdapter {
   /**
    * Deletes a record from the localStorage datastore.
    *
+   * @override
    * @param  {String} id The record id.
    * @return {Promise}
    */
@@ -142,6 +169,7 @@ export default class LocalStorage extends BaseAdapter {
   /**
    * Lists all records from the localStorage datastore.
    *
+   * @override
    * @return {Promise}
    */
   list() {
@@ -157,6 +185,7 @@ export default class LocalStorage extends BaseAdapter {
   /**
    * Store the lastModified value into metadata store.
    *
+   * @override
    * @param  {Number}  lastModified
    * @return {Promise}
    */
@@ -173,6 +202,7 @@ export default class LocalStorage extends BaseAdapter {
   /**
    * Retrieve saved lastModified value.
    *
+   * @override
    * @return {Promise}
    */
   getLastModified() {

--- a/src/adapters/base.js
+++ b/src/adapters/base.js
@@ -7,8 +7,29 @@
  */
 export default class BaseAdapter {
   /**
-   * Deletes every records present in the database..
+   * Opens a connection to the database.
    *
+   * @abstract
+   * @return {Promise}
+   */
+  open() {
+    return Promise.resolve();
+  }
+
+  /**
+   * Closes current connection to the database.
+   *
+   * @abstract
+   * @return {Promise}
+   */
+  close() {
+    return Promise.resolve();
+  }
+
+  /**
+   * Deletes every records present in the database.
+   *
+   * @abstract
    * @return {Promise}
    */
   clear() {
@@ -16,10 +37,11 @@ export default class BaseAdapter {
   }
 
   /**
-   * Adds a record to the IndexedDB database.
+   * Adds a record to the database.
    *
    * Note: An id value is required.
    *
+   * @abstract
    * @param  {Object} record The record object, including an id.
    * @return {Promise}
    */
@@ -30,6 +52,7 @@ export default class BaseAdapter {
   /**
    * Updates a record from the IndexedDB database.
    *
+   * @abstract
    * @param  {Object} record
    * @return {Promise}
    */
@@ -40,6 +63,7 @@ export default class BaseAdapter {
   /**
    * Retrieve a record by its primary key from the database.
    *
+   * @abstract
    * @param  {String} id The record id.
    * @return {Promise}
    */
@@ -50,6 +74,7 @@ export default class BaseAdapter {
   /**
    * Deletes a record from the database.
    *
+   * @abstract
    * @param  {String} id The record id.
    * @return {Promise}
    */
@@ -60,6 +85,7 @@ export default class BaseAdapter {
   /**
    * Lists all records from the database.
    *
+   * @abstract
    * @return {Promise}
    */
   list() {
@@ -69,6 +95,7 @@ export default class BaseAdapter {
   /**
    * Store the lastModified value.
    *
+   * @abstract
    * @param  {Number}  lastModified
    * @return {Promise}
    */
@@ -79,6 +106,7 @@ export default class BaseAdapter {
   /**
    * Retrieve saved lastModified value.
    *
+   * @abstract
    * @return {Promise}
    */
   getLastModified() {

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -12,6 +12,7 @@ const root = typeof global === "object" ? global : window;
 
 if (typeof root.indexedDB !== "object") {
   const iDBSymbols = [
+    "IDBDatabase",
     "IDBTransaction",
     "IDBObjectStore",
     "IDBIndex",

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -20,6 +20,31 @@ describe("adapter.IDB", () => {
 
     afterEach(() => sandbox.restore());
 
+    /** @test {IDB#open} */
+    describe("#open", () => {
+      it("should be fullfilled when a connection is opened", () => {
+        return db.open().should.be.fulfilled;
+      });
+    });
+
+    /** @test {IDB#close} */
+    describe("#close", () => {
+      it("should be fullfilled when a connection is closed", () => {
+        return db.close().should.be.fulfilled;
+      });
+
+      it("should be fullfilled when no connection has been opened", () => {
+        db._db = null;
+        return db.close().should.be.fulfilled;
+      });
+
+      it("should close an opened connection to the database", () => {
+        return db.close()
+          .then(_ => db._db)
+          .should.become(null);
+      });
+    });
+
     /** @test {IDB#create} */
     describe("#create", () => {
       it("should reject on transaction error", () => {

--- a/test/adapters/base_test.js
+++ b/test/adapters/base_test.js
@@ -8,6 +8,14 @@ describe("adapters.BaseAdapter", () => {
   var adapter;
   beforeEach(() => adapter = new BaseAdapter());
 
+  it("should fulfill calls to open", () => {
+    return adapter.open().should.be.fulfilled;
+  });
+
+  it("should fulfill calls to close", () => {
+    return adapter.close().should.be.fulfilled;
+  });
+
   it("should throw for non-implemented methods", () => {
     expect(() => adapter.clear()).to.Throw(Error, "Not Implemented.");
     expect(() => adapter.create()).to.Throw(Error, "Not Implemented.");

--- a/test/adapters/localStorage_test.js
+++ b/test/adapters/localStorage_test.js
@@ -32,6 +32,20 @@ describe("adapter.LocalStorage", () => {
 
     afterEach(() => sandbox.restore());
 
+    /** @test {IDB#open} */
+    describe("#open", () => {
+      it("should be fullfilled when a connection is opened", () => {
+        return db.open().should.be.fulfilled;
+      });
+    });
+
+    /** @test {IDB#close} */
+    describe("#close", () => {
+      it("should be fullfilled when a connection is closed", () => {
+        return db.close().should.be.fulfilled;
+      });
+    });
+
     /** @test {LocalStorage#clear} */
     describe("#clear", () => {
       it("should reject on generic error", () => {


### PR DESCRIPTION
Refs https://github.com/Kinto/kinto.js/pull/219#issuecomment-151587615

Basically we now add `open` and `close` methods to the `BaseAdapter` base class, so implementers must implement them.

Also is now exposed a `Collection#close` method so apps using adapters needing explicit closing can call that (opening is always done implicitly when a first operation is scheduled for execution).

cc @rnewman 

@mozmark: would this work for you?

