### PR TITLE
Switch from assert to deeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "build-demo": "mkdir -p dist && npm run dist-prod && cp dist/kinto-$npm_package_version.min.js demo/kinto.js",
     "demo": "npm run build-demo && http-server demo",
     "dist": "mkdir -p dist && rm -f dist/*.* && npm run dist-dev && npm run dist-prod && npm run dist-noshim && npm run dist-fx",
-    "dist-dev": "browserify -s Kinto -d -e src/index.js -o dist/kinto-$npm_package_version.js -t [ babelify --sourceMapRelative . ]",
-    "dist-noshim": "browserify -s Kinto -g uglifyify --ignore isomorphic-fetch --ignore babel-polyfill -e src/index.js -o dist/kinto-$npm_package_version.noshim.js -t [ babelify --sourceMapRelative . ]",
-    "dist-prod": "browserify -s Kinto -g uglifyify -e src/index.js -o dist/kinto-$npm_package_version.min.js -t [ babelify --sourceMapRelative . ]",
-    "dist-fx": "BABEL_ENV=firefox browserify -s loadKinto --ignore isomorphic-fetch -e fx-src/index.js -o temp.jsm -t [ babelify --sourceMapRelative . ] && mkdir -p dist && cp fx-src/jsm_prefix.js dist/moz-kinto-client.js && echo \"\n/*\n * Version $npm_package_version - $(git rev-parse --short HEAD)\n */\n\" >> dist/moz-kinto-client.js && cat temp.jsm >> dist/moz-kinto-client.js && rm temp.jsm",
+    "dist-dev": "browserify -s Kinto -d --ignore buffertools -e src/index.js -o dist/kinto-$npm_package_version.js -t [ babelify --sourceMapRelative . ]",
+    "dist-noshim": "browserify -s Kinto -g uglifyify --ignore buffertools --ignore isomorphic-fetch --ignore babel-polyfill -e src/index.js -o dist/kinto-$npm_package_version.noshim.js -t [ babelify --sourceMapRelative . ]",
+    "dist-prod": "browserify -s Kinto -g uglifyify --ignore buffertools -e src/index.js -o dist/kinto-$npm_package_version.min.js -t [ babelify --sourceMapRelative . ]",
+    "dist-fx": "BABEL_ENV=firefox browserify -s loadKinto --ignore buffertools --ignore isomorphic-fetch -e fx-src/index.js -o temp.jsm -t [ babelify --sourceMapRelative . ] && mkdir -p dist && cp fx-src/jsm_prefix.js dist/moz-kinto-client.js && echo \"\n/*\n * Version $npm_package_version - $(git rev-parse --short HEAD)\n */\n\" >> dist/moz-kinto-client.js && cat temp.jsm >> dist/moz-kinto-client.js && rm temp.jsm",
     "compute-sri": "cd dist; for file in $(ls kinto-*.js); do printf \"| %-23s | %-64s |\\n\" ${file} $(echo -n 'sha384-' && cat ${file} | openssl dgst -sha384 -binary | openssl enc -base64); done",
     "publish-demo": "npm run dist-prod && cp dist/kinto-$npm_package_version.js demo/kinto.js && gh-pages -d demo",
     "publish-to-npm": "npm run dist && npm run build && npm publish",
@@ -68,6 +68,7 @@
   "dependencies": {
     "babel-polyfill": "^6.7.4",
     "btoa": "^1.1.2",
+    "deeper": "^2.1.0",
     "fake-indexeddb": "1.0.5",
     "kinto-client": "^0.5.0",
     "uuid": "^2.0.1"

--- a/src/collection.js
+++ b/src/collection.js
@@ -2,9 +2,9 @@
 
 import BaseAdapter from "./adapters/base";
 import { waterfall } from "./utils";
-
 import { v4 as uuid4 } from "uuid";
-import { deepEquals, isUUID, pFinally } from "./utils";
+import deepEqual from "deeper";
+import { isUUID, pFinally } from "./utils";
 
 const RECORD_FIELDS_TO_CLEAN = ["_status", "last_modified"];
 const AVAILABLE_HOOKS = ["incoming-changes"];
@@ -133,7 +133,7 @@ function importChange(transaction, remote) {
     transaction.create(synced);
     return {type: "created", data: synced};
   }
-  const identical = deepEquals(cleanRecord(local), cleanRecord(remote));
+  const identical = deepEqual(cleanRecord(local), cleanRecord(remote));
   if (local._status !== "synced") {
     // Locally deleted, unsynced: scheduled for remote deletion.
     if (local._status === "deleted") {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,24 +1,6 @@
 "use strict";
 
-import { deepEqual } from "deeper";
-
 const RE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-/**
- * Deeply checks if two structures are equals.
- *
- * @param  {Any} a
- * @param  {Any} b
- * @return {Boolean}
- */
-export function deepEquals(a, b) {
-  try {
-    deepEqual(a, b);
-  } catch(err) {
-    return false;
-  }
-  return true;
-}
 
 /**
  * Checks if a value is undefined.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { deepEqual } from "assert";
+import { deepEqual } from "deeper";
 
 const RE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 


### PR DESCRIPTION
Use deeper instead of assert, which is shipped entirely by browserify.
(as an example, it reduces the gecko build by 25Ko)

I had to blacklist `buffertools` because of this: https://github.com/othiym23/node-deeper/pull/4

@n1k0 r?