### PR TITLE
Use correct ES6 name for string function

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -42,7 +42,7 @@ function main() {
 
   function doSync() {
     return tasks.sync(syncOptions).catch(function(err) {
-      if (err.message.contains("flushed")) {
+      if (err.message.includes("flushed")) {
         console.warn("Flushed server detected, marking local data for reupload.");
         return tasks.resetSyncStatus()
           .then(function() {


### PR DESCRIPTION
The demo wasn't working for me, failing that "err.message.contains is not a function". I believe that is because the function is called `includes` (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes).