### PR TITLE
Compute SRIs from npmcdn and add version to table

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,8 +37,7 @@ integrity with the hash provided below:
     </script>
 ```
 
-| Filename                | Hash                                                                    |
-|-------------------------|-------------------------------------------------------------------------|
-| kinto.js                | sha384-MUdIR7pARxZVGjSznOFL4DwubWEYfRb//ChmClWFQs5TQpO52dOjRp5sHL7LhMRN |
-| kinto.min.js            | sha384-Ew1h0Ppxehxd4DUjvzJvlwQ1KVZhft1glXSRSvWwjP3dBcC8ghW0y32h2unWzrkM |
-| kinto.noshim.js         | sha384-52EOgtfIvmJD+ADTUIz5qmMeQH9FV3ZtXADKUsG8BQugxRQQ18PSvG3QWhQaTClc |
+| Filename                | Hash (for version 4.0.3)                                                |
+| kinto.js                | sha384-SsHILufiBmKVFtsuyZpCaZt9Ip6xypM8fje3s0x3MXLMgl/yQjT8YtNInVAsmZjc |
+| kinto.min.js            | sha384-Bn0PGfjlRgPVGwz3fwu0t4pzLIrLfIxIHtwN+Z0nguknFcGyJyyyuT9pIB9w6D5g |
+| kinto.noshim.js         | sha384-0bZdaSQcTR9AsdA/x7QDlG9QraRCrcBUfSDlZz28voMIyKRVBPJHVFVM+SZp8pEq |

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist-noshim": "browserify --ignore process -s Kinto -g uglifyify --ignore isomorphic-fetch --ignore babel-polyfill -e src/index.js -o dist/kinto.noshim.js -t [ babelify --sourceMapRelative . ]",
     "dist-prod": "browserify --ignore process -s Kinto -g uglifyify -e src/index.js -o dist/kinto.min.js -t [ babelify --sourceMapRelative . ]",
     "dist-fx": "BABEL_ENV=firefox browserify -s loadKinto --bare --ignore uuid --ignore kinto-http --ignore isomorphic-fetch -e fx-src/index.js -o temp.jsm -t [ babelify --sourceMapRelative . ] && mkdir -p dist && cp fx-src/jsm_prefix.js dist/moz-kinto-offline-client.js && echo \"\n/*\n * Version $npm_package_version - $(git rev-parse --short HEAD)\n */\n\" >> dist/moz-kinto-offline-client.js && cat temp.jsm >> dist/moz-kinto-offline-client.js && rm temp.jsm",
-    "compute-sri": "cd dist; for file in $(ls kinto*.js); do printf \"| %-23s | %-64s |\\n\" ${file} $(echo -n 'sha384-' && cat ${file} | openssl dgst -sha384 -binary | openssl enc -base64); done",
+    "compute-sri": "version=$(npm view kinto version); printf \"| Filename %-14s | Hash %-66s |\\n\" \"\" \"(for version $version)\"; cd dist; for file in kinto*.js; do printf \"| %-23s | %-71s |\\n\" ${file} $(echo -n 'sha384-' && curl --silent https://npmcdn.com/kinto@$version/dist/${file} | openssl dgst -sha384 -binary | openssl enc -base64); done",
     "publish-demo": "npm run dist-prod && cp dist/kinto.js demo/kinto.js && gh-pages -d demo",
     "publish-to-npm": "npm run dist && npm run build && npm publish",
     "report-coverage": "npm run test-cover && ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info",


### PR DESCRIPTION
Since the version of the webpacked assets is not reproducible, use curl to fetch the version of the asset from npmcdn and use that to compute the SRI. Also, add a note in the header of the table to show what version the SRIs correspond to.

r? @Natim @n1k0 @elelay 