### PR TITLE
Fixes #277: Add fetchLimit and fetchToken support to Collection#sync

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -406,6 +406,7 @@ Here's a sample result object:
   skipped:   [],
   published: [],
   resolved:  [],
+  fetchToken: '1234567890123:50'
 }
 ```
 
@@ -421,7 +422,7 @@ The synchronization result object exposes the following properties:
 - `skipped`:   The list of remotely deleted records missing locally.
 - `published`: The list of locally modified records (created, updated, or deleted) which have been successfully pushed to the remote server.
 - `resolved`:  The list of conflicting records which have been successfully resolved according to the selected [strategy](#synchronization-strategies) (note that when using the default `MANUAL` strategy, this list is always empty).
-
+- `fetchToken`:  When the `fetchLimit` option was used and more results are available, use this as the next `fetchToken` value.
 > #### Notes
 > - Detailed API documentation for `SyncResultObject` is available [here](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~SyncResultObject.html).
 
@@ -472,6 +473,14 @@ function sync() {
 ```
 
 Here we're solving encountered conflicts by picking all remote versions. After conflicts being properly addressed, we're syncing the collection again, until no conflicts occur.
+
+## Other options for `Collection#sync`
+
+Apart from the `headers` and `strategy` options, you can also pass the following options to the `sync` function of a Kinto collection:
+
+- `timeout`: The network timeout in milliseconds (default: 5000)
+- `fetchLimit`: The maximum number of records to retrieve (does not restrict number of records uploaded; any records not retrieved will be retrieved in the next call to `sync`; default: null, meaning unlimited)
+- `fetchToken`: When using `fetchLimit`, if the SyncResults contain a `fetchToken` value, repeat the call to `sync`, setting the `fetchToken` option to that value to retrieve the next page. The sync state of the collection (last_modified) will not be updated until you have fetched the last page.
 
 ## The case of a new/flushed server
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -552,7 +552,8 @@ export default class Collection {
       .then(syncResultObject => {
         syncResultObject.lastModified = changeObject.lastModified;
         // Don't persist lastModified value if any conflict or error occured
-        if (!syncResultObject.ok) {
+        // or if pagination is still in progress.
+        if (!syncResultObject.ok || syncResultObject.fetchToken) {
           return syncResultObject;
         }
         // No conflict occured, persist collection's lastModified value
@@ -635,6 +636,8 @@ export default class Collection {
    *
    * Options:
    * - {String} strategy: The selected sync strategy.
+   * - {Number} fetchLimit: Number of items to fetch (oldest first).
+   * - {Number} fetchToken: Page to fetch (combine this with fetchLimit).
    *
    * @param  {SyncResultObject} syncResultObject
    * @param  {Object}           options
@@ -647,13 +650,27 @@ export default class Collection {
     options = Object.assign({
       strategy: Collection.strategy.MANUAL,
       lastModified: this.lastModified,
+      limit: options.fetchLimit || null,
+      token: options.fetchToken || null,
       headers: {},
     }, options);
     // First fetch remote changes from the server
     return this.api.fetchChangesSince(this.bucket, this.name, {
       lastModified: options.lastModified,
+      limit: options.limit,
+      token: options.token,
       headers: options.headers
     })
+      // Deal with pagination
+      .then(changes => {
+        if (changes.fetchToken) {
+          syncResultObject.fetchToken = changes.fetchToken;
+        }
+        // TODO: deal with the case where records disappear from
+        // pages already fetched, due to updates to the server
+        // while the paginating query series is in progress.
+        return changes;
+      })
       // Reflect these changes locally
       .then(changes => this.importChanges(syncResultObject, changes))
       // Handle conflicts, if any
@@ -800,8 +817,10 @@ export default class Collection {
    * - if the server has been detected flushed.
    *
    * Options:
-   * - {Object} headers: HTTP headers to attach to outgoing requests.
    * - {Collection.strategy} strategy: See {@link Collection.strategy}.
+   * - {Number} fetchLimit: Number of items to fetch from the server.
+   * - {Number} fetchToken: Page to fetch (combine this with fetchLimit).
+   * - {Object} headers: HTTP headers to attach to outgoing requests.
    * - {Boolean} ignoreBackoff: Force synchronization even if server is currently
    *   backed off.
    * - {String} remote The remote Kinto server endpoint to use (default: null).
@@ -812,6 +831,8 @@ export default class Collection {
    */
   sync(options={
     strategy: Collection.strategy.MANUAL,
+    fetchLimit: null,
+    fetchToken: null,
     headers: {},
     ignoreBackoff: false,
     remote: null,


### PR DESCRIPTION
To do:

* [x] tests for token param
* [x] docs
* [x] add pagination
* [x] test for parsing of `Next-Page` header
* [x] test for not saving `last_modified` if `Next-Page` header is present