### PR TITLE
Conflicts

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -151,7 +151,7 @@ function importChange(transaction, remote) {
       // one, this represents an object that corresponds to a resolved
       // conflict. Our local version represents the final output, so
       // we keep that one. (No transaction operation to do.)
-      // But if our last_modifieds is undefined,
+      // But if our last_modified is undefined,
       // that means we've created the same object locally as one on
       // the server, which *must* be a conflict.
       return {type: "void"};

--- a/src/collection.js
+++ b/src/collection.js
@@ -150,10 +150,12 @@ function importChange(transaction, remote) {
       // If our local version has the same last_modified as the remote
       // one, this represents an object that corresponds to a resolved
       // conflict. Our local version represents the final output, so
-      // we keep that one. But if our last_modifieds is undefined,
+      // we keep that one. (no transaction operation to do).
+      // But if our last_modifieds is undefined,
       // that means we've created the same object locally as one on
       // the server, which *must* be a conflict.
-      return {type: "updated", data: markSynced(local), previous: local};
+      const updated = markStatus(local, "updated");
+      return {type: "resolved", data: updated, previous: local};
     }
     return {
       type: "conflicts",

--- a/src/collection.js
+++ b/src/collection.js
@@ -150,12 +150,11 @@ function importChange(transaction, remote) {
       // If our local version has the same last_modified as the remote
       // one, this represents an object that corresponds to a resolved
       // conflict. Our local version represents the final output, so
-      // we keep that one. (no transaction operation to do).
+      // we keep that one. (No transaction operation to do.)
       // But if our last_modifieds is undefined,
       // that means we've created the same object locally as one on
       // the server, which *must* be a conflict.
-      const updated = markStatus(local, "updated");
-      return {type: "resolved", data: updated, previous: local};
+      return {type: "void"};
     }
     return {
       type: "conflicts",

--- a/src/collection.js
+++ b/src/collection.js
@@ -146,11 +146,13 @@ function importChange(transaction, remote) {
       transaction.update(synced);
       return {type: "updated", data: synced, previous: local};
     }
-    if (local.last_modified === remote.last_modified) {
+    if (local.last_modified !== undefined && local.last_modified === remote.last_modified) {
       // If our local version has the same last_modified as the remote
       // one, this represents an object that corresponds to a resolved
       // conflict. Our local version represents the final output, so
-      // we keep that one.
+      // we keep that one. But if our last_modifieds is undefined,
+      // that means we've created the same object locally as one on
+      // the server, which *must* be a conflict.
       return {type: "updated", data: markSynced(local), previous: local};
     }
     return {

--- a/src/collection.js
+++ b/src/collection.js
@@ -146,6 +146,13 @@ function importChange(transaction, remote) {
       transaction.update(synced);
       return {type: "updated", data: synced, previous: local};
     }
+    if (local.last_modified === remote.last_modified) {
+      // If our local version has the same last_modified as the remote
+      // one, this represents an object that corresponds to a resolved
+      // conflict. Our local version represents the final output, so
+      // we keep that one.
+      return {type: "updated", data: markSynced(local), previous: local};
+    }
     return {
       type: "conflicts",
       data: {type: "incoming", local: local, remote: remote}

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -621,8 +621,9 @@ describe("Collection", () => {
         local: local,
         remote: remote,
       };
-      const syncResult = new SyncResultObject();
-      const resolution = Object.assign({}, local, {title: "resolved"});
+      const resolution = Object.assign({}, local, {
+        title: "resolved"
+      });
       sandbox.stub(KintoClientCollection.prototype, "listRecords").returns(
         Promise.resolve({
           data: [
@@ -631,6 +632,7 @@ describe("Collection", () => {
           next: () => {},
           last_modified: "\"42\"",
         }));
+      const syncResult = new SyncResultObject();
       return articles.resolve(conflict, resolution)
         .then(() => articles.pullChanges(syncResult))
         .should.eventually.become({
@@ -639,16 +641,16 @@ describe("Collection", () => {
           errors:    [],
           created:   [],
           published: [],
-          updated:   [{
+          resolved:   [{
             id: local.id,
             last_modified: 42,
             title: "resolved",
-            _status: "synced",
+            _status: "updated",
           }],
           skipped:   [],
           deleted:   [],
           conflicts: [],
-          resolved:  [],
+          updated: []
         });
     });
   });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -610,44 +610,6 @@ describe("Collection", () => {
           last_modified: remote.last_modified
         });
     });
-
-    it("should ignore resolved conflicts during sync", () => {
-      const remote = Object.assign({}, local, {
-        title: "blah",
-        last_modified: 42,
-      });
-      const conflict = {
-        type: "incoming",
-        local: local,
-        remote: remote,
-      };
-      const resolution = Object.assign({}, local, {
-        title: "resolved"
-      });
-      sandbox.stub(KintoClientCollection.prototype, "listRecords").returns(
-        Promise.resolve({
-          data: [
-            remote,
-          ],
-          next: () => {},
-          last_modified: "\"42\"",
-        }));
-      const syncResult = new SyncResultObject();
-      return articles.resolve(conflict, resolution)
-        .then(() => articles.pullChanges(syncResult))
-        .should.eventually.become({
-          ok: true,
-          lastModified: 42,
-          errors:    [],
-          created:   [],
-          published: [],
-          resolved:  [],
-          skipped:   [],
-          deleted:   [],
-          conflicts: [],
-          updated: []
-        });
-    });
   });
 
   /** @test {Collection#get} */
@@ -1327,11 +1289,14 @@ describe("Collection", () => {
     });
 
     describe("When a conflict occured", () => {
-      let createdId;
+      let createdId, local;
 
       beforeEach(() => {
         return articles.create({title: "art2"})
-          .then(res => createdId = res.data.id);
+          .then(res => {
+            local = res.data;
+            createdId = local.id;
+          });
       });
 
       it("should resolve listing conflicting changes with MANUAL strategy", () => {
@@ -1368,6 +1333,44 @@ describe("Collection", () => {
               }
             }],
             resolved:  [],
+          });
+      });
+
+      it("should ignore resolved conflicts during sync", () => {
+        const remote = Object.assign({}, local, {
+          title: "blah",
+          last_modified: 42,
+        });
+        const conflict = {
+          type: "incoming",
+          local: local,
+          remote: remote,
+        };
+        const resolution = Object.assign({}, local, {
+          title: "resolved"
+        });
+        sandbox.stub(KintoClientCollection.prototype, "listRecords").returns(
+          Promise.resolve({
+            data: [
+              remote,
+            ],
+            next: () => {},
+            last_modified: "\"42\"",
+          }));
+        const syncResult = new SyncResultObject();
+        return articles.resolve(conflict, resolution)
+          .then(() => articles.pullChanges(syncResult))
+          .should.eventually.become({
+            ok: true,
+            lastModified: 42,
+            errors:    [],
+            created:   [],
+            published: [],
+            resolved:  [],
+            skipped:   [],
+            deleted:   [],
+            conflicts: [],
+            updated: []
           });
       });
     });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -641,12 +641,7 @@ describe("Collection", () => {
           errors:    [],
           created:   [],
           published: [],
-          resolved:   [{
-            id: local.id,
-            last_modified: 42,
-            title: "resolved",
-            _status: "updated",
-          }],
+          resolved:  [],
           skipped:   [],
           deleted:   [],
           conflicts: [],

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -641,6 +641,7 @@ describe("Collection", () => {
           published: [],
           updated:   [{
             id: local.id,
+            last_modified: 42,
             title: "resolved",
             _status: "synced",
           }],

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -649,7 +649,7 @@ describe("Integration tests", function() {
           });
         });
 
-        describe.only("Resolving conflicts doesn't interfere with sync", () => {
+        describe("Resolving conflicts doesn't interfere with sync", () => {
           const conflictingId = uuid4();
           const testData = {
             localSynced: [

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -664,8 +664,8 @@ describe("Integration tests", function() {
           it("should sync over resolved records", () => {
             return tasks.update({id: conflictingId, title: "locally changed title"},
                                 {patch: true})
-              .then(newRecord => {
-                expect(newRecord.data.last_modified).to.exist;
+              .then(({data: newRecord}) => {
+                expect(newRecord.last_modified).to.exist;
                 return tasks.api.bucket("default").collection("tasks").updateRecord(
                   {id: conflictingId, title: "remotely changed title"}, {patch: true});
               })
@@ -685,9 +685,9 @@ describe("Integration tests", function() {
                 expect(syncResult.published).to.have.length.of(1);
               })
               .then(() => tasks.get(conflictingId))
-              .then(record => {
-                expect(record.data.title).eql("locally changed title");
-                expect(record.data._status).eql("synced");
+              .then(({data: record}) => {
+                expect(record.title).eql("locally changed title");
+                expect(record._status).eql("synced");
               });
           });
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -670,6 +670,7 @@ describe("Integration tests", function() {
                                 {patch: true})
               .then(({data: newRecord}) => {
                 expect(newRecord.last_modified).to.exist;
+                // Change the record remotely to introduce a comment
                 return rawCollection.updateRecord({id: conflictingId, title: "remotely changed title"},
                                                   {patch: true});
               })

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -681,6 +681,7 @@ describe("Integration tests", function() {
                 expect(syncResult.ok).eql(true);
                 expect(syncResult.conflicts).to.have.length.of(0);
                 expect(syncResult.updated).to.have.length.of(0);
+                expect(syncResult.published).to.have.length.of(1);
               })
               .then(() => tasks.get(conflictingId))
               .then(record => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -673,7 +673,8 @@ describe("Integration tests", function() {
               .then(syncResult => {
                 expect(syncResult.ok).eql(false);
                 expect(syncResult.conflicts).to.have.length.of(1);
-                // always pick our version, which has an older last_modified
+                // Always pick our version.
+                // #resolve will copy the remote last_modified.
                 return tasks.resolve(syncResult.conflicts[0], syncResult.conflicts[0].local);
               })
               .then(() => tasks.sync())

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -658,10 +658,12 @@ describe("Integration tests", function() {
             localUnsynced: [],
             server: [],
           };
+
           beforeEach(() => testSync(testData));
+
           it("should sync over resolved records", () => {
             return tasks.update({id: conflictingId, title: "locally changed title"},
-                         {patch: true})
+                                {patch: true})
               .then(newRecord => {
                 expect(newRecord.data.last_modified).to.exist;
                 return tasks.api.bucket("default").collection("tasks").updateRecord(
@@ -693,13 +695,10 @@ describe("Integration tests", function() {
             return tasks.create({id: conflictingId2, title: "second title"},
                                 {useRecordId: true})
               .then(() => tasks.sync())
-              .then(() =>
-                rawCollection.updateRecord(
-                  {id: conflictingId, title: "remotely changed title"}, {patch: true})
-                   )
-              .then(() =>
-                rawCollection.updateRecord(
-                  {id: conflictingId2, title: "remotely changed title2"}, {patch: true}))
+              .then(() => rawCollection.updateRecord({id: conflictingId, title: "remotely changed title"},
+                                                     {patch: true}))
+              .then(() => rawCollection.updateRecord({id: conflictingId2, title: "remotely changed title2"},
+                                                     {patch: true}))
               .then(() => tasks.update({id: conflictingId, title: "locally changed title"},
                                        {patch: true}))
               .then(() => tasks.update({id: conflictingId2, title: "local title2"},


### PR DESCRIPTION
Try to address #414 by not considering it a conflict if we pull a change that has the same `last_modified` as the remote version. This represents a conflict that we've already resolved, so it's no longer a conflict, even if its data is different. Tests included.