### PR TITLE
Adapter#execute preload option takes IDs

### DIFF
--- a/fx-src/FirefoxStorage.js
+++ b/fx-src/FirefoxStorage.js
@@ -166,7 +166,7 @@ export default class FirefoxAdapter extends BaseAdapter {
       const parameters = {
         collection_name: collection,
         // XXX: would be easier if a list of strings could be bound instead.
-        record_ids: options.preload.map(r => r.id).join("','")
+        record_ids: options.preload.join("','")
       };
       const rows = yield conn.execute(statements.listRecordsById, parameters);
 

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -234,7 +234,7 @@ export default class IDB extends BaseAdapter {
    * promise will therefore be rejected if the callback returns a Promise.
    *
    * Options:
-   * - {Array} preload: The list of records to make available to
+   * - {Array} preload: The list of record IDs to fetch and make available to
    *   the transaction object get() method (default: [])
    *
    * @example
@@ -268,7 +268,7 @@ export default class IDB extends BaseAdapter {
         // Start transaction.
         const {transaction, store} = this.prepare("readwrite");
         // Preload specified records using index.
-        const ids = options.preload.map(r => r.id);
+        const ids = options.preload;
         store.index("id").openCursor().onsuccess = cursorHandlers.in(ids, (records) => {
           // Store obtained records by id.
           const preloaded = records.reduce((acc, record) => {

--- a/src/collection.js
+++ b/src/collection.js
@@ -506,7 +506,7 @@ export default class Collection {
       const updated = this._updateRaw(oldRecord, newRecord, options);
       transaction.update(updated);
       return {data: updated, oldRecord: oldRecord, permissions: {}};
-    }, {preload: [record]});
+    }, {preload: [record.id]});
   }
 
   /**
@@ -564,7 +564,7 @@ export default class Collection {
         oldRecord = undefined;
       }
       return {data: updated, oldRecord: oldRecord, permissions: {}};
-    }, {preload: [record]});
+    }, {preload: [record.id]});
   }
 
   /**
@@ -639,7 +639,7 @@ export default class Collection {
         transaction.delete(id);
       }
       return {data: existing, permissions: {}};
-    }, {preload: [{id}]});
+    }, {preload: [id]});
   }
 
   /**
@@ -659,7 +659,7 @@ export default class Collection {
         transaction.update(markDeleted(existing));
       }
       return {data: {id, ...existing}, deleted: !!existing, permissions: {}};
-    }, {preload: [{id}]});
+    }, {preload: [id]});
   }
 
   /**
@@ -712,7 +712,7 @@ export default class Collection {
             // Store remote change into local database.
             return importChange(transaction, remote, this.localFields);
           });
-        }, {preload: decodedChanges})
+        }, {preload: decodedChanges.map(record => record.id)})
         .catch(err => {
           const data = {
             type: "incoming",

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -209,7 +209,7 @@ describe("adapter.IDB", () => {
                 transaction.get(1),
                 transaction.get(2),
               ];
-            }, {preload: articles});
+            }, {preload: articles.map(article => article.id)});
           })
           .should.become(articles);
       });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -1802,7 +1802,7 @@ describe("Collection", () => {
         {id: id2, title: "bar"},
       ]})
         .then(() => {
-          const preload = execute.lastCall.args[1].preload.map(r => r.id);
+          const preload = execute.lastCall.args[1].preload;
           expect(preload).eql([id1, id2]);
         });
     });


### PR DESCRIPTION
... instead of records. This matches both the underlying semantics of
the operation (which is fetching these records) as well as the use case
I'm about to implement (which only has access to the IDs).

r? @leplatrem @n1k0 