### PR TITLE
Preparing 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinto",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "description": "An Offline-First JavaScript client for Kinto.",
   "main": "lib/index.js",
   "scripts": {
@@ -96,6 +96,10 @@
     {
       "name": "Mathieu Agopian",
       "url": "https://github.com/magopian"
+    },
+    {
+      "name": "Eric Le Lay",
+      "url": "https://github.com/elelay"
     }
   ],
   "license": "Apache-2.0",


### PR DESCRIPTION
This release causes remote transformers to be invoked even on deleted records, and thereby allows you to write a remote transformer that mutates record IDs (#510). It is a backwards-incompatible change because now a remote transformer must handle deleted records, which are missing all the normal fields you would expect from your records.

There are also some fixes to documentation errors (#515, #514) and updates of dependencies (#508, #512, #509, #502).