### PR TITLE
Richer methods

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -518,7 +518,7 @@ export default class Collection {
         const updated = markStatus(source, newStatus);
         return this.db.execute((transaction) => {
           transaction.update(updated);
-          return {data: updated, permissions: {}};
+          return {data: updated, old: existing, permissions: {}};
         });
       });
   }

--- a/src/collection.js
+++ b/src/collection.js
@@ -571,9 +571,9 @@ export default class Collection {
                          includeMissing: options.unconditional})
       .then(res => {
         const existing = res.data;
-        const ret = {data: {id: id}, permissions: {}};
         if (!existing) {
-          return Promise.resolve(ret);
+          return Promise.resolve({data: {id: id}, deleted: false,
+                                  permissions: {}});
         }
         return this.db.execute((transaction) => {
           // Virtual updates status.
@@ -583,7 +583,7 @@ export default class Collection {
             // Delete for real.
             transaction.delete(id);
           }
-          return ret;
+          return {data: {id: id}, deleted: true, permissions: {}};
         });
       });
   }

--- a/src/collection.js
+++ b/src/collection.js
@@ -521,17 +521,22 @@ export default class Collection {
   /**
    * Retrieve a record by its id from the local database.
    *
+   * Options:
+   * - {Boolean} includeDeleted: Include virtually deleted records.
+   * - {Boolean} includeMissing: Raise an exception if the record
+   *     doesn't exist (or is deleted). (default: true)
+   *
    * @param  {String} id
    * @param  {Object} options
    * @return {Promise}
    */
-  get(id, options={includeDeleted: false}) {
+  get(id, options={includeDeleted: false, includeMissing: false}) {
     if (!this.idSchema.validate(id)) {
       return Promise.reject(Error(`Invalid Id: ${id}`));
     }
     return this.db.get(id).then(record => {
-      if (!record ||
-         (!options.includeDeleted && record._status === "deleted")) {
+      if (!options.includeMissing && (!record ||
+         (!options.includeDeleted && record._status === "deleted"))) {
         throw new Error(`Record with id=${id} not found.`);
       } else {
         return {data: record, permissions: {}};

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -706,6 +706,12 @@ describe("Collection", () => {
           url: "http://foo",
         });
     });
+
+    it("should resolve if includeMissing is true", () => {
+      return articles.get(uuid4(), {includeMissing: true})
+        .then(res => res.data)
+        .should.eventually.become(undefined);
+    });
   });
 
   /** @test {Collection#delete} */

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -788,6 +788,13 @@ describe("Collection", () => {
           .then(res => res.data)
           .should.eventually.be.rejectedWith(Error, /not found/);
       });
+
+      it("should resolve on non-existant record when unconditional is true", () => {
+        let id = uuid4();
+        return articles.delete(id, {virtual: true, unconditional: true})
+          .then(res => res.data.id)
+          .should.eventually.eql(id);
+      });
     });
 
     describe("Factual", () => {
@@ -807,6 +814,13 @@ describe("Collection", () => {
         return articles.delete(uuid4(), {virtual: false})
           .then(res => res.data)
           .should.eventually.be.rejectedWith(Error, /not found/);
+      });
+
+      it("should resolve on non-existant record when unconditional is true", () => {
+        let id = uuid4();
+        return articles.delete(id, {virtual: false, unconditional: true})
+          .then(res => res.data.id)
+          .should.eventually.eql(id);
       });
     });
   });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -483,6 +483,19 @@ describe("Collection", () => {
         .should.become("new title");
     });
 
+    it("should return the old data for the record", () => {
+      return articles.create(article)
+        .then(res => articles.get(res.data.id))
+        .then(res => res.data)
+        .then(existing => {
+          return articles.update(
+            Object.assign({}, existing, {title: "new title"}));
+        })
+        .then(res => res.old.title)
+        .should.become("foo");
+
+    });
+
     it("should update record status on update", () => {
       return articles.create(article)
         .then(res => res.data)

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -789,6 +789,12 @@ describe("Collection", () => {
           .should.eventually.eql("deleted");
       });
 
+      it("should indicate that it deleted something", () => {
+        return articles.delete(id, {virtual: true})
+          .then(res => res.deleted)
+          .should.eventually.eql(true);
+      });
+
       it("should resolve with an already deleted record data", () => {
         return articles.delete(id, {virtual: true})
           .then(res => articles.delete(id, {virtual: true}))
@@ -808,6 +814,13 @@ describe("Collection", () => {
           .then(res => res.data.id)
           .should.eventually.eql(id);
       });
+
+      it("should indicate that it didn't delete when unconditional is true", () => {
+        let id = uuid4();
+        return articles.delete(id, {virtual: true, unconditional: true})
+          .then(res => res.deleted)
+          .should.eventually.eql(false);
+      });
     });
 
     describe("Factual", () => {
@@ -823,6 +836,12 @@ describe("Collection", () => {
           .should.eventually.eql({id: id});
       });
 
+      it("should indicate that it deleted something", () => {
+        return articles.delete(id, {virtual: false})
+          .then(res => res.deleted)
+          .should.eventually.eql(true);
+      });
+
       it("should reject on non-existent record", () => {
         return articles.delete(uuid4(), {virtual: false})
           .then(res => res.data)
@@ -834,6 +853,13 @@ describe("Collection", () => {
         return articles.delete(id, {virtual: false, unconditional: true})
           .then(res => res.data.id)
           .should.eventually.eql(id);
+      });
+
+      it("should indicate that it didn't delete when unconditional is true", () => {
+        let id = uuid4();
+        return articles.delete(id, {virtual: false, unconditional: true})
+          .then(res => res.deleted)
+          .should.eventually.eql(false);
       });
     });
   });


### PR DESCRIPTION
This is an attempt to address #443, #444, and #445 by adding parameters to the `#update`, `#get`, and `#delete` operations that don't fail according to the absence of the records. This makes it easier to write key/value sorts of operations using kinto.js don't have race conditions (although #446 still seems like a problem).