### PR TITLE
Functional test when no change on server (ref #306)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - export PATH=$HOME/.local/bin:$PATH
 - pip install --user `whoami` virtualenv
 - virtualenv .env
-- .env/bin/pip install kinto==1.11.0
+- .env/bin/pip install kinto==1.11.2
 - export KINTO_PSERVE_EXECUTABLE=.env/bin/pserve
 env:
 - ACTION=test

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -136,6 +136,40 @@ describe("Integration tests", () => {
           })));
       }
 
+      describe("No change", () => {
+        const testData = {
+          localSynced: [],
+          localUnsynced: [],
+          server: [
+            {id: uuid4(), title: "task1", done: true},
+          ]
+        };
+        let syncResult1;
+        let syncResult2;
+
+        beforeEach(() => {
+          // Sync twice.
+          return testSync(testData)
+            .then(res => {
+              syncResult1 = res;
+              return tasks.sync();
+            })
+            .then(res => syncResult2 = res);
+        });
+
+        it("should have an ok status", () => {
+          expect(syncResult2.ok).eql(true);
+        });
+
+        it("should not contain conflicts", () => {
+          expect(syncResult2.conflicts).to.have.length.of(0);
+        });
+
+        it("should have same lastModified value", () => {
+          expect(syncResult1.lastModified).to.eql(syncResult2.lastModified);
+        });
+      });
+
       describe("No conflict", () => {
         const testData = {
           localSynced: [


### PR DESCRIPTION
@michielbdejong I tried to reproduce #306 but can't find any problem.

I updated the kinto server to 1.11.2 which includes the fix about `ETag` in 304 responses.

Please take over the branch if you know how to highlight the problem :)

Otherwise it's not a bad idea to merge it IMO.

