### PR TITLE
Encode conflict resolutions during CLIENT_WINS (fixes: #569)

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -1081,7 +1081,8 @@ export default class Collection {
       // Publish local resolution of push conflicts to server (on CLIENT_WINS)
       const resolvedUnsynced = result.resolved.filter(r => r._status !== "synced");
       if (resolvedUnsynced.length > 0) {
-        await this.pushChanges(client, {toSync: resolvedUnsynced}, result, options);
+        const resolvedEncoded = await Promise.all(resolvedUnsynced.map(this._encodeRecord.bind(this, "remote")));
+        await this.pushChanges(client, {toSync: resolvedEncoded}, result, options);
       }
       // Perform a last pull to catch changes that occured after the last pull,
       // while local changes were pushed. Do not do it nothing was pushed.

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1157,6 +1157,13 @@ describe("Integration tests", function() {
                 {title: "task1-local", _status: "synced"},
               ]);
           });
+
+          it("should put the remote database in the expected state", () => {
+            return getRemoteList(tasksTransformed._name).should.become([
+              // local task4 should have been published to the server.
+              {title: "task1-local!", done: false},
+            ]);
+          });
         });
 
         describe("SERVER_WINS strategy", () => {


### PR DESCRIPTION
I don't remember if I didn't add this test the first time around because it wasn't working, or because I didn't think it could not be working, but add the test and add the fix.

@n1k0 @leplatrem r?