### PR TITLE
Output Kinto client version in Moz build for Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dist-dev": "browserify -s Kinto -d -e src/index.js -o dist/kinto-$npm_package_version.js -t [ babelify --sourceMapRelative . ]",
     "dist-noshim": "browserify -s Kinto -g uglifyify --ignore isomorphic-fetch --ignore babel-polyfill -e src/index.js -o dist/kinto-$npm_package_version.noshim.js -t [ babelify --sourceMapRelative . ]",
     "dist-prod": "browserify -s Kinto -g uglifyify -e src/index.js -o dist/kinto-$npm_package_version.min.js -t [ babelify --sourceMapRelative . ]",
-    "dist-fx": "BABEL_ENV=firefox browserify -s loadKinto --ignore isomorphic-fetch -e fx-src/index.js -o temp.jsm -t [ babelify --sourceMapRelative . ] && mkdir -p dist && cp fx-src/jsm_prefix.js dist/moz-kinto-client.js && cat temp.jsm >> dist/moz-kinto-client.js && rm temp.jsm",
+    "dist-fx": "BABEL_ENV=firefox browserify -s loadKinto --ignore isomorphic-fetch -e fx-src/index.js -o temp.jsm -t [ babelify --sourceMapRelative . ] && mkdir -p dist && cp fx-src/jsm_prefix.js dist/moz-kinto-client.js && echo \"\n/*\n * Version $npm_package_version - $(git rev-parse --short HEAD)\n */\n\" >> dist/moz-kinto-client.js && cat temp.jsm >> dist/moz-kinto-client.js && rm temp.jsm",
     "compute-sri": "cd dist; for file in $(ls kinto-*.js); do printf \"| %-23s | %-64s |\\n\" ${file} $(echo -n 'sha384-' && cat ${file} | openssl dgst -sha384 -binary | openssl enc -base64); done",
     "publish-demo": "npm run dist-prod && cp dist/kinto-$npm_package_version.js demo/kinto.js && gh-pages -d demo",
     "report-coverage": "npm run test-cover && ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info",


### PR DESCRIPTION
I realized that currently there was no easy way to obtain the version of the client embedded in Firefox.

I added a `echo $npm_package_version` in the `run dist-fx`. But maybe we could generalize it to every builds?

@mozmark r?
@n1k0 feedback?

The output looks like so:
```js
/*
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
  [...]
 * limitations under the License.
 */

/*
 * This file is generated from kinto.js - do not modify directly.
 */

this.EXPORTED_SYMBOLS = ["loadKinto"];

/*
 * Version 1.2.0
 */

(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.e
```