### PR TITLE
deepEqual: Remove instanceof Object check

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -125,7 +125,7 @@ export function deepEqual(a, b) {
   if (typeof(a) !== typeof(b)) {
     return false;
   }
-  if (!(a instanceof Object) || !(b instanceof Object)) {
+  if (!(a && typeof a == "object") || !(b && typeof b == "object")) {
     return false;
   }
   if (Object.keys(a).length !== Object.keys(b).length) {


### PR DESCRIPTION
This is useful when the Object constructor might differ from object to
object. This has been true for me when hacking on Gecko -- the objects
that make it to the deepEqual function are instances of Object (from the
kinto-http-client scope), but the reference Object points to
Object (from the kinto-offline-client scope). We might also expect this
sort of thing to come up when someone uses Kinto in a WebExtension; the
scope of the WebExtension will be different from the scope of the code
running on the page. Instead of using the "instanceof Object" check, use
the "typeof" check. Unfortunately, because JavaScript, null and
undefined also have typeof "object", so try to rule out falsy things
explicitly.

r? @n1k0 