### PR TITLE
Transform even deleted records

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -860,7 +860,8 @@ coll = kinto.collection("articles", {
 >
 > - The `decode` method should be the strict reverse version of `encode`;
 > - Your transformer will be called even on deleted records, so be sure to handle those correctly in both encoding and decoding;
-> - Be careful when altering `record.id`, since this can interfere with syncing;
+> - Most transformers should pass `id` and `last_modified` through unaltered, since they are used in syncing;
+> - If you do alter `id` or `last_modified`, be careful, since this can interfere with syncing;
 > - While this example transformer returns the modified record synchronously, you can also use promises to make it asynchronous — see [dedicated section](#async-transformers).
 
 Calling `coll.sync()` here will store encoded records on the server; when pulling for changes, the client will decode remote data before importing them, so you're always guaranteed to have the local database containing data in clear:

--- a/docs/api.md
+++ b/docs/api.md
@@ -859,7 +859,8 @@ coll = kinto.collection("articles", {
 > #### Notes
 >
 > - The `decode` method should be the strict reverse version of `encode`;
-> - `record.id` should *always* be left unchanged by a transformer;
+> - Your transformer will be called even on deleted records, so be sure to handle those correctly in both encoding and decoding;
+> - Be careful when altering `record.id`, since this can interfere with syncing;
 > - While this example transformer returns the modified record synchronously, you can also use promises to make it asynchronous — see [dedicated section](#async-transformers).
 
 Calling `coll.sync()` here will store encoded records on the server; when pulling for changes, the client will decode remote data before importing them, so you're always guaranteed to have the local database containing data in clear:

--- a/src/collection.js
+++ b/src/collection.js
@@ -744,7 +744,7 @@ export default class Collection {
    * - `toDelete`: unsynced deleted records we can safely delete;
    * - `toSync`: local updates to send to the server.
    *
-   * @return {Object}
+   * @return {Promise}
    */
   gatherLocalChanges() {
     return Promise.all([

--- a/src/collection.js
+++ b/src/collection.js
@@ -620,9 +620,6 @@ export default class Collection {
    */
   importChanges(syncResultObject, changeObject) {
     return Promise.all(changeObject.changes.map(change => {
-      if (change.deleted) {
-        return Promise.resolve(change);
-      }
       return this._decodeRecord("remote", change);
     }))
       .then(decodedChanges => {
@@ -750,19 +747,18 @@ export default class Collection {
    * @return {Object}
    */
   gatherLocalChanges() {
-    let _toDelete;
     return Promise.all([
       this.list({filters: {_status: ["created", "updated"]}, order: ""}),
       this.list({filters: {_status: "deleted"}, order: ""},
                 {includeDeleted: true}),
     ])
       .then(([unsynced, deleted]) => {
-        _toDelete = deleted.data;
-        // Encode unsynced records.
-        return Promise.all(
-          unsynced.data.map(this._encodeRecord.bind(this, "remote")));
+        return Promise.all([
+          Promise.all(unsynced.data.map(this._encodeRecord.bind(this, "remote"))),
+          Promise.all(deleted.data.map(this._encodeRecord.bind(this, "remote")))
+        ]);
       })
-      .then(toSync => ({toDelete: _toDelete, toSync}));
+      .then(([toSync, toDelete]) => ({toSync, toDelete}));
   }
 
   /**


### PR DESCRIPTION
The docs say that remote transformers must preserve `id`. I can't figure out why that should be the case, except that it enables a tiny optimization where we don't have to run the transformer on deleted records. This might be intentional, in case we wanted to spare client code from handling deleted records specially.

In my use case, I'd like to obfuscate record IDs on the server so that they don't leak information about what application is using Kinto locally.