### PR TITLE
Add collection transformers.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -570,7 +570,7 @@ kinto.events.on("deprecated", function(event) {
 
 Transformers are basically hooks for encoding and decoding records, which can work synchronously or asynchronously.
 
-For now, only *remote transformers* have been implemented, but there are plans to implement local transformers and collection transformers in a next version.
+For now, only *remote transformers* and *collection transformers* have been implemented, but there are plans to implement local transformers in a next version.
 
 ### Remote transformers
 
@@ -623,7 +623,8 @@ coll.create({title: "foo"}).then(_ => coll.sync())
 
 ### Local transformers
 
-In a near future, Kinto.js will provide transfomers aimed at providing facilities to encode and decode records when persisted locally.
+In a near future, Kinto.js will provide transfomers aimed at providing facilities to encode and decode records when persisted locally. If you are interested into
+making this happen, [don't hesitate to connect with us](https://kiwiirc.com/client/irc.freenode.net/?#kinto).
 
 ### Async transformers
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -570,7 +570,7 @@ kinto.events.on("deprecated", function(event) {
 
 Transformers are basically hooks for encoding and decoding records, which can work synchronously or asynchronously.
 
-For now, only *remote transformers* and *collection transformers* have been implemented, but there are plans to implement local transformers in a next version.
+For now, only *remote transformers* and *hooks* have been implemented, but there are plans to implement local transformers in a next version.
 
 ### Remote transformers
 
@@ -623,8 +623,7 @@ coll.create({title: "foo"}).then(_ => coll.sync())
 
 ### Local transformers
 
-In a near future, Kinto.js will provide transfomers aimed at providing facilities to encode and decode records when persisted locally. If you are interested into
-making this happen, [don't hesitate to connect with us](https://kiwiirc.com/client/irc.freenode.net/?#kinto).
+In a near future, Kinto.js will provide transfomers aimed at providing facilities to encode and decode records when persisted locally.
 
 ### Async transformers
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -46,7 +46,6 @@ Then create the Kinto object passing a reference to your adapter class:
 const kinto = new Kinto({adapter: MyAdapter});
 ```
 
-<<<<<<< bb86b694d73101136b4c6c39b47bcf8e27afd4f0
 Read the `BaseAdapter` class [source code](https://github.com/Kinto/kinto.js/blob/master/src/adapters/base.js) to figure out what needs to be implemented exactly. The [IDB](https://github.com/Kinto/kinto.js/blob/master/src/adapters/IDB.js) adapter is also worth a read if you need guidance writing your own.
 
 ## Supporting transactions
@@ -97,13 +96,13 @@ Hooks can be called to extend the behaviour of kinto. So far it is only possible
 To install a hook, you need to pass it to the collection:
 
 ```
-function doSomething(payload) {
+function doSomething(payload, collection) {
   // Do something with the payload here.
 };
 
 let collection = db.collection(collectionName, {
-    "hooks": {
-      "incoming-changes": doSomething
-    }
+  "hooks": {
+    "incoming-changes": doSomething
+  }
 });
 ```

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -46,6 +46,7 @@ Then create the Kinto object passing a reference to your adapter class:
 const kinto = new Kinto({adapter: MyAdapter});
 ```
 
+<<<<<<< bb86b694d73101136b4c6c39b47bcf8e27afd4f0
 Read the `BaseAdapter` class [source code](https://github.com/Kinto/kinto.js/blob/master/src/adapters/base.js) to figure out what needs to be implemented exactly. The [IDB](https://github.com/Kinto/kinto.js/blob/master/src/adapters/IDB.js) adapter is also worth a read if you need guidance writing your own.
 
 ## Supporting transactions
@@ -84,4 +85,25 @@ db.list()
       transaction.update(Object.assign({}, existing, {foo: "bar"}));
     }, {preload});
   });
+```
+
+## Hooks
+
+Hooks can be called to extend the behaviour of kinto. So far it is only possible to hook when incoming changes are to be applied.
+
+- `incoming-changes` hooks are called just after new changes are retrieved, and
+  before these changes are reflected locally.
+
+To install a hook, you need to pass it to the collection:
+
+```
+function doSomething(payload) {
+  // Do something with the payload here.
+};
+
+let collection = db.collection(collectionName, {
+    "hooks": {
+      "incoming-changes": doSomething
+    }
+});
 ```

--- a/src/KintoBase.js
+++ b/src/KintoBase.js
@@ -91,7 +91,8 @@ export default class KintoBase {
       adapter:             this._options.adapter,
       dbPrefix:            this._options.dbPrefix,
       idSchema:            options.idSchema,
-      remoteTransformers:  options.remoteTransformers
+      remoteTransformers:  options.remoteTransformers,
+      collectionTransformers: options.collectionTransformers,
     });
   }
 }

--- a/src/KintoBase.js
+++ b/src/KintoBase.js
@@ -92,7 +92,7 @@ export default class KintoBase {
       dbPrefix:            this._options.dbPrefix,
       idSchema:            options.idSchema,
       remoteTransformers:  options.remoteTransformers,
-      collectionTransformers: options.collectionTransformers,
+      hooks:               options.hooks,
     });
   }
 }

--- a/src/collection.js
+++ b/src/collection.js
@@ -324,11 +324,11 @@ export default class Collection {
     if (!Array.isArray(hook)) {
       throw new Error("A hook definition should be an array of functions.");
     }
-    return hook.map(fun => {
-      if (typeof fun !== "function") {
+    return hook.map(fn => {
+      if (typeof fn !== "function") {
         throw new Error("A hook definition should be an array of functions.");
       }
-      return fun;
+      return fn;
     });
   }
 
@@ -731,7 +731,7 @@ export default class Collection {
       return Promise.resolve(payload);
     }
     return waterfall(this.hooks[hookName].map(hook => {
-      return record => hook(payload);
+      return record => hook(payload, this);
     }), payload);
   }
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -6,9 +6,8 @@ import { waterfall } from "./utils";
 import { v4 as uuid4 } from "uuid";
 import { deepEquals, isUUID, pFinally } from "./utils";
 
-<<<<<<< e030e48ddf01fc99d081510a097865cdf55af165
-
 const RECORD_FIELDS_TO_CLEAN = ["_status", "last_modified"];
+const AVAILABLE_HOOKS = ["incoming-changes"];
 
 /**
  * Cleans a record object, excluding passed keys.
@@ -25,9 +24,6 @@ export function cleanRecord(record, excludeFields=RECORD_FIELDS_TO_CLEAN) {
     return acc;
   }, {});
 }
-=======
-const AVAILABLE_HOOKS = ["incoming-changes"];
->>>>>>> Use a concept of hooks rather than transformers.
 
 /**
  * Synchronization result object.
@@ -630,7 +626,6 @@ export default class Collection {
         if (!syncResultObject.ok) {
           return syncResultObject;
         }
-        // XXX import of data should be done after conflict handling.
         // No conflict occured, persist collection's lastModified value
         return this.db.saveLastModified(syncResultObject.lastModified)
           .then(lastModified => {
@@ -726,7 +721,7 @@ export default class Collection {
     })
       .then(changes => this.applyHook("incoming-changes", {changes}))
       // Reflect these changes locally
-      .then(payload => this.importChanges(syncResultObject, payload.changes))
+      .then(({changes}) => this.importChanges(syncResultObject, changes))
       // Handle conflicts, if any
       .then(result => this._handleConflicts(result, options.strategy));
   }
@@ -736,7 +731,7 @@ export default class Collection {
       return Promise.resolve(payload);
     }
     return waterfall(this.hooks[hookName].map(hook => {
-      return record => hook(payload, this);
+      return record => hook(payload);
     }), payload);
   }
 

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -998,26 +998,39 @@ describe("Collection", () => {
         });
       });
 
-      describe("collectionTransformers", () => {
+      describe("collectionTransfomers", () => {
         it("should call the collection transformer", () => {
-          let transformerCalled = false;
+          let transformerEncoderCalled = false;
+          let transformerDecoderCalled = false;
           articles = testCollection({
-            collectionTransformers: [function(changes) {
-              transformerCalled = true;
-              return changes;
+            collectionTransformers: [{
+              encode: function(changes, collection) {
+                transformerEncoderCalled = true;
+                return changes;
+              },
+              decode: function(changes, collection) {
+                transformerDecoderCalled = true;
+                return changes;
+              }
             }]
           });
 
           return articles.pullChanges(result)
             .then(_ => {
-              expect(transformerCalled).to.be.true;
+              expect(transformerDecoderCalled).to.be.true;
+              expect(transformerEncoderCalled).to.be.false;
             });
         });
 
         it("should reject the promise if the transformer raises", () => {
           articles = testCollection({
-            collectionTransformers: [function(changes, collection) {
-              throw new Error("Invalid collection data");
+            collectionTransformers: [{
+              encode: function(changes, collection) {
+                return changes;
+              },
+              decode: function(changes, collection) {
+                throw new Error("Invalid collection data");
+              }
             }]
           });
 

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -1042,7 +1042,7 @@ describe("Collection", () => {
           articles = testCollection({
             hooks: {
               "incoming-changes": [
-                function(payload, collection) {
+                function(payload) {
                   hookCalled = true;
                   return payload;
                 }
@@ -1051,16 +1051,14 @@ describe("Collection", () => {
           });
 
           return articles.pullChanges(result)
-            .then(_ => {
-              expect(hookCalled).to.be.true;
-            });
+            .then(_ => {expect(hookCalled).to.be.true;});
         });
 
-        it("should reject the promise if the hook raises", () => {
+        it("should reject the promise if the hook throws", () => {
           articles = testCollection({
             hooks: {
               "incoming-changes": [
-                function(changes, collection) {
+                function(changes) {
                   throw new Error("Invalid collection data");
                 }
               ]

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -1677,7 +1677,7 @@ describe("Collection", () => {
       it("should reject on server backoff by default", () => {
         articles.api = {backoff: 30000};
         return articles.sync()
-          .should.be.rejectedWith(Error, /Server is backed off; retry in 30s/);
+          .should.be.rejectedWith(Error, /back off; retry in 30s/);
       });
 
       it("should perform sync on server backoff when ignoreBackoff is true", () => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1153,7 +1153,7 @@ describe("Integration tests", () => {
     it("should reject sync when the server sends a Backoff header", () => {
       // Note: first call receive the Backoff header, second actually rejects.
       return tasks.sync().then(_ => tasks.sync())
-        .should.be.rejectedWith(Error, /Server is backed off; retry in 10s/);
+        .should.be.rejectedWith(Error, /Server is asking clients to back off; retry in 10s/);
     });
   });
 


### PR DESCRIPTION
This adds the concept of collection transformers.

I haven't updated the documentation because I'm not sure about the concepts we want to expose, as mentioned in #154 & #153.

The documentation states that transformers should be able to encode and decode, but I'm not sure that should be the case for what's implemented here as "collection transformers". I'm happy to have any feedback on the naming (and of course the implementation).

If we chose to go with the "transformers" approach (and still not have decode / encode), then the documentation will need to be updated to explain what a collection should be.

For what it's worth, the first version of this code was implemented with "decode" and "encode" functions, but I couldn't see why we were needing them, so I removed them and passed a function instead.

I'm very interested by any feedback on this, so if anyone has time, don't hesitate :) cc @n1k0  @michielbdejong 