### PR TITLE
Relaxed UUID validation.

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -5,7 +5,7 @@ import { reduceRecords, waterfall } from "./utils";
 import { cleanRecord } from "./api";
 
 import { v4 as uuid4 } from "uuid";
-import { deepEquals, isUUID4 } from "./utils";
+import { deepEquals, isUUID } from "./utils";
 
 /**
  * Synchronization result object.
@@ -79,7 +79,7 @@ function createUUIDSchema() {
     },
 
     validate(id) {
-      return isUUID4(id);
+      return isUUID(id);
     }
   };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@
 
 import { deepEqual } from "assert";
 
-const RE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const RE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Deeply checks if two structures are equals.
@@ -123,12 +123,12 @@ export function partition(array, n) {
 }
 
 /**
- * Checks if a string is an UUID, according to RFC4122.
+ * Checks if a string is an UUID.
  *
  * @param  {String} uuid The uuid to validate.
  * @return {Boolean}
  */
-export function isUUID4(uuid) {
+export function isUUID(uuid) {
   return RE_UUID.test(uuid);
 }
 

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -9,7 +9,7 @@ import {
   filterObjects,
   reduceRecords,
   partition,
-  isUUID4,
+  isUUID,
   waterfall
 } from "../src/utils";
 
@@ -162,21 +162,22 @@ describe("Utils", () => {
     });
   });
 
-  /** @test {isUUID4} */
-  describe("#isUUID4", () => {
+  /** @test {isUUID} */
+  describe("#isUUID", () => {
     it("should check that a string uses a valid UUID format", () => {
-      expect(isUUID4("110ec58a-a0f2-4ac4-8393-c866d813b8d1")).eql(true);
+      expect(isUUID("63e5ccb8-1798-3b9f-48f5-12b5ca13054e")).eql(true);
+      expect(isUUID("00000000-0000-5000-a000-000000000000")).eql(true);
+      expect(isUUID("00000000-0000-4000-e000-000000000000")).eql(true);
     });
 
     it("should check that a string does not use a valid UUID format", () => {
-      expect(isUUID4("110ex58a-a0f2-4ac4-8393-c866d813b8d1")).eql(false);
-      expect(isUUID4("")).eql(false);
-      expect(isUUID4(null)).eql(false);
-      expect(isUUID4(undefined)).eql(false);
-      expect(isUUID4(42)).eql(false);
-      expect(isUUID4({})).eql(false);
-      expect(isUUID4("00000000-0000-5000-a000-000000000000")).eql(false);
-      expect(isUUID4("00000000-0000-4000-e000-000000000000")).eql(false);
+      expect(isUUID("63e5xcb8-1798-4b9f-48f5-12b5ca13054e")).eql(false);
+      expect(isUUID("")).eql(false);
+      expect(isUUID(null)).eql(false);
+      expect(isUUID(undefined)).eql(false);
+      expect(isUUID(42)).eql(false);
+      expect(isUUID({})).eql(false);
+      expect(isUUID("00000000-0000-5000-a000-000000000000")).eql(true);
     });
   });
 


### PR DESCRIPTION
We're now accepting uuid formats matching the cliquet spec. But we're still creating UUID4 by default.

r=? @natim @leplatrem @almet