### PR TITLE
implement #526 permanent storage option for IDB adapter

### DIFF
--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -35,6 +35,36 @@ describe("adapter.IDB", () => {
 
       return prom.should.be.rejectedWith("fail");
     });
+
+    it("should use storage option", () => {
+      const fakeOpenRequest = {};
+      const open = sandbox.stub(indexedDB, "open").returns(fakeOpenRequest);
+      const db = new IDB("another/db", {storage: "permanent"});
+      const prom = db.open(indexedDB).then(() => {
+        sinon.assert.calledWithExactly(open, "another/db", {
+          storage: "permanent", version: 1
+        });
+      });
+      
+      fakeOpenRequest.onsuccess({target: {result: {}}});
+      
+      return prom.should.be.fulfilled;
+    });
+
+    it("should fallback to no storage option", () => {
+      const fakeOpenRequest = {};
+      const open = sandbox.stub(indexedDB, "open");
+      open.withArgs(sinon.match.any, {
+        storage: "permanent", version: 1
+      }).throws();
+      open.withArgs(sinon.match.any, 1).returns(fakeOpenRequest);
+      const db = new IDB("another/db", {storage: "permanent"});
+      const prom = db.open(indexedDB);
+      
+      fakeOpenRequest.onsuccess({target: {result: {}}});
+      
+      return prom.should.be.fulfilled;
+    });
   });
 
   /** @test {IDB#close} */


### PR DESCRIPTION
Tries to specify storage (Firefox experimental option) and falls back to
unspecified storage. Shouldn't hurt other platforms: they throw on open
with non integer version parameter (tested in chromium only).

1 integration test fails but not from my changes:

>  1) Integration tests Default server configuration Synchronization Outgoing conflicting deletion With remote deletion "before each" hook for "should properly list the encountered conflict":
>     DataError: Data provided to an operation does not meet requirements.
