### PR TITLE
Introduce failing test for updating lastModified

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -654,16 +654,7 @@ export default class Collection {
       })
       .then(syncResultObject => {
         syncResultObject.lastModified = changeObject.lastModified;
-        // Don't persist lastModified value if any conflict or error occured
-        if (!syncResultObject.ok) {
-          return syncResultObject;
-        }
-        // No conflict occured, persist collection's lastModified value
-        return this.db.saveLastModified(syncResultObject.lastModified)
-          .then(lastModified => {
-            this._lastModified = lastModified;
-            return syncResultObject;
-          });
+        return syncResultObject;
       });
   }
 
@@ -1093,7 +1084,20 @@ export default class Collection {
         // Avoid redownloading our own changes during the last pull.
         const pullOpts = {...options, exclude: result.published};
         return this.pullChanges(client, result, pullOpts);
+      })
+      .then(syncResultObject => {
+        // Don't persist lastModified value if any conflict or error occured
+        if (!syncResultObject.ok) {
+          return syncResultObject;
+        }
+        // No conflict occured, persist collection's lastModified value
+        return this.db.saveLastModified(syncResultObject.lastModified)
+          .then(lastModified => {
+            this._lastModified = lastModified;
+            return syncResultObject;
+          });
       });
+
     // Ensure API default remote is reverted if a custom one's been used
     return pFinally(syncPromise, () => this.api.remote = previousRemote);
   }

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -445,6 +445,7 @@ describe("Integration tests", function() {
 
           it("should have updated lastModified", () => {
             expect(syncResult.lastModified).to.equal(tasks.lastModified);
+            expect(tasks.db.getLastModified()).eventually.equal(syncResult.lastModified);
           });
 
           it("should have no incoming conflict listed", () => {
@@ -627,6 +628,7 @@ describe("Integration tests", function() {
 
           it("should have updated lastModified", () => {
             expect(syncResult.lastModified).to.equal(tasks.lastModified);
+            expect(tasks.db.getLastModified()).eventually.equal(syncResult.lastModified);
           });
 
           it("should have no incoming conflict listed", () => {
@@ -901,6 +903,7 @@ describe("Integration tests", function() {
 
           it("should have updated lastModified", () => {
             expect(syncResult.lastModified).to.equal(tasks.lastModified);
+            expect(tasks.db.getLastModified()).eventually.equal(syncResult.lastModified);
           });
 
           it("should have the outgoing conflict listed", () => {
@@ -1143,6 +1146,7 @@ describe("Integration tests", function() {
 
           it("should have updated lastModified", () => {
             expect(syncResult.lastModified).to.equal(tasks.lastModified);
+            expect(tasks.db.getLastModified()).eventually.equal(syncResult.lastModified);
           });
 
           it("should have the outgoing conflict listed", () => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -443,6 +443,10 @@ describe("Integration tests", function() {
             expect(syncResult.lastModified).to.be.a("number");
           });
 
+          it("should have updated lastModified", () => {
+            expect(syncResult.lastModified).to.equal(tasks.lastModified);
+          });
+
           it("should have no incoming conflict listed", () => {
             expect(syncResult.conflicts).to.have.length.of(0);
           });
@@ -619,6 +623,10 @@ describe("Integration tests", function() {
 
           it("should have a valid lastModified value", () => {
             expect(syncResult.lastModified).to.be.a("number");
+          });
+
+          it("should have updated lastModified", () => {
+            expect(syncResult.lastModified).to.equal(tasks.lastModified);
           });
 
           it("should have no incoming conflict listed", () => {
@@ -891,6 +899,10 @@ describe("Integration tests", function() {
             expect(syncResult.lastModified).to.be.a("number");
           });
 
+          it("should have updated lastModified", () => {
+            expect(syncResult.lastModified).to.equal(tasks.lastModified);
+          });
+
           it("should have the outgoing conflict listed", () => {
             expect(syncResult.conflicts).to.have.length.of(1);
             expect(syncResult.conflicts[0].type).eql("outgoing");
@@ -1127,6 +1139,10 @@ describe("Integration tests", function() {
 
           it("should have a valid lastModified value", () => {
             expect(syncResult.lastModified).to.be.a("number");
+          });
+
+          it("should have updated lastModified", () => {
+            expect(syncResult.lastModified).to.equal(tasks.lastModified);
           });
 
           it("should have the outgoing conflict listed", () => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -444,7 +444,7 @@ describe("Integration tests", function() {
           });
 
           it("should have updated lastModified", () => {
-            expect(syncResult.lastModified).to.equal(tasks.lastModified);
+            expect(tasks.lastModified).to.equal(syncResult.lastModified);
             expect(tasks.db.getLastModified()).eventually.equal(syncResult.lastModified);
           });
 
@@ -627,7 +627,7 @@ describe("Integration tests", function() {
           });
 
           it("should have updated lastModified", () => {
-            expect(syncResult.lastModified).to.equal(tasks.lastModified);
+            expect(tasks.lastModified).to.equal(syncResult.lastModified);
             expect(tasks.db.getLastModified()).eventually.equal(syncResult.lastModified);
           });
 
@@ -902,7 +902,7 @@ describe("Integration tests", function() {
           });
 
           it("should have updated lastModified", () => {
-            expect(syncResult.lastModified).to.equal(tasks.lastModified);
+            expect(tasks.lastModified).to.equal(syncResult.lastModified);
             expect(tasks.db.getLastModified()).eventually.equal(syncResult.lastModified);
           });
 
@@ -1145,7 +1145,7 @@ describe("Integration tests", function() {
           });
 
           it("should have updated lastModified", () => {
-            expect(syncResult.lastModified).to.equal(tasks.lastModified);
+            expect(tasks.lastModified).to.equal(syncResult.lastModified);
             expect(tasks.db.getLastModified()).eventually.equal(syncResult.lastModified);
           });
 


### PR DESCRIPTION
I wasn't sure what the correct behavior for manual conflict resolution
was, but I'm pretty sure that we should update lastModified for all of
these cases. So far, we only do so in three of them.

This is a test case illustrating the failure in #535.