### PR TITLE
Fix JSM compatibility for Firefox adapter

### DIFF
--- a/fx-src/FirefoxStorage.js
+++ b/fx-src/FirefoxStorage.js
@@ -202,6 +202,16 @@ export default class FirefoxAdapter extends BaseAdapter {
     });
   }
 
+  /**
+   * Load a list of records into the local database.
+   *
+   * Note: The adapter is not in charge of filtering the already imported
+   * records. This is done in `Collection#loadDump()`, as a common behaviour
+   * between every adapters.
+   *
+   * @param  {Array} records.
+   * @return {Array} imported records.
+   */
   loadDump(records) {
     let connection = this._connection;
     let collection_name = this.collection;

--- a/fx-src/index.js
+++ b/fx-src/index.js
@@ -24,6 +24,7 @@ import FirefoxAdapter from "./FirefoxStorage";
 export default function loadKinto() {
   const { EventEmitter } = Cu.import("resource://devtools/shared/event-emitter.js", {});
 
+  Cu.import("resource://gre/modules/Timer.jsm");
   Cu.importGlobalProperties(['fetch']);
 
   class KintoFX extends KintoBase {

--- a/src/collection.js
+++ b/src/collection.js
@@ -797,19 +797,17 @@ export default class Collection {
    */
   loadDump(records) {
     const reject = msg => Promise.reject(new Error(msg));
-    if (!(typeof records.sort == 'function')) {
+    if (!Array.isArray(records)) {
       return reject("Records is not an array.");
     }
 
     for(const record of records) {
       if (!record.id || !this.idSchema.validate(record.id)) {
-        return reject("Record has invalid ID: " +
-                      JSON.stringify(record));
+        return reject("Record has invalid ID: " + JSON.stringify(record));
       }
 
       if (!record.last_modified) {
-        return reject("Record has no last_modified value: " +
-                      JSON.stringify(record));
+        return reject("Record has no last_modified value: " + JSON.stringify(record));
       }
     }
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -791,9 +791,12 @@ export default class Collection {
   /**
    * Load a list of records already synced with the remote server.
    *
+   * The local records which are unsynced or whose timestamp is either missing
+   * or superior to those being loaded will be ignored.
+   *
    * @param  {Array} records.
    * @param  {Object} options Options.
-   * @return {Promise}
+   * @return {Promise} with the effectively imported records.
    */
   loadDump(records) {
     const reject = msg => Promise.reject(new Error(msg));

--- a/src/collection.js
+++ b/src/collection.js
@@ -797,7 +797,7 @@ export default class Collection {
    */
   loadDump(records) {
     const reject = msg => Promise.reject(new Error(msg));
-    if (!(records instanceof Array)) {
+    if (!(typeof records.sort == 'function')) {
       return reject("Records is not an array.");
     }
 


### PR DESCRIPTION
When implementing more tests cases for the `loadDump()` feature, we faced a couple of problems releated to JSM (ref #273)

This diff appears to solve them properly.

We take any feedback! :)

@mozmark r?