### PR TITLE
build listRecordsById query dynamically

### DIFF
--- a/fx-src/FirefoxStorage.js
+++ b/fx-src/FirefoxStorage.js
@@ -75,11 +75,13 @@ const statements = {
       FROM collection_data
         WHERE collection_name = :collection_name;`,
 
+  // N.B. we have to have a dynamic number of placeholders, which you
+  // can't do without building your own statement. See `execute` for details
   "listRecordsById": `
     SELECT record_id, record
       FROM collection_data
-        WHERE collection_name = :collection_name
-          AND record_id IN (:record_ids);`,
+        WHERE collection_name = ?
+          AND record_id IN `,
 
   "importData": `
     REPLACE INTO collection_data (collection_name, record_id, record)
@@ -163,12 +165,17 @@ export default class FirefoxAdapter extends BaseAdapter {
 
     return conn.executeTransaction(function* doExecuteTransaction() {
       // Preload specified records from DB, within transaction.
-      const parameters = {
-        collection_name: collection,
-        // XXX: would be easier if a list of strings could be bound instead.
-        record_ids: options.preload.join("','")
-      };
-      const rows = yield conn.execute(statements.listRecordsById, parameters);
+      const parameters = [
+        collection,
+        ...options.preload
+      ];
+      const placeholders = [];
+      for (let i in options.preload) {
+        placeholders.push('?');
+      }
+      const stmt = statements.listRecordsById + "(" + placeholders.join(",") + ");";
+      const rows = yield conn.execute(stmt,
+                                      parameters);
 
       const preloaded = rows.reduce((acc, row) => {
         const record = JSON.parse(row.getResultByName("record"));


### PR DESCRIPTION
The old code ended up generating queries like:

SELECT record_id, record
  FROM collection_data
    WHERE collection_name = 'foo'
      AND record_id IN ('1\',\'2\',\'3');

... which is completely wrong. Instead of generating a list of values,
it just assumed the quotes and commas were part of one large value.

According to http://stackoverflow.com/a/4789034, "There is no way to
directly bind a text parameter to multiple integer (or, for that matter,
multiple text) parameters." Instead we commit this atrocity.

r? @leplatrem 