### PR TITLE
refs #257: Allowing defining the remote endpoint in #sync().

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,10 +1,10 @@
 function main() {
-  var db = new Kinto({
+  var db = new Kinto();
+  var tasks = db.collection("tasks");
+  var syncOptions = {
     remote: "https://kinto.dev.mozaws.net/v1/",
     headers: {Authorization: "Basic " + btoa("user:pass")}
-  });
-  var tasks = db.collection("tasks");
-
+  };
   document.getElementById("form")
     .addEventListener("submit", function(event) {
       event.preventDefault();
@@ -41,12 +41,12 @@ function main() {
     });
 
   function doSync() {
-    return tasks.sync().catch(function(err) {
+    return tasks.sync(syncOptions).catch(function(err) {
       if (err.message.contains("flushed")) {
         console.warn("Flushed server detected, marking local data for reupload.");
         return tasks.resetSyncStatus()
           .then(function() {
-            return tasks.sync();
+            return tasks.sync(syncOptions);
           });
       }
       throw err;

--- a/docs/api.md
+++ b/docs/api.md
@@ -379,6 +379,7 @@ import Collection from "kinto/lib/collection";
 
 articles.sync({
   strategy: Kinto.syncStrategy.CLIENT_WINS,
+  remote: "https://alt.server.tld/v1",
   headers: {Authorization: "Basic bWF0Og=="}
 })
   .then(result => {

--- a/src/api.js
+++ b/src/api.js
@@ -34,8 +34,8 @@ export default class Api {
    * Constructor.
    *
    * Options:
-   * - {Object}       headers The key-value headers to pass to each request.
-   * - {String}       events  The HTTP request mode.
+   * - {Object} headers      The key-value headers to pass to each request.
+   * - {String} requestMode  The HTTP request mode.
    *
    * @param  {String}       remote  The remote URL.
    * @param  {EventEmitter} events  The events handler
@@ -49,12 +49,9 @@ export default class Api {
       remote = remote.slice(0, -1);
     }
     this._backoffReleaseTime = null;
-    // public properties
-    /**
-     * The remote endpoint base URL.
-     * @type {String}
-     */
     this.remote = remote;
+
+    // public properties
     /**
      * The optional generic headers.
      * @type {Object}
@@ -73,24 +70,44 @@ export default class Api {
       throw new Error("No events handler provided");
     }
     this.events = events;
-    try {
-      /**
-       * The current server protocol version, eg. `v1`.
-       * @type {String}
-       */
-      this.version = remote.match(/\/(v\d+)\/?$/)[1];
-    } catch (err) {
-      throw new Error("The remote URL must contain the version: " + remote);
-    }
-    if (this.version !== SUPPORTED_PROTOCOL_VERSION) {
-      throw new Error(`Unsupported protocol version: ${this.version}`);
-    }
+
     /**
      * The HTTP instance.
      * @type {HTTP}
      */
     this.http = new HTTP(this.events, {requestMode: options.requestMode});
     this._registerHTTPEvents();
+  }
+
+  /**
+   * The remote endpoint base URL. Setting the value will also extract and
+   * validate the version.
+   * @type {String}
+   */
+  get remote() {
+    return this._remote;
+  }
+
+  set remote(url) {
+    let version;
+    try {
+      version = url.match(/\/(v\d+)\/?$/)[1];
+    } catch (err) {
+      throw new Error("The remote URL must contain the version: " + url);
+    }
+    if (version !== SUPPORTED_PROTOCOL_VERSION) {
+      throw new Error(`Unsupported protocol version: ${version}`);
+    }
+    this._remote = url;
+    this._version = version;
+  }
+
+  /**
+   * The current server protocol version, eg. `v1`.
+   * @type {String}
+   */
+  get version() {
+    return this._version;
   }
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -148,3 +148,18 @@ export function waterfall(fns, init) {
     return promise.then(nextFn);
   }, Promise.resolve(init));
 }
+
+/**
+ * Ensure a callback is always executed at the end of the passed promise flow.
+ *
+ * @link   https://github.com/domenic/promises-unwrapping/issues/18
+ * @param  {Promise}  promise  The promise.
+ * @param  {Function} fn       The callback.
+ * @return {Promise}
+ */
+export function pFinally(promise, fn) {
+  return promise.then(
+    value => Promise.resolve(fn()).then(() => value),
+    reason => Promise.resolve(fn()).then(() => { throw reason; })
+  );
+}

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -10,7 +10,8 @@ import {
   reduceRecords,
   partition,
   isUUID,
-  waterfall
+  waterfall,
+  pFinally
 } from "../src/utils";
 
 chai.should();
@@ -210,6 +211,28 @@ describe("Utils", () => {
         x => Promise.resolve(x + 1),
         x => Promise.resolve(x * 2),
       ], 42).should.become(86);
+    });
+  });
+
+  describe("pFinally", () => {
+    it("should execute a callback when the promise succeeds", () => {
+      let flag = false;
+
+      return pFinally(Promise.resolve("plop"), () => flag = true)
+        .then(res => {
+          expect(flag).eql(true);
+          expect(res).eql("plop");
+        });
+    });
+
+    it("should execute a callback when the promise is rejected", () => {
+      let flag = false;
+
+      return pFinally(Promise.reject("err"), () => flag = true)
+        .catch(err => {
+          expect(flag).eql(true);
+          expect(err).eql("err");
+        });
     });
   });
 });


### PR DESCRIPTION
Took the easiest way to allow passing the remote to `#sync()`. Works, but ugly, as I'm mutating the api instance during the time of the sync flow execution :/ That's the price to pay for strict BC.

Later we'll move the whole sync flow to its own module, so that's a temporary situation (famous last words).

r=? @leplatrem 