### PR TITLE
Set last_modified on updated record if missing

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -422,6 +422,9 @@ export default class Collection {
           const source = options.patch ? Object.assign({}, existing, record)
                                        : record;
           const updated = markStatus(source, newStatus);
+          if (existing.last_modified && !updated.last_modified) {
+            updated.last_modified = existing.last_modified;
+          }
           transaction.update(updated);
           return {data: updated, permissions: {}};
         });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -461,6 +461,36 @@ describe("Collection", () => {
           _status: "updated"
         });
     });
+
+    it("should remove previous record fields", () => {
+      return articles.create(article)
+        .then(res => articles.get(res.data.id))
+        .then(res => {
+          return articles.update(
+            Object.assign({}, {id: res.data.id}, {
+              title: "new title",
+            }));
+        })
+        .then(res => res.data)
+          .should.eventually.not.have.property("url");
+    });
+
+    it("should preserve record.last_modified", () => {
+      return articles.create({
+        title: "foo",
+        url: "http://foo",
+        last_modified: 123456789012
+      })
+        .then(res => articles.get(res.data.id))
+        .then(res => {
+          return articles.update(
+            Object.assign({}, {id: res.data.id}, {
+              title: "new title",
+            }));
+        })
+        .then(res => res.data)
+          .should.eventually.have.property("last_modified").eql(123456789012);
+    });
   });
 
   /** @test {Collection#resolve} */


### PR DESCRIPTION
Here's what happens without this patch:
* Start an empty Kinto server
* Sync (collection is empty)
* Create record '12345678-1234-1234-1234-1234567890ab' as `{ value: 'a' }`, and sync (record is created remotely)
* Update record '12345678-1234-1234-1234-1234567890ab' to `{ value: 'b' }`, and sync

Expected: the record is updated remotely
Actual:
* First, data is fetched, and (due to https://github.com/Kinto/kinto.js/issues/306 I think?) record  '12345678-1234-1234-1234-1234567890ab' is updated to `{ value: 'a' }`, but that's probably unrelated here.
* Now `gatherLocalChanges` notes the update to `{ value: 'b' }` and adds it to `toSync`, but without `last_modified`.
* Since there is not `last_modified` on `updatedRecord`, the `If-None-Match: *` header is set
* This request fails, of course.
* The record is reverted to  `{ value: 'a' }`