### PR TITLE
Use IndexedDB indexes on gatherLocalChanges()

### DIFF
--- a/fx-src/FirefoxStorage.js
+++ b/fx-src/FirefoxStorage.js
@@ -13,6 +13,7 @@
  */
 
 import BaseAdapter from "../src/adapters/base";
+import { reduceRecords } from "../src/utils";
 
 Components.utils.import("resource://gre/modules/Sqlite.jsm");
 Components.utils.import("resource://gre/modules/Task.jsm");
@@ -183,11 +184,11 @@ export default class FirefoxAdapter extends BaseAdapter {
       });
   }
 
-  list() {
-    const params = {
+  list(params={filters: {}, order: ""}) {
+    const parameters = {
       collection_name: this.collection,
     };
-    return this._executeStatement(statements.listRecords, params)
+    return this._executeStatement(statements.listRecords, parameters)
       .then(result => {
         const records = [];
         for (let k = 0; k < result.length; k++) {
@@ -195,6 +196,11 @@ export default class FirefoxAdapter extends BaseAdapter {
           records.push(JSON.parse(row.getResultByName("record")));
         }
         return records;
+      })
+      .then(results => {
+        // The resulting list of records is filtered and sorted.
+        // XXX: with some efforts, this could be implemented using SQL.
+        return reduceRecords(params.filters, params.order, results);
       });
   }
 

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -1,6 +1,7 @@
 "use strict";
 
 import BaseAdapter from "./base.js";
+import { reduceRecords } from "../utils";
 
 /**
  * IndexedDB adapter.
@@ -205,12 +206,33 @@ export default class IDB extends BaseAdapter {
    * @override
    * @return {Promise}
    */
-  list() {
+  list(params={filters: {}, order: ""}) {
+    // Extract from `params.filters` the fields that are indexed.
+    const filteredFields = Object.keys(params.filters);
+    const indexedFields = filteredFields.filter(f => {
+      return ["id", "_status", "last_modified"].indexOf(f) !== -1;
+    });
+    // Since indices were created on single-columns, use the first one only.
+    const indexField = indexedFields[0];
+
     return this.open().then(() => {
       return new Promise((resolve, reject) => {
         const results = [];
         const {transaction, store} = this.prepare();
-        const request = store.openCursor();
+
+        let request;
+        if (indexField) {
+          // Filter using index.
+          const value = params.filters[indexField];
+          const range = IDBKeyRange.only(value);
+          const index = store.index(indexField);
+          request = index.openCursor(range);
+        }
+        else {
+          // Get all records.
+          request = store.openCursor();
+        }
+
         request.onsuccess = function(event) {
           const cursor = event.target.result;
           if (cursor) {
@@ -221,7 +243,16 @@ export default class IDB extends BaseAdapter {
         transaction.onerror = event => reject(new Error(event.target.error));
         transaction.oncomplete = event => resolve(results);
       });
-    }).catch(this._handleError("list"));
+    })
+    .then((results) => {
+      // The resulting list of records is filtered and sorted.
+      const remainingFilters = Object.assign({}, params.filters);
+      // If `indexField` was used already, don't filter again.
+      delete remainingFilters[indexField];
+      // XXX: with some efforts, this could be implemented using IDB API.
+      return reduceRecords(remainingFilters, params.order, results);
+    })
+    .catch(this._handleError("list"));
   }
 
   /**

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -206,7 +206,7 @@ export default class IDB extends BaseAdapter {
    * @override
    * @return {Promise}
    */
-  list(params={filters: {}, order: ""}) {
+  list(params={filters: {}}) {
     // Extract from `params.filters` the fields that are indexed.
     const filteredFields = Object.keys(params.filters);
     const indexedFields = filteredFields.filter(f => {

--- a/src/adapters/base.js
+++ b/src/adapters/base.js
@@ -63,9 +63,10 @@ export default class BaseAdapter {
    * Lists all records from the database.
    *
    * @abstract
+   * @param  {Object} params  The filters and order to apply to the results.
    * @return {Promise}
    */
-  list() {
+  list(params={filters: {}, order: ""}) {
     throw new Error("Not Implemented.");
   }
 

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -276,7 +276,7 @@ describe("adapter.IDB", () => {
           }
         }
       });
-      return db.list({})
+      return db.list()
         .should.be.rejectedWith(Error, "transaction error");
     });
   });


### PR DESCRIPTION
* [x] Take advantage of index if available for filtered field
* [x] Optimized gatherLocalChanges()
* [x] Move reduceRecords to IDB and Firefox storage (long term: replace it with generated sql)

Small benchmark: 4500 records in local store. None of them changed.

Before (1000+):
![capture d ecran de 2016-01-29 14-38-28](https://cloud.githubusercontent.com/assets/546692/12676974/1a9d9b90-c696-11e5-8230-53355628129f.png)

After (<50):

![capture d ecran de 2016-02-01 11-32-58](https://cloud.githubusercontent.com/assets/546692/12714953/b9814002-c8d7-11e5-8a9a-6fc675e6bae0.png)



