### PR TITLE
Fix broken link to 'installation'

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,7 +10,7 @@ The final demo code is [available](https://github.com/Kinto/kinto.js/tree/master
 >
 > **For this tutorial we'll be using a public test server instance of [Kinto](http://kinto.readthedocs.org/); data stored on this instance are purged every 24 hours. Don't rely on this server for production use.**
 >
-> If you plan on using your own version of Kinto, please refer to the [setup instructions](installation.md).
+> If you plan on using your own version of Kinto, please refer to the [setup instructions](http://kinto.readthedocs.io/en/latest/get-started.html).
 
 ## Bootstrapping a demo Web application
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,7 +10,7 @@ The final demo code is [available](https://github.com/Kinto/kinto.js/tree/master
 >
 > **For this tutorial we'll be using a public test server instance of [Kinto](http://kinto.readthedocs.org/); data stored on this instance are purged every 24 hours. Don't rely on this server for production use.**
 >
-> If you plan on using your own version of Kinto, please refer to the [setup instructions](http://kinto.readthedocs.org/en/stable/installation.html).
+> If you plan on using your own version of Kinto, please refer to the [setup instructions](installation.md).
 
 ## Bootstrapping a demo Web application
 


### PR DESCRIPTION
I found the broken link.
'http://kinto.readthedocs.org/en/stable/installation.html' is not exist.