### PR TITLE
Fix conflict handling with published deletions.

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -889,8 +889,10 @@ export default class Collection {
 
         // The result of a batch returns data and permissions.
         // XXX: permissions are ignored currently.
-        const conflicts = synced.conflicts.map((c) => {
-          return {type: c.type, local: c.local.data, remote: c.remote};
+        const conflicts = synced.conflicts.map(({type, local, remote}) => {
+          // Note: we ensure that local data are actually available, as they may
+          // be missing in the case of a published deletion.
+          return {type, local: local && local.data || {}, remote};
         });
         // Merge outgoing conflicts into sync result object
         syncResultObject.add("conflicts", conflicts);

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -720,7 +720,7 @@ describe("Integration tests", function() {
       });
 
       describe("Outgoing conflicting deletion", () => {
-        let id, syncResult;
+        let id, conflicts;
 
         beforeEach(() => {
           return tasks.create({title: "initial"})
@@ -746,16 +746,23 @@ describe("Integration tests", function() {
               return tasks.sync();
             })
             .then((res) => {
-              syncResult = res;
+              conflicts = res.conflicts;
             });
         });
 
         it("should properly list the encountered conflict", () => {
-          const {conflicts} = syncResult;
+          expect(conflicts).to.have.length.of(1);
+        });
 
-          expect(conflicts).to.have.length.of(1),
+        it("should list the proper type of conflict", () => {
           expect(conflicts[0].type).eql("outgoing");
+        });
+
+        it("should have the expected conflicting local version", () => {
           expect(conflicts[0].local).eql({});
+        });
+
+        it("should have the expected conflicting remote version", () => {
           expect(conflicts[0].remote)
             .to.have.property("id").eql(id);
           expect(conflicts[0].remote)

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -732,15 +732,8 @@ describe("Integration tests", function() {
               return tasks.delete(id);
             })
             .then(() => {
-              return fetch(`${TEST_KINTO_SERVER}/buckets/default/collections/tasks/records/${id}`, {
-                method: "PUT",
-                headers: {
-                  "Accept":        "application/json",
-                  "Content-Type":  "application/json",
-                  "Authorization": "Basic " + btoa("user:pass"),
-                },
-                body: JSON.stringify({data: {title: "server-updated", done: true}})
-              });
+              return tasks.api.bucket("default").collection("tasks")
+                .updateRecord({id, title: "server-updated"});
             })
             .then(() => {
               return tasks.sync();


### PR DESCRIPTION
This fixes an issue brought to our attention by @ochameau (thanks!), where a conflicting remote deletion couldn't be properly handled during the publication part of the synchronization flow.

Basically kinto-http.js, when aggregating results from a batch operation, exposes the request data body as the local (initial) version of the conflict; but in the case of deletion, there is no request body sent.

This patch simply ensures there's data available in the received `local` part of the conflict object, and fallbacks to `{}` if there's none.

r=? @leplatrem @glasserc 

