### PR TITLE
[1.2] Ensure a single instance of babel-polyfill is imported.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "demo": "npm run dist && http-server demo",
     "dist": "mkdir -p dist && rm -f dist/*.* && npm run dist-dev && npm run dist-prod && npm run dist-noshim && npm run dist-fx",
     "dist-dev": "browserify -s Kinto -d -e src/index.js -o dist/kinto-$npm_package_version.js -t [ babelify --sourceMapRelative . ]",
-    "dist-noshim": "browserify -s Kinto -g uglifyify --ignore isomorphic-fetch --ignore babel-core/polyfill -e src/index.js -o dist/kinto-$npm_package_version.noshim.js -t [ babelify --sourceMapRelative . ]",
+    "dist-noshim": "browserify -s Kinto -g uglifyify --ignore isomorphic-fetch --ignore babel-polyfill -e src/index.js -o dist/kinto-$npm_package_version.noshim.js -t [ babelify --sourceMapRelative . ]",
     "dist-prod": "browserify -s Kinto -g uglifyify -e src/index.js -o dist/kinto-$npm_package_version.min.js -t [ babelify --sourceMapRelative . ]",
     "dist-fx": "browserify -s loadKinto -e fx-src/index.js -o temp.jsm -t [ babelify --blacklist regenerator,es6.arrowFunctions ] && mkdir -p dist && cp fx-src/jsm_prefix.js dist/moz-kinto-client.js && cat temp.jsm >> dist/moz-kinto-client.js && rm temp.jsm",
     "publish-demo": "gh-pages -d demo",
@@ -64,13 +64,14 @@
   "dependencies": {
     "babel": "^5.8.19",
     "btoa": "^1.1.2",
-    "fake-indexeddb": "^1.0.3",
+    "fake-indexeddb": "1.0.3",
     "isomorphic-fetch": "^2.1.1",
     "localStorage": "^1.0.3",
     "uuid": "^2.0.1"
   },
   "devDependencies": {
     "babel-eslint": "^4.0.10",
+    "babel-polyfill": "^6.7.4",
     "babelify": "^6.1.3",
     "browserify": "^13.0.0",
     "chai": "^3.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,11 @@
 "use strict";
 
-import { EventEmitter } from "events";
+// babel-polyfill can only be imported once
+if (!global._babelPolyfill) {
+  require("babel-polyfill");
+}
 
-import "babel/polyfill";
+import { EventEmitter } from "events";
 import "isomorphic-fetch";
 
 import BaseAdapter from "./adapters/base";


### PR DESCRIPTION
When having kinto.js as a dependency in another project using the Babel polyfill as well, we get an `only one instance of babel/polyfill is allowed` error, because that polyfill can [only be imported once](https://phabricator.babeljs.io/T1019).

This maintenance patch for the 1.2-maintenance branch fixes this, and we'll publish a 1.2.1 patch release when this is landed onto that branch.

Note that we should issue the fix for master as well, though in a next PR.

r=? @leplatrem 