### PR TITLE
Fixes #277: Limit number of changes to read from a sync() operation.

### DIFF
--- a/src/adapters/LocalStorage.js
+++ b/src/adapters/LocalStorage.js
@@ -22,7 +22,7 @@ export default class LocalStorage extends BaseAdapter {
     super();
     this._db = null;
     this._keyStoreName = `${this.dbname}/__keys`;
-    this._keyLastModified = `${this.dbname}/__lastModified`;
+    this._metaPrefix = `${this.dbname}/meta`;
     // public properties
     /**
      * The database name.
@@ -191,12 +191,7 @@ export default class LocalStorage extends BaseAdapter {
    */
   saveLastModified(lastModified) {
     const value = parseInt(lastModified, 10);
-    try {
-      localStorage.setItem(this._keyLastModified, JSON.stringify(value));
-      return Promise.resolve(value);
-    } catch(err) {
-      return this._handleError("saveLastModified", err);
-    }
+    return this.saveMetaProperty("lastModified", value);
   }
 
   /**
@@ -206,14 +201,42 @@ export default class LocalStorage extends BaseAdapter {
    * @return {Promise}
    */
   getLastModified() {
+    return this.getMetaProperty("lastModified")
+      .then(lastModified => parseInt(lastModified, 10) || null);
+  }
+
+  /**
+   * Saves a meta property.
+   *
+   * @param  {String} name
+   * @param  {Any}    value
+   * @return {Promise}
+   */
+  saveMetaProperty(name, value) {
     try {
-      const lastModified = JSON.parse(localStorage.getItem(this._keyLastModified));
-      return Promise.resolve(parseInt(lastModified, 10) || null);
+      const key = `${this._metaPrefix}name`;
+      localStorage.setItem(key, JSON.stringify(value));
+      return Promise.resolve(value);
     } catch(err) {
-      return this._handleError("getLastModified", err);
+      return this._handleError("saveMetaProperty", err);
     }
   }
 
+  /**
+   * Retrieves a meta property value.
+   *
+   * @param  {String} name
+   * @return {Promise}
+   */
+  getMetaProperty(name) {
+    try {
+      const key = `${this._metaPrefix}name`;
+      const lastModified = JSON.parse(localStorage.getItem(key));
+      return Promise.resolve(parseInt(lastModified, 10) || null);
+    } catch(err) {
+      return this._handleError("getMetaProperty", err);
+    }
+  }
 
   /**
    * Load a dump of records exported from a server.

--- a/src/api.js
+++ b/src/api.js
@@ -191,9 +191,15 @@ export default class Api {
         if (res.status === 304) {
           return {
             lastModified: options.lastModified,
+            token: null,
             changes: []
           };
         }
+
+        // Extract pagination token, if any
+        const nextPage = res.headers.get("Next-Page");
+        const token = nextPage ? urlParse(nextPage, true).query._token : null;
+
         // XXX: ETag are supposed to be opaque and stored «as-is».
         // Extract response data
         let etag = res.headers.get("ETag");  // e.g. '"42"'
@@ -208,7 +214,7 @@ export default class Api {
           throw Error("Server has been flushed.");
         }
 
-        return {lastModified: etag, changes: records};
+        return {lastModified: etag, token, changes: records};
       });
   }
 

--- a/src/api.js
+++ b/src/api.js
@@ -162,7 +162,7 @@ export default class Api {
    * @param  {Object} options     The options object.
    * @return {Promise}
    */
-  fetchChangesSince(bucketName, collName, options={lastModified: null, headers: {}}) {
+  fetchChangesSince(bucketName, collName, options={lastModified: null, headers: {}, limit: null}) {
     const recordsUrl = this.endpoints().records(bucketName, collName);
     let queryString = "";
     const headers = Object.assign({}, this.optionHeaders, options.headers);
@@ -170,6 +170,11 @@ export default class Api {
     if (options.lastModified) {
       queryString = "?_since=" + options.lastModified;
       headers["If-None-Match"] = quote(options.lastModified);
+    }
+
+    if (options.limit) {
+      queryString += (queryString.indexOf("?") == -1 ? "?" : "&");
+      queryString += "_limit=" + options.limit;
     }
 
     return this.fetchServerSettings()

--- a/src/api.js
+++ b/src/api.js
@@ -191,14 +191,13 @@ export default class Api {
         if (res.status === 304) {
           return {
             lastModified: options.lastModified,
-            token: null,
+            nextPage: null,
             changes: []
           };
         }
 
         // Extract pagination token, if any
-        const nextPage = res.headers.get("Next-Page");
-        const token = nextPage ? urlParse(nextPage, true).query._token : null;
+        const nextPage = res.headers.get("Next-Page") || null;
 
         // XXX: ETag are supposed to be opaque and stored «as-is».
         // Extract response data
@@ -214,7 +213,7 @@ export default class Api {
           throw Error("Server has been flushed.");
         }
 
-        return {lastModified: etag, token, changes: records};
+        return {lastModified: etag, nextPage, changes: records};
       });
   }
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -613,8 +613,10 @@ export default class Collection {
    * {@link SyncResultObject} with import results.
    *
    * Options:
-   * - {String} strategy: The selected sync strategy.
+   * - {String} strategy:   The selected sync strategy.
    * - {String} fetchLimit: Number of items to pull from the server.
+   * - {String} maxPages:   Max number of pages of changes to fetch from the
+   *   server.
    *
    * @param  {SyncResultObject} syncResultObject
    * @param  {Object}           options
@@ -634,6 +636,7 @@ export default class Collection {
       lastModified: options.lastModified,
       headers: options.headers,
       limit: options.fetchLimit,
+      maxPages: options.maxPages,
     })
       // Reflect these changes locally
       .then(changes => this.importChanges(syncResultObject, changes))
@@ -767,11 +770,19 @@ export default class Collection {
    * - {Boolean} ignoreBackoff: Force synchronization even if server is currently
    *   backed off.
    * - {Number} fetchLimit: Number of items to fetch from the server.
+   * - {Number} maxPages: Maximum number of pages of changes to fetch from the
+   *   server.
    *
    * @param  {Object} options Options.
    * @return {Promise}
    */
-  sync(options={strategy: Collection.strategy.MANUAL, headers: {}, ignoreBackoff: false, fetchLimit: null}) {
+  sync(options={
+    strategy: Collection.strategy.MANUAL,
+    headers: {},
+    ignoreBackoff: false,
+    fetchLimit: null,
+    maxPages: null
+  }) {
     if (!options.ignoreBackoff && this.api.backoff > 0) {
       const seconds = Math.ceil(this.api.backoff / 1000);
       return Promise.reject(

--- a/src/collection.js
+++ b/src/collection.js
@@ -614,6 +614,7 @@ export default class Collection {
    *
    * Options:
    * - {String} strategy: The selected sync strategy.
+   * - {String} fetchLimit: Number of items to pull from the server.
    *
    * @param  {SyncResultObject} syncResultObject
    * @param  {Object}           options
@@ -631,7 +632,8 @@ export default class Collection {
     // First fetch remote changes from the server
     return this.api.fetchChangesSince(this.bucket, this.name, {
       lastModified: options.lastModified,
-      headers: options.headers
+      headers: options.headers,
+      limit: options.fetchLimit
     })
       // Reflect these changes locally
       .then(changes => this.importChanges(syncResultObject, changes))
@@ -764,11 +766,12 @@ export default class Collection {
    * - {Collection.strategy} strategy: See {@link Collection.strategy}.
    * - {Boolean} ignoreBackoff: Force synchronization even if server is currently
    *   backed off.
+   * - {Number} fetchLimit: Number of items to fetch from the server.
    *
    * @param  {Object} options Options.
    * @return {Promise}
    */
-  sync(options={strategy: Collection.strategy.MANUAL, headers: {}, ignoreBackoff: false}) {
+  sync(options={strategy: Collection.strategy.MANUAL, headers: {}, ignoreBackoff: false, fetchLimit: null}) {
     if (!options.ignoreBackoff && this.api.backoff > 0) {
       const seconds = Math.ceil(this.api.backoff / 1000);
       return Promise.reject(

--- a/src/collection.js
+++ b/src/collection.js
@@ -633,7 +633,7 @@ export default class Collection {
     return this.api.fetchChangesSince(this.bucket, this.name, {
       lastModified: options.lastModified,
       headers: options.headers,
-      limit: options.fetchLimit
+      limit: options.fetchLimit,
     })
       // Reflect these changes locally
       .then(changes => this.importChanges(syncResultObject, changes))

--- a/test/adapters/common.js
+++ b/test/adapters/common.js
@@ -107,6 +107,26 @@ export function adapterTestSuite(createDB, options={only: false}) {
       });
     });
 
+    describe("#saveMetaProperty", () => {
+      it("should resolve with meta property value", () => {
+        return db.saveMetaProperty("foo", 42)
+          .should.eventually.become(42);
+      });
+
+      it("should save a meta property value", () => {
+        return db.saveMetaProperty("foo", 42)
+          .then(_ => db.getMetaProperty("foo"))
+          .should.eventually.become(42);
+      });
+
+      it("should allow updating previous value", () => {
+        return db.saveMetaProperty("foo", 42)
+          .then(_ => db.saveMetaProperty("foo", 43))
+          .then(_ => db.getMetaProperty("foo"))
+          .should.eventually.become(43);
+      });
+    });
+
     describe("#saveLastModified", () => {
       it("should resolve with lastModified value", () => {
         return db.saveLastModified(42)

--- a/test/adapters/localStorage_test.js
+++ b/test/adapters/localStorage_test.js
@@ -123,21 +123,21 @@ describe("adapter.LocalStorage", () => {
       });
     });
 
-    /** @test {LocalStorage#saveLastModified} */
+    /** @test {LocalStorage#saveMetaProperty} */
     describe("#saveLastModified", () => {
       it("should reject on generic error", () => {
         sandbox.stub(localStorage, "setItem", thrower("err"));
-        return db.saveLastModified(42)
-          .should.be.rejectedWith(Error, /^Error: saveLastModified\(\) err/);
+        return db.saveMetaProperty("foo", 42)
+          .should.be.rejectedWith(Error, /^Error: saveMetaProperty\(\) err/);
       });
     });
 
-    /** @test {LocalStorage#getLastModified} */
-    describe("#getLastModified", () => {
+    /** @test {LocalStorage#getMetaProperty} */
+    describe("#getMetaProperty", () => {
       it("should reject on generic error", () => {
         sandbox.stub(JSON, "parse", thrower("err"));
-        return db.getLastModified()
-          .should.be.rejectedWith(Error, /^Error: getLastModified\(\) err/);
+        return db.getMetaProperty("foo")
+          .should.be.rejectedWith(Error, /^Error: getMetaProperty\(\) err/);
       });
     });
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -266,7 +266,7 @@ describe("Api", () => {
         return api.fetchChangesSince("blog", "articles", { lastModified: 42 })
           .should.eventually.become({
             lastModified: 41,
-            token: null,
+            nextPage: null,
             changes: []
           });
       });
@@ -277,7 +277,7 @@ describe("Api", () => {
         return api.fetchChangesSince("blog", "articles", {lastModified: 42})
           .should.eventually.become({
             lastModified: 42,
-            token: null,
+            nextPage: null,
             changes: [],
           });
       });
@@ -316,7 +316,7 @@ describe("Api", () => {
         return api.fetchChangesSince("blog", "articles", {lastModified: 42})
           .should.become({
             changes: [],
-            token: "nextToken",
+            nextPage: "http://test/v1/?_token=nextToken",
             lastModified: 42,
           });
       });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -232,6 +232,15 @@ describe("Api", () => {
           .then(_ => expect(fetch.secondCall.args[0]).to.match(/\?_since=42/));
       });
 
+      it("should request server changes using the limit option", () =>{
+        return api.fetchChangesSince("blog", "articles", {
+          lastModified: 42,
+          limit: 100,
+        }).then(_ => {
+          expect(fetch.secondCall.args[0]).to.match(/\?_since=42&_limit=100/);
+        });
+      });
+
       it("should attach an If-None-Match header if lastModified is provided", () =>{
         return api.fetchChangesSince("blog", "articles", {lastModified: 42})
           .then(_ => expect(fetch.secondCall.args[1].headers["If-None-Match"]).eql(quote(42)));

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -913,7 +913,12 @@ describe("Collection", () => {
             sinon.assert.calledWithExactly(fetchChangesSince,
               TEST_BUCKET_NAME,
               TEST_COLLECTION_NAME,
-              {lastModified: null, headers: {}, limit: undefined});
+              {
+                lastModified: null,
+                headers: {},
+                limit: undefined,
+                maxPages: undefined,
+              });
           });
       });
 
@@ -924,7 +929,12 @@ describe("Collection", () => {
             sinon.assert.calledWithExactly(fetchChangesSince,
               TEST_BUCKET_NAME,
               TEST_COLLECTION_NAME,
-              {lastModified: 42, headers: {}, limit: undefined});
+              {
+                lastModified: 42,
+                headers: {},
+                limit: undefined,
+                maxPages: undefined,
+              });
           });
       });
 
@@ -935,7 +945,28 @@ describe("Collection", () => {
             sinon.assert.calledWithExactly(fetchChangesSince,
               TEST_BUCKET_NAME,
               TEST_COLLECTION_NAME,
-              {lastModified: null, headers: {}, limit: 100});
+              {
+                lastModified: null,
+                headers: {},
+                limit: 100,
+                maxPages: undefined,
+              });
+          });
+      });
+
+      it("should use maxPages to fetch remote changes from the server", () => {
+        return articles.pullChanges(result, {maxPages: 8})
+          .then(_ => {
+            sinon.assert.calledOnce(fetchChangesSince);
+            sinon.assert.calledWithExactly(fetchChangesSince,
+              TEST_BUCKET_NAME,
+              TEST_COLLECTION_NAME,
+              {
+                lastModified: null,
+                headers: {},
+                limit: undefined,
+                maxPages: 8,
+              });
           });
       });
 

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -913,7 +913,7 @@ describe("Collection", () => {
             sinon.assert.calledWithExactly(fetchChangesSince,
               TEST_BUCKET_NAME,
               TEST_COLLECTION_NAME,
-              {lastModified: null, headers: {}});
+              {lastModified: null, headers: {}, limit: undefined});
           });
       });
 
@@ -924,7 +924,18 @@ describe("Collection", () => {
             sinon.assert.calledWithExactly(fetchChangesSince,
               TEST_BUCKET_NAME,
               TEST_COLLECTION_NAME,
-              {lastModified: 42, headers: {}});
+              {lastModified: 42, headers: {}, limit: undefined});
+          });
+      });
+
+      it("should use limit to fetch remote changes from the server", () => {
+        return articles.pullChanges(result, {fetchLimit: 100})
+          .then(_ => {
+            sinon.assert.calledOnce(fetchChangesSince);
+            sinon.assert.calledWithExactly(fetchChangesSince,
+              TEST_BUCKET_NAME,
+              TEST_COLLECTION_NAME,
+              {lastModified: null, headers: {}, limit: 100});
           });
       });
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -149,13 +149,41 @@ describe("Integration tests", () => {
             .then(res => syncResult = res);
         });
 
-        it("should retrieve the max nb of records specified in limit", () => {
+        it("should retrieve all the changes", () => {
           expect(syncResult.created).to.have.length.of(4);
         });
 
-        it("should retrieve the expected chunk of records", () => {
+        it("should retrieve the expected changes", () => {
           expect(syncResult.created.map(r => r.title))
             .eql(["task4", "task3", "task2", "task1"]);
+        });
+      });
+
+      describe("Max page", () => {
+        const testData = {
+          localSynced: [],
+          localUnsynced: [],
+          server: [
+            {id: uuid4(), title: "task1", done: true},
+            {id: uuid4(), title: "task2", done: true},
+            {id: uuid4(), title: "task3", done: true},
+            {id: uuid4(), title: "task4", done: true},
+          ]
+        };
+        let syncResult;
+
+        beforeEach(() => {
+          return testSync(testData, {fetchLimit: 2, maxPages: 1})
+            .then(res => syncResult = res);
+        });
+
+        it("should retrieve the max nb of pages of changes", () => {
+          expect(syncResult.created).to.have.length.of(2);
+        });
+
+        it("should retrieve the expected changes", () => {
+          expect(syncResult.created.map(r => r.title))
+            .eql(["task4", "task3"]);
         });
       });
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -131,6 +131,34 @@ describe("Integration tests", () => {
           })));
       }
 
+      describe("Fetch limit", () => {
+        const testData = {
+          localSynced: [],
+          localUnsynced: [],
+          server: [
+            {id: uuid4(), title: "task1", done: true},
+            {id: uuid4(), title: "task2", done: true},
+            {id: uuid4(), title: "task3", done: true},
+            {id: uuid4(), title: "task4", done: true},
+          ]
+        };
+        let syncResult;
+
+        beforeEach(() => {
+          return testSync(testData, {fetchLimit: 2})
+            .then(res => syncResult = res);
+        });
+
+        it("should retrieve the max nb of records specified in limit", () => {
+          expect(syncResult.created).to.have.length.of(2);
+        });
+
+        it("should retrieve the expected chunk of records", () => {
+          expect(syncResult.created.map(r => r.title))
+            .eql(["task4", "task3"]);
+        });
+      });
+
       describe("No conflict", () => {
         const testData = {
           localSynced: [
@@ -1002,7 +1030,7 @@ describe("Integration tests", () => {
       });
     });
 
-    describe("Schemas", () => {
+    describe("Id schemas & transformers", () => {
       function createIntegerIdSchema() {
         let _next = 0;
         return {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -131,7 +131,7 @@ describe("Integration tests", () => {
           })));
       }
 
-      describe("Fetch limit", () => {
+      describe("Pagination", () => {
         const testData = {
           localSynced: [],
           localUnsynced: [],
@@ -150,12 +150,12 @@ describe("Integration tests", () => {
         });
 
         it("should retrieve the max nb of records specified in limit", () => {
-          expect(syncResult.created).to.have.length.of(2);
+          expect(syncResult.created).to.have.length.of(4);
         });
 
         it("should retrieve the expected chunk of records", () => {
           expect(syncResult.created.map(r => r.title))
-            .eql(["task4", "task3"]);
+            .eql(["task4", "task3", "task2", "task1"]);
         });
       });
 


### PR DESCRIPTION
Supersedes #278, WiP:

Reference: [Kinto server docs about paginated changes retrieval](http://kinto.readthedocs.org/en/latest/api/1.x/synchronisation.html#paginated-changes)

- [x] Support the `_limit` query string parameter when fetching changes from the server
- [x] Check for the `Next-Page` header value in HTTP responses
- [x] Recursively retrieve all next pages until there's none, aggregate the results
- [x] Add support for a `maxPages` option so you can limit the number of pages to retrieve
- [x] Expose methods to store and retrieve any collection metadata to `BaseAdapter`; this is required to persist the next page url along the `lastModified` value
- [ ] Store the last next page url in collection db metas, in case the  `maxPages` option has been used and the whole synchronization flow is therefore not fully completed
- [ ] When a next page url is stored, we should *not* bump the collection `lastModified` value; we should do so as soon as there's no `Next-Page` header sent by the server
- [ ] Add a check in `#sync()` if a next page url to crawl is remaining, and start the change retrieval process from there
- [ ] If a `412` status code is received during the paginated changes retrieval flow, restart it from the beginning
- [ ] Ensure any stored next page url is cleared when `#clear()` and `#resetSyncStatus()` are called
- [ ]  Update docs
 
/cc @michielbdejong @Natim @ferjm 