### PR TITLE
534: filter documents as they are retrieved from IDB

### DIFF
--- a/fx-src/FirefoxStorage.js
+++ b/fx-src/FirefoxStorage.js
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 import BaseAdapter from "../src/adapters/base";
-import { reduceRecords } from "../src/utils";
+import { filterObjects, sortObjects } from "../src/utils";
 
 Components.utils.import("resource://gre/modules/Sqlite.jsm");
 Components.utils.import("resource://gre/modules/Task.jsm");
@@ -347,4 +347,17 @@ function transactionProxy(collection, preloaded) {
       return id in preloaded ? preloaded[id] : undefined;
     }
   };
+}
+
+/**
+ * Filter and sort list against provided filters and order.
+ *
+ * @param  {Object} filters  The filters to apply.
+ * @param  {String} order    The order to apply.
+ * @param  {Array}  list     The list to reduce.
+ * @return {Array}
+ */
+export function reduceRecords(filters, order, list) {
+  const filtered = filters ? filterObjects(filters, list) : list;
+  return order ? sortObjects(order, filtered) : filtered;
 }

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import BaseAdapter from "./base.js";
-import { filterObject, sortObjects } from "../utils";
+import { filterObject, omitKeys, sortObjects } from "../utils";
 
 const INDEXED_FIELDS = ["id", "_status", "last_modified"];
 
@@ -332,10 +332,8 @@ export default class IDB extends BaseAdapter {
     return this.open().then(() => {
       return new Promise((resolve, reject) => {
         let results = [];
-        // Prepare filters
-        const remainingFilters = {...filters};
         // If `indexField` was used already, don't filter again.
-        delete remainingFilters[indexField];
+        const remainingFilters = omitKeys(filters, indexField);
 
         const {transaction, store} = this.prepare();
         createListRequest(store, indexField, value, remainingFilters, (_results) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,21 +37,32 @@ export function sortObjects(order, list) {
 }
 
 /**
+ * Test if a single object matches all given filters.
+ *
+ * @param  {Object} filters  The filters object.
+ * @param  {Object} entry    The object to filter.
+ * @return {Function}
+ */
+export function filterObject(filters, entry) {
+  return Object.keys(filters).every(filter => {
+    const value = filters[filter];
+    if (Array.isArray(value)) {
+      return value.some(candidate => candidate === entry[filter]);
+    }
+    return entry[filter] === value;
+  });
+}
+
+/**
  * Filters records in a list matching all given filters.
  *
- * @param  {String} filters  The filters object.
+ * @param  {Object} filters  The filters object.
  * @param  {Array}  list     The collection to filter.
  * @return {Array}
  */
 export function filterObjects(filters, list) {
-  return list.filter(entry => {
-    return Object.keys(filters).every(filter => {
-      const value = filters[filter];
-      if (Array.isArray(value)) {
-        return value.some(candidate => candidate === entry[filter]);
-      }
-      return entry[filter] === value;
-    });
+  return list.filter((entry) => {
+    return filterObject(filters, entry);
   });
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,19 +67,6 @@ export function filterObjects(filters, list) {
 }
 
 /**
- * Filter and sort list against provided filters and order.
- *
- * @param  {Object} filters  The filters to apply.
- * @param  {String} order    The order to apply.
- * @param  {Array}  list     The list to reduce.
- * @return {Array}
- */
-export function reduceRecords(filters, order, list) {
-  const filtered = filters ? filterObjects(filters, list) : list;
-  return order ? sortObjects(order, filtered) : filtered;
-}
-
-/**
  * Checks if a string is an UUID.
  *
  * @param  {String} uuid The uuid to validate.

--- a/test/adapters/FirefoxStorage_test.js
+++ b/test/adapters/FirefoxStorage_test.js
@@ -22,6 +22,7 @@ global.Sqlite = {
 };
 
 const FirefoxAdapter = require("../../fx-src/FirefoxStorage").default;
+const reduceRecords = require("../../fx-src/FirefoxStorage").reduceRecords;
 
 describe("FirefoxStorage", () => {
   let sandbox;
@@ -79,4 +80,31 @@ describe("FirefoxStorage", () => {
       }, {preload: [1, 2, 3]});
     });
   });
+});
+
+describe("FirefoxStorage_reduceRecords", () => {
+  /** @test {reduceRecords} */
+  describe("#reduceRecords", () => {
+    it("should filter and order list", () => {
+      expect(reduceRecords({unread: false, complete: true}, "-title", [
+        {title: "a", unread: true, complete: true},
+        {title: "b", unread: false, complete: true},
+        {title: "c", unread: false, complete: true},
+      ])).eql([
+        {title: "c", unread: false, complete: true},
+        {title: "b", unread: false, complete: true},
+      ]);
+    });
+
+    it("should support empty filter", () => {
+      const records = [{a: 1}, {a: 2}];
+      expect(reduceRecords({}, "-a", records)).eql(records.reverse());
+    });
+
+    it("should support empty sort order", () => {
+      const records = [{a: 1}, {b: 2}];
+      expect(reduceRecords({}, "", records)).eql(records);
+    });
+  });
+
 });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -7,7 +7,6 @@ import {
   sortObjects,
   filterObjects,
   omitKeys,
-  reduceRecords,
   isUUID,
   waterfall,
   pFinally
@@ -121,30 +120,6 @@ describe("Utils", () => {
         {title: "a"},
         {title: "c"},
       ]);
-    });
-  });
-
-  /** @test {reduceRecords} */
-  describe("#reduceRecords", () => {
-    it("should filter and order list", () => {
-      expect(reduceRecords({unread: false, complete: true}, "-title", [
-        {title: "a", unread: true, complete: true},
-        {title: "b", unread: false, complete: true},
-        {title: "c", unread: false, complete: true},
-      ])).eql([
-        {title: "c", unread: false, complete: true},
-        {title: "b", unread: false, complete: true},
-      ]);
-    });
-
-    it("should support empty filter", () => {
-      const records = [{a: 1}, {a: 2}];
-      expect(reduceRecords({}, "-a", records)).eql(records.reverse());
-    });
-
-    it("should support empty sort order", () => {
-      const records = [{a: 1}, {b: 2}];
-      expect(reduceRecords({}, "", records)).eql(records);
     });
   });
 


### PR DESCRIPTION
Code for #534 : don't put documents in the results to be discarded later but filter them earliest.

I thought it would give a moderate performance boost and indeed get 8% time improvement and no memory change (1% not significant)  for a query rejecting every document.

My test code (oldTickets contains 7626 documents, none match)
```
function perfTest(cnt, acc){
	if(cnt <= 0){
		avg = acc.length && (acc.reduce(function(s, x) { return s + x; }, 0) / acc.length);
		console.log("perfTest avg=", avg);
	}else{
		if(cnt % 10 === 0){
			console.log("perfTest", cnt, "remaining");
		}
		before = new Date();
		oldTickets.list({filters: {status: "open"}}).then(function(){
		  after = new Date();
		  //console.log("list() took", after - before, "ms");
		  acc.push(after - before);
		  perfTest(cnt - 1, acc);
		});
	}
}

perfTest(50, []);
```

1. load oldTickets at https://trackers.elelay.fr/trackers-base.html
2. quit firefox
3. open firefox with a single tab to https://trackers.elelay.fr/trackers-base.html
4. let the app load (labels on buttons)
5. run the test code above
6. quit firefox
7. repeat 3. - 6. with https://trackers.elelay.fr/trackers-filter-as-you-go.html

Results:

|   | average time | virtual mem  | resident mem |
| ---- | ----------------- | --------------- | ------------ |
| master | 2.156s | 1257MB | 360MB |
| filter-as-you-go | 1.969s | 1274MB | 357MB |
| **improvement** | 8.7% faster | 1.4% more | 0.8% less |
