### PR TITLE
restore idSchema in fx-src

### DIFF
--- a/fx-src/index.js
+++ b/fx-src/index.js
@@ -66,7 +66,7 @@ export default function loadKinto() {
 
     collection(collName, options={}) {
       const idSchema = makeIDSchema();
-      const expandedOptions = {...idSchema, ...options};
+      const expandedOptions = {idSchema, ...options};
       return super.collection(collName, expandedOptions);
     }
   }


### PR DESCRIPTION
The intended shape of the expanded options is:

```
{
  idSchema: {
    generate: ....
    validate: ....
  },
  ... other options
}
```

I don't see an easy way to test this because it calls its superclass,
which isn't easy to stub or mock.

This is one of two changes that need to be made to get FF tests to pass (the other is in the FF test itself).

r? @leplatrem @n1k0 @Natim @lavish205 