### PR TITLE
Fix skipped remote deletion (fixes #540)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -590,7 +590,7 @@ The synchronization result object exposes the following properties:
 - `created`:   The list of remote records which have been successfully imported into the local database.
 - `updated`:   The list of updates with old and new record which have been successfully reflected into the local database.
 - `deleted`:   The list of remotely deleted records which have been successfully deleted as well locally.
-- `skipped`:   The list of remotely deleted records missing locally.
+- `skipped`:   The list of remotely deleted records that were missing or also deleted locally.
 - `published`: The list of locally modified records (created, updated, or deleted) which have been successfully pushed to the remote server.
 - `resolved`:  The list of conflicting records which have been successfully resolved according to the selected [strategy](#synchronization-strategies) (note that when using the default `MANUAL` strategy, this list is always empty).
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -381,7 +381,7 @@ Let's review the different result object properties:
 - `deleted`: the list of records deleted locally;
 - `published`: the list of records published; here we see we successfully pushed our two local tasks;
 - `conflicts`: the list of conflicts encountered, if any (we'll see this in a minute);
-- `skipped`: the list of skipped operations; for example, if we're trying to remotely delete a record which doesn't exist on the server, that information will be listed here.
+- `skipped`: the list of skipped records; for example, if we're trying to remotely delete a record which doesn't exist on the server, that information will be listed here.
 
 ## Handling conflicts
 

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   "dependencies": {
     "babel-polyfill": "^6.7.4",
     "btoa": "^1.1.2",
-    "kinto-http": "^2.0.0",
+    "kinto-http": "^2.5.1",
     "uuid": "^2.0.1"
   },
   "devDependencies": {

--- a/src/collection.js
+++ b/src/collection.js
@@ -895,7 +895,7 @@ export default class Collection {
         return Promise.all(synced.conflicts.map(({type, local, remote}) => {
           // Note: we ensure that local data are actually available, as they may
           // be missing in the case of a published deletion.
-          const safeLocal = local && local.data || {};
+          const safeLocal = local && local.data || {id: remote.id};
           return this._decodeRecord("remote", safeLocal).then(realLocal => {
             return this._decodeRecord("remote", remote).then(realRemote => {
               return {type, local: realLocal, remote: realRemote};

--- a/src/collection.js
+++ b/src/collection.js
@@ -911,13 +911,10 @@ export default class Collection {
         // For created and updated records, the last_modified coming from server
         // will be stored locally.
         const published = synced.published.map((c) => c.data);
-        const skipped = synced.skipped.map((c) => c.data);
 
         // Records that must be deleted are either deletions that were pushed
         // to server (published) or deleted records that were never pushed (skipped).
-        const missingRemotely = skipped.map(r => {
-          return {...r, deleted: true};
-        });
+        const missingRemotely = synced.skipped.map(r => ({...r, deleted: true}));
         const toApplyLocally = published.concat(missingRemotely);
 
         const toDeleteLocally = toApplyLocally.filter((r) => r.deleted);

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2059,7 +2059,10 @@ describe("Collection", () => {
         published: [],
         errors:    [],
         conflicts: [],
-        skipped:   [{data: {id: records[0].id}}]
+        skipped:   [{
+          id: records[0].id,
+          error: {errno: 110, code: 404, error: "Not found"}
+        }]
       }));
       return articles.pushChanges(client, result)
         .then(_ => articles.get(records[0].id, {includeDeleted: true}))

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2061,7 +2061,7 @@ describe("Collection", () => {
         conflicts: [],
         skipped:   [{
           id: records[0].id,
-          error: {errno: 110, code: 404, error: "Not found"}
+          error: {errno: 110, code: 404, error: "Not found"},
         }]
       }));
       return articles.pushChanges(client, result)

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -809,7 +809,6 @@ describe("Integration tests", function() {
 
       });
 
-
       describe("Outgoing conflicting deletion", () => {
 
         describe("With remote update", () => {
@@ -845,7 +844,7 @@ describe("Integration tests", function() {
           });
 
           it("should have the expected conflicting local version", () => {
-            expect(conflicts[0].local).eql({});
+            expect(conflicts[0].local).eql({id});
           });
 
           it("should have the expected conflicting remote version", () => {
@@ -888,7 +887,6 @@ describe("Integration tests", function() {
           });
         });
       });
-
 
       describe("Outgoing conflict", () => {
         let syncResult;


### PR DESCRIPTION
This pull-request relies on kinto-http.js 2.5.1 

The `skipped` attribute in sync result now contains the record id that was skipped instead of a plain 404 error response body.

An integration test now executes a skipped remote deletion.

@n1k0 r?