### PR TITLE
Prepare version 4.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinto",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "An Offline-First JavaScript client for Kinto.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This addresses a bug where conflicts weren't being resolved as "equal" in certain runtime environments (i.e. Gecko). See #529 for details.

r? @n1k0 