### PR TITLE
Prepare 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinto",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "An Offline-First JavaScript client for Kinto.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This release fixes a bug with the `incoming-changes` hook which prevents hooks from returning Promises (#495, #496).

r? @leplatrem 
