### PR TITLE
Add generator runtime for async/await

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "plugins": ["transform-object-rest-spread", "transform-async-to-generator"],
+  "plugins": ["transform-object-rest-spread", "transform-async-to-generator", "transform-runtime"],
   "env": {
     "development": {
       "presets": ["es2015"]

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "babel-loader": "^6.2.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.4.3",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",


### PR DESCRIPTION
After #548, running the demo fails with `ReferenceError: regeneratorRuntime is not defined`

I added the necessary Babel stuff. But this makes the build bigger :/

Before:

```
-rw-rw-r--  1 mathieu mathieu 1,2M sep 16 11:01 kinto.js
-rw-rw-r--  1 mathieu mathieu 250K sep 16 11:01 kinto.min.js
-rw-rw-r--  1 mathieu mathieu  86K sep 16 11:01 kinto.noshim.js
-rw-rw-r--  1 mathieu mathieu  88K sep 16 11:01 moz-kinto-offline-client.js
```

After:

```
-rw-rw-r--  1 mathieu mathieu 1,3M sep 16 11:04 kinto.js
-rw-rw-r--  1 mathieu mathieu 286K sep 16 11:04 kinto.min.js
-rw-rw-r--  1 mathieu mathieu 147K sep 16 11:04 kinto.noshim.js
-rw-rw-r--  1 mathieu mathieu 138K sep 16 11:04 moz-kinto-offline-client.js
```

What do think ?

Personnally, I think that having async/await in the codebase really helps understand the flow, and will really help us to refactor stuff. I'm ready ready to accept a bigger dist output...

I also think we have to put some more efforts to tweak the `noshim` and `moz-*` builds.