### PR TITLE
Allow patching a record using Collection#update().

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -120,6 +120,7 @@ Result is:
 > #### Notes
 >
 > - An ID is required, otherwise the promise will be rejected;
+> - The `patch` option allows amending the existing record with passed data. By default this option is set to `false`, so existing records are overriden with passed data;
 > - Detailed API documentation for `Collection#update()` is available [here](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-update).
 
 ## Deleting records

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -446,6 +446,21 @@ describe("Collection", () => {
       return articles.update({id: "deadbeef"})
         .should.be.rejectedWith(Error, /Invalid Id/);
     });
+
+    it("should patch existing record when patch option is used", () => {
+      const id = uuid4();
+      return articles.create({id, title: "foo", last_modified: 42},
+                             {useRecordId: true})
+        .then(() => articles.update({id, rank: 99}, {patch: true}))
+        .then((res) => res.data)
+        .should.eventually.become({
+          id,
+          title: "foo",
+          rank: 99,
+          last_modified: 42,
+          _status: "updated"
+        });
+    });
   });
 
   /** @test {Collection#resolve} */

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -69,6 +69,11 @@ describe("Integration tests", () => {
       });
   }
 
+  after((done) => {
+    // Ensure no pserve process remains after tests having been executed.
+    spawn("killall", ["pserve"]).on("close", () => done());
+  });
+
   beforeEach(function() {
     this.timeout(12500);
 


### PR DESCRIPTION
WiP; refs #286, #309.

This adds support for a new `patch` option to `Collection#update()`, so one can simply augment an existing record with supplementary properties or replace the values of existing ones.

Feedback=? @michielbdejong  