### PR TITLE
Decode conflicts

### DIFF
--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -852,15 +852,8 @@ describe("Integration tests", function() {
           // Ensure that the remote record looks like something that's
           // been transformed
           return collection._encodeRecord("remote", record).then(record => {
-            return fetch(`${TEST_KINTO_SERVER}/buckets/default/collections/${collection._name}/records`, {
-              method: "POST",
-              headers: {
-                "Accept":        "application/json",
-                "Content-Type":  "application/json",
-                "Authorization": "Basic " + btoa("user:pass"),
-              },
-              body: JSON.stringify({data: record})
-            });
+            return collection.api.bucket("default").collection(collection._name)
+              .createRecord(record);
           })
             .then(_ => collection.sync())
             .then(res => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -874,7 +874,8 @@ describe("Integration tests", function() {
         }
 
         beforeEach(() => {
-          return setupConflict(tasks).then(() => setupConflict(tasksTransformed));
+          return setupConflict(tasks)
+            .then(() => setupConflict(tasksTransformed));
         });
 
         describe("MANUAL strategy (default)", () => {
@@ -1097,9 +1098,9 @@ describe("Integration tests", function() {
         describe("CLIENT_WINS strategy with transformers", () => {
           beforeEach(() => {
             return tasksTransformed.sync({strategy: Kinto.syncStrategy.CLIENT_WINS})
-            .then(res => {
-              syncResult = res;
-            });
+              .then(res => {
+                syncResult = res;
+              });
           });
 
           it("should put local database in the expected state", () => {
@@ -1224,9 +1225,9 @@ describe("Integration tests", function() {
         describe("SERVER_WINS strategy with transformers", () => {
           beforeEach(() => {
             return tasksTransformed.sync({strategy: Kinto.syncStrategy.SERVER_WINS})
-            .then(res => {
-              syncResult = res;
-            });
+              .then(res => {
+                syncResult = res;
+              });
           });
 
           it("should not publish anything", () => {


### PR DESCRIPTION
The test in the first commit fails. A similar bug exists for SERVER_WINS strategies, obviously, but I haven't written it yet. The tests in the second commit don't fail, but I had already written them and I want to make sure they don't start failing when I apply the fix.