### PR TITLE
Prepare 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinto",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "An Offline-First JavaScript client for Kinto.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
I made a mistake in releasing 4.0.0 and published something wrong to NPM. This release is just a rebuild of 4.0.0, which shouldn't be used.