### PR TITLE
Add support for db.import

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -214,6 +214,29 @@ articles.list({sort: "-title"})
 > - By default, the records are sorted on `last_modified` in descending order.
 > - As mentioned in the [limitations](limitations.md) section, the sort is performed in memory.
 
+## Importing a data dump locally
+
+You may want to preload a dump of records from the server, before
+actually starting the first sync with it.
+
+The list of imported records is returned.
+
+```js
+articles.loadDump([
+  {
+    id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f8",
+    title: "baz",
+    last_modified: 1432222889337
+  }
+])
+  .then(records => console.log(records));
+```
+
+> #### Notes
+>
+> - Existing records are replaced if they do not have more recent modifications.
+> - Imported records won't be synced with the server.
+> - The importation is optimized in a single database transaction.
 
 ## Clearing the collection
 

--- a/src/adapters/base.js
+++ b/src/adapters/base.js
@@ -112,4 +112,14 @@ export default class BaseAdapter {
   getLastModified() {
     throw new Error("Not Implemented.");
   }
+
+  /**
+   * Load a dump of records exported from a server.
+   *
+   * @abstract
+   * @return {Promise}
+   */
+  loadDump(records) {
+    throw new Error("Not Implemented.");
+  }
 }

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -149,5 +149,22 @@ describe("adapter.IDB", () => {
           .should.be.rejectedWith(Error, "transaction error");
       });
     });
+
+    /** @test {IDB#loadDump} */
+    describe("#loadDump", () => {
+      it("should reject on transaction error", () => {
+        sandbox.stub(db, "prepare").returns({
+          store: {add() {}},
+          transaction: {
+            get onerror() {},
+            set onerror(onerror) {
+              onerror({target: {error: "transaction error"}});
+            }
+          }
+        });
+        return db.loadDump([{foo: "bar"}])
+          .should.be.rejectedWith(Error, /^Error: loadDump/);
+      });
+    });
   });
 });

--- a/test/adapters/base_test.js
+++ b/test/adapters/base_test.js
@@ -25,5 +25,6 @@ describe("adapters.BaseAdapter", () => {
     expect(() => adapter.list()).to.Throw(Error, "Not Implemented.");
     expect(() => adapter.saveLastModified()).to.Throw(Error, "Not Implemented.");
     expect(() => adapter.getLastModified()).to.Throw(Error, "Not Implemented.");
+    expect(() => adapter.loadDump()).to.Throw(Error, "Not Implemented.");
   });
 });

--- a/test/adapters/localStorage_test.js
+++ b/test/adapters/localStorage_test.js
@@ -140,6 +140,15 @@ describe("adapter.LocalStorage", () => {
           .should.be.rejectedWith(Error, /^Error: getLastModified\(\) err/);
       });
     });
+
+    /** @test {LocalStorage#loadDump} */
+    describe("#loadDump", () => {
+      it("should reject on generic error", () => {
+        sandbox.stub(localStorage, "setItem", thrower("err"));
+        return db.loadDump([{foo: "bar"}])
+          .should.be.rejectedWith(Error, /^Error: loadDump\(\) err/);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
For some of the Mozilla platform use-cases, it's desirable to have the ability to import initial data. Since we only need it here, for the time being, we can prototype the idea in the Firefox storage adapter and apply what we learn to the other adapters.