### PR TITLE
Prepare version 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinto",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "An Offline-First JavaScript client for Kinto.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This merges #562, which is a major version change because it removes the
Firefox storage adapter. This code is specific to Gecko and will move to
that repository.
