### PR TITLE
Cleanup/refactor sync code

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -8,6 +8,9 @@ This page lists the breaking API changes between major versions of Kinto.js, as 
 * `collection.sync()` now rejects asynchronously when the specified remote is invalid (#540)
 * `incoming-changes` hook now receives decoded records
 * Remote deletion conflicts are now resolved with decoded records
+* Last pull step in sync() only retrieves what was changed remotely while pushing local changes
+* `pushChanges()` prototype changes and now accepts a list of records
+* the database is not scanned anymore when pushing conflicts rsolutions
 
 ## 3.x to 4.x
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -9,9 +9,9 @@ This page lists the breaking API changes between major versions of Kinto.js, as 
 * `incoming-changes` hook now receives decoded records
 * Remote deletion conflicts are now resolved with decoded records
 * Last pull step in sync() only retrieves what was changed remotely while pushing local changes
-* `importChanges()` prototype was changed and now accepts a list of records and a strategy string
-* `pushChanges()` prototype was changed and now accepts a list of records
-* the database is not scanned anymore when pushing conflicts rsolutions
+* `importChanges()` method was changed and now accepts a list of records and a strategy string
+* `pushChanges()` method was changed and now accepts a list of records
+* the database is not scanned anymore when pushing conflicts resolutions
 
 ## 3.x to 4.x
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -9,7 +9,8 @@ This page lists the breaking API changes between major versions of Kinto.js, as 
 * `incoming-changes` hook now receives decoded records
 * Remote deletion conflicts are now resolved with decoded records
 * Last pull step in sync() only retrieves what was changed remotely while pushing local changes
-* `pushChanges()` prototype changes and now accepts a list of records
+* `importChanges()` prototype was changed and now accepts a list of records and a strategy string
+* `pushChanges()` prototype was changed and now accepts a list of records
 * the database is not scanned anymore when pushing conflicts rsolutions
 
 ## 3.x to 4.x

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -6,6 +6,8 @@ This page lists the breaking API changes between major versions of Kinto.js, as 
 
 * The helper `utils/reduceRecords` was removed (#543)
 * `collection.sync()` now rejects asynchronously when the specified remote is invalid (#540)
+* `incoming-changes` hook now receives decoded records
+* Remote deletion conflicts are now resolved with decoded records
 
 ## 3.x to 4.x
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -611,20 +611,12 @@ export default class Collection {
   }
 
   /**
-   * Imports remote changes into the local database. The change object contains
-   * two properties:
-   *
-   * - `changes`: an array exposing the list of changes that occurred on the
-   *   server since the last successful synchronization (basically the list of
-   *   updated and/or deleted records);
-   * - `lastModified`: the last modified timestamp of the remote collection.
-   *
-   * @param  {SyncResultObject} syncResultObject   The sync result object.
-   * @param  {Object}       changeObject           The change object.
-   * @param  {Number}       changeObject.lastModified The last modified
-   * timestamp of the remote collection.
-   * @param  {Array}        changeObject.changes The list of changes that
-   * occurred on the server since the last successful synchronization.
+   * Imports remote changes into the local database.
+   * This method is in charge of detecting the conflicts, and resolve them
+   * according to the specified strategy.
+   * @param  {SyncResultObject} syncResultObject The sync result object.
+   * @param  {Array}            decodedChanges   The list of changes to import in the local database.
+   * @param  {String}           strategy         The {@link Collection.strategy}.
    * @return {Promise}
    */
   async importChanges(syncResultObject, decodedChanges, strategy) {
@@ -663,6 +655,15 @@ export default class Collection {
     return syncResultObject;
   }
 
+  /**
+   * Imports the responses of pushed changes into the local database.
+   * Basically it stores the timestamp assigned by the server into the local
+   * database.
+   * @param  {SyncResultObject} syncResultObject The sync result object.
+   * @param  {Array}            toApplyLocally   The list of changes to import in the local database.
+   * @param  {String}           strategy         The {@link Collection.strategy}.
+   * @return {Promise}
+   */
   async importPublications(syncResultObject, toApplyLocally, strategy) {
     const toDeleteLocally = toApplyLocally.filter((r) => r.deleted);
     const toUpdateLocally = toApplyLocally.filter((r) => !r.deleted);
@@ -906,6 +907,9 @@ export default class Collection {
    *
    * @param  {KintoClient.Collection} client           Kinto client Collection instance.
    * @param  {SyncResultObject}       syncResultObject The sync result object.
+   * @param  {Object}                 changes          The change object.
+   * @param  {Array}                  changes.toDelete The list of records to delete.
+   * @param  {Array}                  changes.toSync   The list of records to create/update.
    * @param  {Object}                 options          The options object.
    * @return {Promise}
    */

--- a/src/collection.js
+++ b/src/collection.js
@@ -622,10 +622,10 @@ export default class Collection {
    * according to the specified strategy.
    * @param  {SyncResultObject} syncResultObject The sync result object.
    * @param  {Array}            decodedChanges   The list of changes to import in the local database.
-   * @param  {String}           strategy         The {@link Collection.strategy}.
+   * @param  {String}           strategy         The {@link Collection.strategy} (default: MANUAL)
    * @return {Promise}
    */
-  async importChanges(syncResultObject, decodedChanges, strategy) {
+  async importChanges(syncResultObject, decodedChanges, strategy=Collection.strategy.MANUAL) {
     // Retrieve records matching change ids.
     try {
       const {imports, resolved} = await this.db.execute(transaction => {
@@ -671,7 +671,7 @@ export default class Collection {
    * @param  {String}           strategy         The {@link Collection.strategy}.
    * @return {Promise}
    */
-  async _applyPushedResults(syncResultObject, toApplyLocally, conflicts, strategy) {
+  async _applyPushedResults(syncResultObject, toApplyLocally, conflicts, strategy=Collection.strategy.MANUAL) {
     const toDeleteLocally = toApplyLocally.filter((r) => r.deleted);
     const toUpdateLocally = toApplyLocally.filter((r) => !r.deleted);
 
@@ -710,7 +710,7 @@ export default class Collection {
    * @param  {String}           strategy  The {@link Collection.strategy}.
    * @return {Promise}
    */
-  _handleConflicts(transaction, conflicts, strategy=Collection.strategy.MANUAL) {
+  _handleConflicts(transaction, conflicts, strategy) {
     if (strategy === Collection.strategy.MANUAL) {
       return [];
     }

--- a/src/collection.js
+++ b/src/collection.js
@@ -830,10 +830,12 @@ export default class Collection {
     const since = this.lastModified ? this.lastModified
                                     : await this.db.getLastModified();
 
-    options = {strategy: Collection.strategy.MANUAL,
+    options = {
+      strategy: Collection.strategy.MANUAL,
       lastModified: since,
       headers: {},
-      ...options};
+      ...options
+    };
 
     // Optionally ignore some records when pulling for changes.
     // (avoid redownloading our own changes on last step of #sync())

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -34,7 +34,7 @@ const appendTransformer = function(s) {
   };
 };
 
-describe.only("Integration tests", function() {
+describe("Integration tests", function() {
   let sandbox, server, kinto, tasks, tasksTransformed;
 
   // Disabling test timeouts until pserve gets decent startup time.

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -34,7 +34,7 @@ const appendTransformer = function(s) {
   };
 };
 
-describe("Integration tests", function() {
+describe.only("Integration tests", function() {
   let sandbox, server, kinto, tasks, tasksTransformed;
 
   // Disabling test timeouts until pserve gets decent startup time.


### PR DESCRIPTION
Now that we have switched to async/await it's a lot easier to read the code of the sync process and spot inconsistencies :)

I did that refactoring by keeping an eye on the integration tests. I'll have to change the specs/code of the unit tests now.

* [x] Refactor / added some comments
* [x] Update docstrings
* [ ] Document changes
* [x] Make unit tests pass

Fixes #418 #340 