### PR TITLE
Fix parsing of ES7 code in esdoc

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -31,8 +31,8 @@ In the generated `CHANGELOG.md`, replace `HEAD` by `vX.Y.Z` in full changelog an
 
 ### Publish on NPM
 
-    $ npm build
-    $ npm dist
+    $ npm run build
+    $ npm run dist
 
 Ensure NPM package content is ready and valid. The `dist/` folder should contain browersified assets and `lib/` the babelized ES5 files.
 

--- a/esdoc.json
+++ b/esdoc.json
@@ -13,6 +13,9 @@
           {"from": "^src", "to": "lib"}
         ]
       }
+    },
+    {
+      "name": "esdoc-es7-plugin"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "chai-as-promised": "^5.0.0",
     "coveralls": "^2.11.3",
     "esdoc": "^0.4.0",
+    "esdoc-es7-plugin": "0.0.3",
     "esdoc-importpath-plugin": "0.0.1",
     "eslint": "^1.2.0",
     "gh-pages": "^0.8.0",

--- a/src/collection.js
+++ b/src/collection.js
@@ -797,8 +797,7 @@ export default class Collection {
    * The local records which are unsynced or whose timestamp is either missing
    * or superior to those being loaded will be ignored.
    *
-   * @param  {Array} records.
-   * @param  {Object} options Options.
+   * @param  {Array} records The previously exported list of records to load.
    * @return {Promise} with the effectively imported records.
    */
   loadDump(records) {


### PR DESCRIPTION
Used to fail with this:

```
error: could not parse the following code. if you want to use ES7, see esdoc-es7-plugin(https://github.com/esdoc/esdoc-es7-plugin)
/home/mathieu/Code/Mozilla/kinto.js/src/collection.js
676|         // Merge outgoing conflicts into sync result object
677|         syncResultObject.add("conflicts", conflicts);
678|         // Reflect publication results localy
679|         const missingRemotely = skipped.map(r => ({...r, deleted: true}));
680|         const toApplyLocally = published.concat(missingRemotely);
681|         return Promise.all(toApplyLocally.map(record => {
682|           if (record.deleted) {

```

@n1k0 r?