### PR TITLE
Richer methods 2

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -531,7 +531,7 @@ export default class Collection {
 
     return this.db.execute((transaction) => {
       transaction.update(updated);
-      return {data: updated, permissions: {}};
+      return {data: updated, oldRecord: oldRecord, permissions: {}};
     });
   }
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -651,11 +651,12 @@ export default class Collection {
       .then(res => {
         const existing = res.data;
         if (!existing) {
-          return Promise.resolve({data: {id: id}, permissions: {}});
+          return Promise.resolve({data: {id: id}, deleted: false,
+                                  permissions: {}});
         }
         return this.db.execute((transaction) => {
           transaction.update(markDeleted(existing));
-          return {data: {id: id}, permissions: {}};
+          return {data: {id: id}, deleted: true, permissions: {}};
         });
       });
   }

--- a/src/collection.js
+++ b/src/collection.js
@@ -510,24 +510,24 @@ export default class Collection {
    * Lower-level primitive for updating a record while respecting
    * _status and last_modified.
    *
-   * @param  {Object} existing: the record retrieved from the DB
-   * @param  {Object} source: the record to replace it with
+   * @param  {Object} oldRecord: the record retrieved from the DB
+   * @param  {Object} newRecord: the record to replace it with
    * @return {Promise}
    */
-  _updateRaw(existing, source, {synced = false} = {}) {
+  _updateRaw(oldRecord, newRecord, {synced = false} = {}) {
     let updated;
     // Make sure to never loose the existing timestamp.
-    if (existing && existing.last_modified && !source.last_modified) {
-      source.last_modified = existing.last_modified;
+    if (oldRecord && oldRecord.last_modified && !newRecord.last_modified) {
+      newRecord.last_modified = oldRecord.last_modified;
     }
     // If only local fields have changed, then keep record as synced.
-    const isIdentical = existing && recordsEqual(existing, source, this.localFields);
-    const keepSynced = isIdentical && existing._status == "synced";
+    const isIdentical = oldRecord && recordsEqual(oldRecord, newRecord, this.localFields);
+    const keepSynced = isIdentical && oldRecord._status == "synced";
     let newStatus = (keepSynced || synced) ? "synced" : "updated";
-    if (!existing) {
+    if (!oldRecord) {
       newStatus = "created";
     }
-    updated = markStatus(source, newStatus);
+    updated = markStatus(newRecord, newStatus);
 
     return this.db.execute((transaction) => {
       transaction.update(updated);

--- a/src/collection.js
+++ b/src/collection.js
@@ -521,6 +521,9 @@ export default class Collection {
   /**
    * Retrieve a record by its id from the local database.
    *
+   * Options:
+   * - {Boolean} includeDeleted: Include virtually deleted records.
+   *
    * @param  {String} id
    * @param  {Object} options
    * @return {Promise}
@@ -529,13 +532,31 @@ export default class Collection {
     if (!this.idSchema.validate(id)) {
       return Promise.reject(Error(`Invalid Id: ${id}`));
     }
-    return this.db.get(id).then(record => {
-      if (!record ||
-         (!options.includeDeleted && record._status === "deleted")) {
+    return this.getRaw(id).then(res => {
+      if (!res.data ||
+         (!options.includeDeleted && res.data._status === "deleted")) {
         throw new Error(`Record with id=${id} not found.`);
       } else {
-        return {data: record, permissions: {}};
+        return res;
       }
+    });
+  }
+
+  /**
+   * Retrieve a record by its id from the local database, or
+   * undefined if none exists.
+   *
+   * This will also return virtually deleted records.
+   *
+   * @param  {String} id
+   * @return {Promise}
+   */
+  getRaw(id) {
+    if (!this.idSchema.validate(id)) {
+      return Promise.reject(Error(`Invalid Id: ${id}`));
+    }
+    return this.db.get(id).then(record => {
+      return {data: record, permissions: {}};
     });
   }
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -637,6 +637,30 @@ export default class Collection {
   }
 
   /**
+   * Deletes a record from the local database, if any exists.
+   * Otherwise, do nothing.
+   *
+   * @param  {String} id       The record's Id.
+   * @return {Promise}
+   */
+  deleteAny(id) {
+    if (!this.idSchema.validate(id)) {
+      return Promise.reject(new Error(`Invalid Id: ${id}`));
+    }
+    return this.getRaw(id)
+      .then(res => {
+        const existing = res.data;
+        if (!existing) {
+          return Promise.resolve({data: {id: id}, permissions: {}});
+        }
+        return this.db.execute((transaction) => {
+          transaction.update(markDeleted(existing));
+          return {data: {id: id}, permissions: {}};
+        });
+      });
+  }
+
+  /**
    * Lists records from the local database.
    *
    * Params:

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -927,6 +927,31 @@ describe("Collection", () => {
     });
   });
 
+  /** @test {Collection#deleteAny} */
+  describe("#deleteAny", () => {
+    let articles, id;
+
+    beforeEach(() => {
+      articles = testCollection();
+      return articles.create(article)
+        .then(result => id = result.data.id);
+    });
+
+    it("should delete an existing record", () => {
+      return articles.deleteAny(id)
+        .then(res => articles.getRaw(res.data.id))
+        .then(res => res.data._status)
+        .should.eventually.eql("deleted");
+    });
+
+    it("should resolve on non-existant record", () => {
+      let id = uuid4();
+      return articles.deleteAny(id)
+        .then(res => res.data.id)
+        .should.eventually.eql(id);
+    });
+  });
+
   /** @test {Collection#list} */
   describe("#list", () => {
     let articles;

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -981,6 +981,19 @@ describe("Collection", () => {
         .then(res => res.data.id)
         .should.eventually.eql(id);
     });
+
+    it("should indicate that it deleted", () => {
+      return articles.deleteAny(id)
+        .then(res => res.deleted)
+        .should.eventually.eql(true);
+    });
+
+    it("should indicate that it didn't delete when record is gone", () => {
+      let id = uuid4();
+      return articles.deleteAny(id)
+        .then(res => res.deleted)
+        .should.eventually.eql(false);
+    });
   });
 
   /** @test {Collection#list} */

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -483,6 +483,19 @@ describe("Collection", () => {
         .should.become("new title");
     });
 
+    it("should return the old data for the record", () => {
+      return articles.create(article)
+        .then(res => articles.get(res.data.id))
+        .then(res => res.data)
+        .then(existing => {
+          return articles.update(
+            Object.assign({}, existing, {title: "new title"}));
+        })
+        .then(res => res.oldRecord.title)
+        .should.become("foo");
+
+    });
+
     it("should update record status on update", () => {
       return articles.create(article)
         .then(res => res.data)
@@ -685,6 +698,24 @@ describe("Collection", () => {
         })
         .then(res => res.data)
           .should.eventually.have.property("last_modified").eql(123456789012);
+    });
+
+    it("should return the old data for the record", () => {
+      return articles.create(article)
+        .then(res => articles.get(res.data.id))
+        .then(res => res.data)
+        .then(existing => {
+          return articles.put(
+            Object.assign({}, existing, {title: "new title"}));
+        })
+        .then(res => res.oldRecord.title)
+        .should.become("foo");
+    });
+
+    it("should signal when a record was created by oldRecord=undefined", () => {
+      return articles.put({id: uuid4()})
+        .then(res => res.oldRecord)
+        .should.become(undefined);
     });
   });
 


### PR DESCRIPTION
This is another approach to solve #443, #444, and #445. Unlike #447, which adds options to existing methods, this PR introduces new methods which do not support the old use cases at all but simply support what I need -- raw access to a key-value store without application-level access. These methods are called `getRaw()`, `put()`, and `deleteAny()`. I re-use code from the existing `get()` and `update()` methods by extracting them (`get()` now just calls `getRaw()` and then throws if it's missing; `update()` calls `_updateRaw()`). This seemed better than copying and pasting the entire methods, although I'm open to doing that if the auxiliary methods seem too complicated. I decided not to refactor `delete()`, since very little code is shared.

r? @n1k0 