### PR TITLE
Fixes #241: Preserving old files in gh-pages branch.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist-dev": "browserify -s Kinto -d -e src/index.js -o demo/kinto-$npm_package_version.dev.js -t [ babelify --sourceMapRelative . ]",
     "dist-prod": "browserify -s Kinto -g uglifyify -e src/index.js -o demo/kinto-$npm_package_version.min.js -t [ babelify --sourceMapRelative . ]",
     "dist-fx": "browserify -s loadKinto -e fx-src/index.js -o temp.jsm -t [ babelify --blacklist regenerator,es6.arrowFunctions ] && mkdir -p dist && cp fx-src/jsm_prefix.js dist/moz-kinto-client.js && cat temp.jsm >> dist/moz-kinto-client.js && rm temp.jsm",
-    "publish-demo": "npm run dist && gh-pages -d demo",
+    "publish-demo": "npm run dist && gh-pages --add -d demo",
     "publish-package": "npm run build && npm publish",
     "report-coverage": "npm run test-cover && ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info",
     "tdd": "mocha -w --compilers js:babel/register --require ./test/_setup.js 'test/**/*_test.js'",


### PR DESCRIPTION
Refs #241.

We also need to ensure we're not publishing previously versioned assets, when reusing the current `package.json` version tag if it's not been updated on master while code has changed.
