### PR TITLE
Add transactions to Collection layer (fixes #467)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -373,6 +373,58 @@ Result:
 > - Clearing the local collection will mark the collection as never synchronized;
 > - Detailed API documentation for `Collection#clear()` is available [here](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-clear).
 
+## Transactions
+
+Kinto.js exposes a concept of a "local transaction", which guarantees
+that a set of local operations will happen atomically -- that is, all
+or nothing.
+
+Note that as Kinto is still a distributed database, transactions
+aren't consistent. In other words, your "transaction" can still
+conflict with other operations on some other node.
+
+To initiate a transaction, call `Collection#execute()` like this:
+
+```js
+articles.execute(txn => {
+    let article1 = txn.get(id1);
+    let article2 = txn.get(id2);
+    return [article1, article2];
+  }, {preloadIds: [id1, id2])
+  .then(console.log.bind(console));
+```
+
+The `execute` function takes two arguments. The first is a function
+that will be called with a transaction, and can perform operations on
+it. These operations are synchronous and so don't produce
+promises. The full list of operations is available
+[here](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~CollectionTransaction.html).
+
+The second argument to `execute()` should include a set of record IDs
+on which your transaction wants to operate. These IDs will be read at
+the beginning of your transaction, and the corresponding records will
+be made available to the transaction. Most operations, including even
+`put` and `delete`, will require that you provide the relevant IDs.
+
+Result:
+
+```js
+[
+    {
+      data: {
+        id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f8",
+        title: "foo",
+      }
+    },
+    {
+      data: {
+        id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f7",
+        title: "bar",
+      }
+    }
+]
+```
+
 ## Authentication
 
 Authenticating against a Kinto server can be achieved by adding an `Authorization` header to the request.

--- a/docs/api.md
+++ b/docs/api.md
@@ -379,9 +379,10 @@ Kinto.js exposes a concept of a "local transaction", which guarantees
 that a set of local operations will happen atomically -- that is, all
 or nothing.
 
-Note that as Kinto is still a distributed database, transactions
-aren't consistent. In other words, your "transaction" can still
-conflict with other operations on some other node.
+Note that these transactions are local to the browser, and they don't
+go to the server. Other Kinto clients can make changes to the server
+during your transaction, and those changes may still introduce
+conflicts with the changes you've made as part of a transaction.
 
 To initiate a transaction, call `Collection#execute()` like this:
 
@@ -404,7 +405,7 @@ The second argument to `execute()` should include a set of record IDs
 on which your transaction wants to operate. These IDs will be read at
 the beginning of your transaction, and the corresponding records will
 be made available to the transaction. Most operations, including even
-`put` and `delete`, will require that you provide the relevant IDs.
+`put()` and `delete()`, will require that you provide the relevant IDs.
 
 Result:
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -692,7 +692,7 @@ export default class Collection {
    *    when the transaction commits.
    */
   execute(doOperations, {preloadIds = []} = {}) {
-    for(let id of preloadIds) {
+    for (let id of preloadIds) {
       if (!this.idSchema.validate(id)) {
         return Promise.reject(Error(`Invalid Id: ${id}`));
       }

--- a/src/collection.js
+++ b/src/collection.js
@@ -369,7 +369,7 @@ export default class Collection {
 
     const validatedHooks = {};
 
-    for (let hook in hooks) {
+    for (const hook in hooks) {
       if (AVAILABLE_HOOKS.indexOf(hook) === -1) {
         throw new Error("The hook should be one of " + AVAILABLE_HOOKS.join(", "));
       }
@@ -723,7 +723,7 @@ export default class Collection {
           return [{type: "errors", data}];
         })
         .then(imports => {
-          for (let imported of imports) {
+          for (const imported of imports) {
             if (imported.type !== "void") {
               syncResultObject.add(imported.type, imported.data);
             }
@@ -1145,7 +1145,7 @@ export default class Collection {
       return reject("Records is not an array.");
     }
 
-    for (let record of records) {
+    for (const record of records) {
       if (!record.id || !this.idSchema.validate(record.id)) {
         return reject("Record has invalid ID: " + JSON.stringify(record));
       }

--- a/src/collection.js
+++ b/src/collection.js
@@ -369,7 +369,7 @@ export default class Collection {
 
     const validatedHooks = {};
 
-    for (const hook in hooks) {
+    for (let hook in hooks) {
       if (AVAILABLE_HOOKS.indexOf(hook) === -1) {
         throw new Error("The hook should be one of " + AVAILABLE_HOOKS.join(", "));
       }
@@ -683,7 +683,7 @@ export default class Collection {
           return [{type: "errors", data}];
         })
         .then(imports => {
-          for (const imported of imports) {
+          for (let imported of imports) {
             if (imported.type !== "void") {
               syncResultObject.add(imported.type, imported.data);
             }
@@ -729,7 +729,7 @@ export default class Collection {
    *    when the transaction commits.
    */
   execute(doOperations, {preloadIds = []} = {}) {
-    for(const id of preloadIds) {
+    for(let id of preloadIds) {
       if (!this.idSchema.validate(id)) {
         return Promise.reject(Error(`Invalid Id: ${id}`));
       }
@@ -1140,7 +1140,7 @@ export default class Collection {
       return reject("Records is not an array.");
     }
 
-    for (const record of records) {
+    for (let record of records) {
       if (!record.id || !this.idSchema.validate(record.id)) {
         return reject("Record has invalid ID: " + JSON.stringify(record));
       }

--- a/src/collection.js
+++ b/src/collection.js
@@ -713,14 +713,17 @@ export default class Collection {
    * will succeed, or none will.
    *
    * The argument to this function is itself a function which will be
-   * called with a transaction. Collection methods are available on
-   * this transaction, and they will return promises as normal. The
-   * promises for individual operations will be resolved after the
-   * transaction commits.
+   * called with a {@link CollectionTransaction}. Collection methods
+   * are available on this transaction, but instead of returning
+   * promises, they are synchronous. execute() returns a Promise whose
+   * value will be the return value of the provided function.
    *
-   * If you also want to perform read operations like {@link
-   * Collection.get}, pass a second argument which specifies the IDs
-   * of the objects you want to preload as part of the operation.
+   * Most operations will require access to the record itself, which
+   * must be preloaded by passing its ID in the preloadIds option.
+   *
+   * Options:
+   * - {Array} preloadIds: list of IDs to fetch at the beginning of
+   *   the transaction
    *
    * @return {Promise} Resolves with the result of the given function
    *    when the transaction commits.
@@ -1199,7 +1202,7 @@ export class CollectionTransaction {
    * This will also return virtually deleted records.
    *
    * @param  {String} id
-   * @return {Promise}
+   * @return {Object}
    */
   getRaw(id) {
     const record = this.adapterTransaction.get(id);
@@ -1214,7 +1217,7 @@ export class CollectionTransaction {
    *
    * @param  {String} id
    * @param  {Object} options
-   * @return {Promise}
+   * @return {Object}
    */
   get(id, options={includeDeleted: false}) {
     const res = this.getRaw(id);
@@ -1235,7 +1238,7 @@ export class CollectionTransaction {
    *
    * @param  {String} id       The record's Id.
    * @param  {Object} options  The options object.
-   * @return {Promise}
+   * @return {Object}
    */
   delete(id, options={virtual: true}) {
     // Ensure the record actually exists.
@@ -1259,7 +1262,7 @@ export class CollectionTransaction {
    * Otherwise, do nothing.
    *
    * @param  {String} id       The record's Id.
-   * @return {Promise}
+   * @return {Object}
    */
   deleteAny(id) {
     const existing = this.adapterTransaction.get(id);

--- a/src/collection.js
+++ b/src/collection.js
@@ -490,7 +490,7 @@ export default class Collection {
     if (typeof(record) !== "object") {
       return Promise.reject(new Error("Record is not an object."));
     }
-    if (!record.id) {
+    if (record.id === undefined) {
       return Promise.reject(new Error("Cannot update a record missing id."));
     }
     if (!this.idSchema.validate(record.id)) {

--- a/src/collection.js
+++ b/src/collection.js
@@ -445,11 +445,11 @@ export default class Collection {
     if (typeof(record) !== "object") {
       return reject("Record is not an object.");
     }
-    if ((options.synced || options.useRecordId) && !record.id) {
+    if ((options.synced || options.useRecordId) && !record.hasOwnProperty("id")) {
       return reject(
         "Missing required Id; synced and useRecordId options require one");
     }
-    if (!options.synced && !options.useRecordId && record.id) {
+    if (!options.synced && !options.useRecordId && record.hasOwnProperty("id")) {
       return reject("Extraneous Id; can't create a record having one set.");
     }
     const newRecord = {...record,
@@ -493,7 +493,7 @@ export default class Collection {
     if (typeof(record) !== "object") {
       return Promise.reject(new Error("Record is not an object."));
     }
-    if (record.id === undefined) {
+    if (!record.hasOwnProperty("id")) {
       return Promise.reject(new Error("Cannot update a record missing id."));
     }
     if (!this.idSchema.validate(record.id)) {
@@ -517,7 +517,7 @@ export default class Collection {
     if (typeof(record) !== "object") {
       return Promise.reject(new Error("Record is not an object."));
     }
-    if (!record.id) {
+    if (!record.hasOwnProperty("id")) {
       return Promise.reject(new Error("Cannot update a record missing id."));
     }
     if (!this.idSchema.validate(record.id)) {
@@ -1102,7 +1102,7 @@ export default class Collection {
     }
 
     for (let record of records) {
-      if (!record.id || !this.idSchema.validate(record.id)) {
+      if (!record.hasOwnProperty("id") || !this.idSchema.validate(record.id)) {
         return reject("Record has invalid ID: " + JSON.stringify(record));
       }
 
@@ -1250,7 +1250,7 @@ export class CollectionTransaction {
     if (typeof(record) !== "object") {
       throw new Error("Record is not an object.");
     }
-    if (record.id === undefined) {
+    if (!record.hasOwnProperty("id")) {
       throw new Error("Cannot update a record missing id.");
     }
     if (!this.collection.idSchema.validate(record.id)) {
@@ -1308,7 +1308,7 @@ export class CollectionTransaction {
     if (typeof(record) !== "object") {
       throw new Error("Record is not an object.");
     }
-    if (!record.id) {
+    if (!record.hasOwnProperty("id")) {
       throw new Error("Cannot update a record missing id.");
     }
     if (!this.collection.idSchema.validate(record.id)) {

--- a/src/collection.js
+++ b/src/collection.js
@@ -736,7 +736,7 @@ export default class Collection {
     }
 
     return this.db.execute((transaction) => {
-      const txn = new CollectionTransaction(transaction);
+      const txn = new CollectionTransaction(this, transaction);
       return doOperations(txn);
     }, {preload: preloadIds});
   }
@@ -1191,7 +1191,8 @@ export default class Collection {
  * perform just one operation in its own transaction.
  */
 export class CollectionTransaction {
-  constructor(adapterTransaction) {
+  constructor(collection, adapterTransaction) {
+    this.collection = collection;
     this.adapterTransaction = adapterTransaction;
   }
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -529,7 +529,7 @@ export default class Collection {
   }
 
   /**
-   * Like {@link CollectionTransaction#get}, but wrapped in its won transaction.
+   * Like {@link CollectionTransaction#get}, but wrapped in its own transaction.
    *
    * Options:
    * - {Boolean} includeDeleted: Include virtually deleted records.

--- a/src/collection.js
+++ b/src/collection.js
@@ -1188,9 +1188,9 @@ export class CollectionTransaction {
     if (!res.data ||
         (!options.includeDeleted && res.data._status === "deleted")) {
       throw new Error(`Record with id=${id} not found.`);
-    } else {
-      return res;
     }
+
+    return res;
   }
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -131,7 +131,7 @@ export function deepEqual(a, b) {
   if (Object.keys(a).length !== Object.keys(b).length) {
     return false;
   }
-  for(let k in a) {
+  for (let k in a) {
     if (!deepEqual(a[k], b[k])) {
       return false;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -131,7 +131,7 @@ export function deepEqual(a, b) {
   if (Object.keys(a).length !== Object.keys(b).length) {
     return false;
   }
-  for(const k in a) {
+  for(let k in a) {
     if (!deepEqual(a[k], b[k])) {
       return false;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -131,7 +131,7 @@ export function deepEqual(a, b) {
   if (Object.keys(a).length !== Object.keys(b).length) {
     return false;
   }
-  for(let k in a) {
+  for(const k in a) {
     if (!deepEqual(a[k], b[k])) {
       return false;
     }

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2325,6 +2325,27 @@ describe("Collection", () => {
         .then(result => expect(result.data._status).eql("deleted"));
     });
 
+    it("should support update", () => {
+      const articles = testCollection();
+      let id;
+      return articles.create(article)
+        .then(result => {
+          id = result.data.id;
+          return articles.execute(txn => txn.update({id, title: "new title"}), {preloadIds: [id]});
+        })
+        .then(result => articles.get(id))
+        .then(result => expect(result.data.title).eql("new title"));
+    });
+
+    it("should support put", () => {
+      const articles = testCollection();
+      const id = uuid4();
+      return articles.put({id, ...article})
+        .then(result => result.data.id)
+        .then(result => articles.get(id))
+        .then(result => expect(result.data.title).eql("foo"));
+    });
+
     it("should roll back operations if there's a failure", () => {
       const articles = testCollection();
       let id;

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2278,4 +2278,27 @@ describe("Collection", () => {
       });
     });
   });
+
+  /** @test {Collection#execute} */
+  describe("#execute", () => {
+    it("should support get", () => {
+      const articles = testCollection();
+      return articles.create(article)
+        .then(result => {
+          const id = result.data.id;
+          return articles.execute(txn => txn.get(id), {preloadIds: [id]});
+        })
+        .then(result => expect(result.data.title).eql("foo"));
+    });
+
+    it("should support getRaw", () => {
+      const articles = testCollection();
+      return articles.create(article)
+        .then(result => {
+          const id = result.data.id;
+          return articles.execute(txn => txn.getRaw(id), {preloadIds: [id]});
+        })
+        .then(result => expect(result.data.title).eql("foo"));
+    });
+  });
 });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2389,5 +2389,28 @@ describe("Collection", () => {
         .then(result => articles.getRaw(id2))
         .then(result => expect(result.data._status).eql("deleted"));
     });
+
+    it("should resolve to the return value of the transaction", () => {
+      const articles = testCollection();
+      return articles.create(article)
+        .then(() => {
+          return articles.execute(txn => {
+            return "hello";
+          });
+        })
+        .then(result => expect(result).eql("hello"));
+    });
+
+    it("has operations that are synchronous", () => {
+      const articles = testCollection();
+      let createdArticle;
+      return articles.create(article)
+        .then(result => {
+          return articles.execute(txn => {
+            createdArticle = txn.get(result.data.id).data;
+          }, {preloadIds: [result.data.id]});
+        })
+        .then(result => expect(createdArticle.title).eql("foo"));
+    });
   });
 });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2301,6 +2301,18 @@ describe("Collection", () => {
         .then(result => expect(result.data.title).eql("foo"));
     });
 
+    it("should support delete", () => {
+      const articles = testCollection();
+      let id;
+      return articles.create(article)
+        .then(result => {
+          id = result.data.id;
+          return articles.execute(txn => txn.delete(id), {preloadIds: [id]});
+        })
+        .then(result => articles.getRaw(id))
+        .then(result => expect(result.data._status).eql("deleted"));
+    });
+
     it("should support deleteAny", () => {
       const articles = testCollection();
       let id;

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -833,7 +833,9 @@ describe("Collection", () => {
         idSchema: createIntegerIdSchema()
       });
 
-      return articles.create(article)
+      // First, get rid of the old record with the ID from the other ID schema
+      return articles.clear()
+        .then(() => articles.create(article))
         .then(result => articles.get(result.data.id))
         .then(res => res.data.title)
         .should.eventually.eql(article.title);

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2281,8 +2281,12 @@ describe("Collection", () => {
 
   /** @test {Collection#execute} */
   describe("#execute", () => {
+    let articles;
+    beforeEach(() => {
+      articles = testCollection();
+    });
+
     it("should support get", () => {
-      const articles = testCollection();
       return articles.create(article)
         .then(result => {
           const id = result.data.id;
@@ -2292,7 +2296,6 @@ describe("Collection", () => {
     });
 
     it("should support getRaw", () => {
-      const articles = testCollection();
       return articles.create(article)
         .then(result => {
           const id = result.data.id;
@@ -2302,7 +2305,6 @@ describe("Collection", () => {
     });
 
     it("should support delete", () => {
-      const articles = testCollection();
       let id;
       return articles.create(article)
         .then(result => {
@@ -2314,7 +2316,6 @@ describe("Collection", () => {
     });
 
     it("should support deleteAny", () => {
-      const articles = testCollection();
       let id;
       return articles.create(article)
         .then(result => {
@@ -2326,14 +2327,12 @@ describe("Collection", () => {
     });
 
     it("should support create", () => {
-      const articles = testCollection();
       const id = uuid4();
       return articles.execute(txn => txn.create({id, ...article}), {preloadIds: [id]})
         .then(result => expect(result.data.title).eql("foo"));
     });
 
     it("should support update", () => {
-      const articles = testCollection();
       let id;
       return articles.create(article)
         .then(result => {
@@ -2345,7 +2344,6 @@ describe("Collection", () => {
     });
 
     it("should support put", () => {
-      const articles = testCollection();
       const id = uuid4();
       return articles.put({id, ...article})
         .then(result => result.data.id)
@@ -2354,7 +2352,6 @@ describe("Collection", () => {
     });
 
     it("should roll back operations if there's a failure", () => {
-      const articles = testCollection();
       let id;
       return articles.create(article)
         .then(result => {
@@ -2370,7 +2367,6 @@ describe("Collection", () => {
     });
 
     it("should perform all operations if there's no failure", () => {
-      const articles = testCollection();
       let id1, id2;
       return articles.create(article)
         .then(result => {
@@ -2391,7 +2387,6 @@ describe("Collection", () => {
     });
 
     it("should resolve to the return value of the transaction", () => {
-      const articles = testCollection();
       return articles.create(article)
         .then(() => {
           return articles.execute(txn => {
@@ -2402,7 +2397,6 @@ describe("Collection", () => {
     });
 
     it("has operations that are synchronous", () => {
-      const articles = testCollection();
       let createdArticle;
       return articles.create(article)
         .then(result => {

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -518,6 +518,17 @@ describe("Collection", () => {
         .should.be.rejectedWith(Error, /Invalid Id/);
     });
 
+    it("should update a record from its id (custom IdSchema)", () => {
+      articles = testCollection({
+        idSchema: createIntegerIdSchema()
+      });
+
+      return articles.create(article)
+        .then(result => articles.update({id: result.data.id, title: "foo"}))
+        .then(res => res.data.title)
+        .should.eventually.eql("foo");
+    });
+
     it("should patch existing record when patch option is used", () => {
       const id = uuid4();
       return articles.create({id, title: "foo", last_modified: 42},

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2325,6 +2325,13 @@ describe("Collection", () => {
         .then(result => expect(result.data._status).eql("deleted"));
     });
 
+    it("should support create", () => {
+      const articles = testCollection();
+      const id = uuid4();
+      return articles.execute(txn => txn.create({id, ...article}), {preloadIds: [id]})
+        .then(result => expect(result.data.title).eql("foo"));
+    });
+
     it("should support update", () => {
       const articles = testCollection();
       let id;

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2300,5 +2300,17 @@ describe("Collection", () => {
         })
         .then(result => expect(result.data.title).eql("foo"));
     });
+
+    it("should support deleteAny", () => {
+      const articles = testCollection();
+      let id;
+      return articles.create(article)
+        .then(result => {
+          id = result.data.id;
+          return articles.execute(txn => txn.deleteAny(id), {preloadIds: [id]});
+        })
+        .then(result => articles.getRaw(id))
+        .then(result => expect(result.data._status).eql("deleted"));
+    });
   });
 });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -1017,7 +1017,7 @@ describe("Collection", () => {
     });
 
     it("should resolve on non-existant record", () => {
-      let id = uuid4();
+      const id = uuid4();
       return articles.deleteAny(id)
         .then(res => res.data.id)
         .should.eventually.eql(id);
@@ -1030,7 +1030,7 @@ describe("Collection", () => {
     });
 
     it("should indicate that it didn't delete when record is gone", () => {
-      let id = uuid4();
+      const id = uuid4();
       return articles.deleteAny(id)
         .then(res => res.deleted)
         .should.eventually.eql(false);

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2292,7 +2292,8 @@ describe("Collection", () => {
           const id = result.data.id;
           return articles.execute(txn => txn.get(id), {preloadIds: [id]});
         })
-        .then(result => expect(result.data.title).eql("foo"));
+        .then(result => expect(result.data.title)
+              .eql("foo"));
     });
 
     it("should support getRaw", () => {
@@ -2301,7 +2302,8 @@ describe("Collection", () => {
           const id = result.data.id;
           return articles.execute(txn => txn.getRaw(id), {preloadIds: [id]});
         })
-        .then(result => expect(result.data.title).eql("foo"));
+        .then(result => expect(result.data.title)
+              .eql("foo"));
     });
 
     it("should support delete", () => {
@@ -2312,7 +2314,8 @@ describe("Collection", () => {
           return articles.execute(txn => txn.delete(id), {preloadIds: [id]});
         })
         .then(result => articles.getRaw(id))
-        .then(result => expect(result.data._status).eql("deleted"));
+        .then(result => expect(result.data._status)
+              .eql("deleted"));
     });
 
     it("should support deleteAny", () => {
@@ -2323,13 +2326,15 @@ describe("Collection", () => {
           return articles.execute(txn => txn.deleteAny(id), {preloadIds: [id]});
         })
         .then(result => articles.getRaw(id))
-        .then(result => expect(result.data._status).eql("deleted"));
+        .then(result => expect(result.data._status)
+              .eql("deleted"));
     });
 
     it("should support create", () => {
       const id = uuid4();
       return articles.execute(txn => txn.create({id, ...article}), {preloadIds: [id]})
-        .then(result => expect(result.data.title).eql("foo"));
+        .then(result => expect(result.data.title)
+              .eql("foo"));
     });
 
     it("should support update", () => {
@@ -2340,7 +2345,8 @@ describe("Collection", () => {
           return articles.execute(txn => txn.update({id, title: "new title"}), {preloadIds: [id]});
         })
         .then(result => articles.get(id))
-        .then(result => expect(result.data.title).eql("new title"));
+        .then(result => expect(result.data.title)
+              .eql("new title"));
     });
 
     it("should support put", () => {
@@ -2348,7 +2354,8 @@ describe("Collection", () => {
       return articles.put({id, ...article})
         .then(result => result.data.id)
         .then(result => articles.get(id))
-        .then(result => expect(result.data.title).eql("foo"));
+        .then(result => expect(result.data.title)
+              .eql("foo"));
     });
 
     it("should roll back operations if there's a failure", () => {
@@ -2363,7 +2370,8 @@ describe("Collection", () => {
         })
         .catch(() => null)
         .then(result => articles.getRaw(id))
-        .then(result => expect(result.data._status).eql("created"));
+        .then(result => expect(result.data._status)
+              .eql("created"));
     });
 
     it("should perform all operations if there's no failure", () => {
@@ -2381,9 +2389,11 @@ describe("Collection", () => {
           }, {preloadIds: [id1, id2]});
         })
         .then(result => articles.getRaw(id1))
-        .then(result => expect(result.data._status).eql("deleted"))
+        .then(result => expect(result.data._status)
+              .eql("deleted"))
         .then(result => articles.getRaw(id2))
-        .then(result => expect(result.data._status).eql("deleted"));
+        .then(result => expect(result.data._status)
+              .eql("deleted"));
     });
 
     it("should resolve to the return value of the transaction", () => {
@@ -2393,7 +2403,8 @@ describe("Collection", () => {
             return "hello";
           });
         })
-        .then(result => expect(result).eql("hello"));
+        .then(result => expect(result)
+              .eql("hello"));
     });
 
     it("has operations that are synchronous", () => {
@@ -2404,7 +2415,8 @@ describe("Collection", () => {
             createdArticle = txn.get(result.data.id).data;
           }, {preloadIds: [result.data.id]});
         })
-        .then(result => expect(createdArticle.title).eql("foo"));
+        .then(result => expect(createdArticle.title)
+              .eql("foo"));
     });
   });
 });


### PR DESCRIPTION
This is a proof-of-concept of transaction support at the Collection layer (#467). I would like to solicit feedback.

The approach in this branch is to wrap the underlying DB/adapter transaction using a CollectionTransaction and slowly move Collection methods into the CollectionTransaction class. Rather than delete the existing methods, we leave them as "atomic" operations that wrap them in an immediate `execute`.

So far I have moved `get`, `getRaw`, `delete`, and `deleteAny`. There remain `put`, `update`, `create`, and maybe some others.

This approach makes each of the CollectionTransaction functions synchronous, which means that their output can be returned by the user's function however it wants. So example use might be:

```javascript
collection.execute(txn => {
    return [
        txn.deleteAny("id1"),
        txn.deleteAny("id2")
    ];
}).then(res => {
    assertEqual(res[0], {deleted: true, data: {myKey: "a value"}});
    assertEqual(res[1], {deleted: false, data: undefined});
});
```

I wasn't really sure what to do with the tests. I left the tests on Collection for now and merely added some happy-path stuff to the `execute` method. Maybe I should move the tests to a new `CollectionTransaction` block, and add tests to the `Collection` class that verify that it calls `execute`? That seemed like overkill to me.

I wasn't really sure what to call `CollectionTransaction` or where to put it. For now it's in collection.js. I'm open to alternatives.

r? @leplatrem @n1k0
