### PR TITLE
Add sync events

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -737,6 +737,19 @@ articles.sync({ignoreBackoff: true})
 
 Using the `events` on a `Kinto` instance property you can subscribe public events from. That `events` property implements nodejs' [EventEmitter interface](https://nodejs.org/api/events.html#events_class_events_eventemitter).
 
+
+#### The `sync:success` and `sync:error` events
+
+Triggered on [`#sync()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-sync) call, whether it succeeds or not.
+
+
+#### The `retry-after` event
+
+Triggered when a `Retry-After` HTTP header has been received from the last received response from the server, meaning clients should retry the same request after the specified amount of time.
+
+> Note: With *kinto-http.js* 2.7 and above, the requests are transparently retried. This event is thus only useful for tracking such situations.
+
+
 #### The `backoff` event
 
 Triggered when a `Backoff` HTTP header has been received from the last received response from the server, meaning clients should hold on performing further requests during a given amount of time.

--- a/src/collection.js
+++ b/src/collection.js
@@ -1097,10 +1097,14 @@ export default class Collection {
         // No conflict occured, persist collection's lastModified value
         this._lastModified = await this.db.saveLastModified(result.lastModified);
       }
+    } catch (e) {
+      this.events.emit("sync:error", e);
+      throw e;
     } finally {
       // Ensure API default remote is reverted if a custom one's been used
       this.api.remote = previousRemote;
     }
+    this.events.emit("sync:success", result);
     return result;
   }
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -1053,6 +1053,12 @@ export default class Collection {
     collection: null,
     remote: null,
   }) {
+    options = {
+      ...options,
+      bucket: options.bucket || this.bucket,
+      collection: options.collection || this.name,
+    };
+
     const previousRemote = this.api.remote;
     if (options.remote) {
       // Note: setting the remote ensures it's valid, throws when invalid.
@@ -1064,7 +1070,7 @@ export default class Collection {
         new Error(`Server is asking clients to back off; retry in ${seconds}s or use the ignoreBackoff option.`));
     }
 
-    const client = this.api.bucket(options.bucket || this.bucket).collection(options.collection || this.name);
+    const client = this.api.bucket(options.bucket).collection(options.collection);
 
     const result = new SyncResultObject();
     try {
@@ -1098,13 +1104,13 @@ export default class Collection {
         this._lastModified = await this.db.saveLastModified(result.lastModified);
       }
     } catch (e) {
-      this.events.emit("sync:error", e);
+      this.events.emit("sync:error", {...options, error: e});
       throw e;
     } finally {
       // Ensure API default remote is reverted if a custom one's been used
       this.api.remote = previousRemote;
     }
-    this.events.emit("sync:success", result);
+    this.events.emit("sync:success", {...options, result});
     return result;
   }
 

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2382,6 +2382,40 @@ describe("Collection", () => {
             expect(onerror.called).eql(true);
           });
       });
+
+      it("should send an error event", () => {
+        articles.pushChanges.throws(new Error("boom"));
+        return articles.sync()
+          .catch(() => {
+            expect(onsuccess.called).eql(false);
+            expect(onerror.called).eql(true);
+          });
+      });
+
+      it("should provide success details about sync", () => {
+        return articles.sync()
+          .then(() => {
+            const data = onsuccess.firstCall.args[0];
+            expect(data).to.have.property("result");
+            expect(data).to.have.property("remote");
+            expect(data).to.have.property("bucket");
+            expect(data).to.have.property("collection");
+            expect(data).to.have.property("headers");
+          });
+      });
+
+      it("should provide error details about sync", () => {
+        articles.pushChanges.throws(new Error("boom"));
+        return articles.sync()
+          .catch(() => {
+            const data = onerror.firstCall.args[0];
+            expect(data).to.have.property("error");
+            expect(data).to.have.property("remote");
+            expect(data).to.have.property("bucket");
+            expect(data).to.have.property("collection");
+            expect(data).to.have.property("headers");
+          });
+      });
     });
   });
 

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2350,6 +2350,29 @@ describe("Collection", () => {
           .then(_ => sinon.assert.calledOnce(pullChanges));
       });
     });
+
+    describe("Events", () => {
+      beforeEach(() => {
+        sandbox.stub(articles.db, "getLastModified").returns(Promise.resolve({}));
+        sandbox.stub(articles, "pullChanges");
+        sandbox.stub(articles, "pushChanges");
+      });
+
+      it("should send a success event", () => {
+        const callback = sinon.spy();
+        articles.events.on("sync:success", callback);
+        return articles.sync()
+          .then(() => expect(callback.called).eql(true));
+      });
+
+      it("should send an error event", () => {
+        const callback = sinon.spy();
+        articles.events.on("sync:error", callback);
+        articles.pushChanges.throws(new Error("boom"));
+        return articles.sync()
+          .catch(() => expect(callback.called).eql(true));
+      });
+    });
   });
 
   /** @test {Collection#execute} */

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2352,25 +2352,35 @@ describe("Collection", () => {
     });
 
     describe("Events", () => {
+      let onsuccess;
+      let onerror;
+
       beforeEach(() => {
+        onsuccess = sinon.spy();
+        onerror = sinon.spy();
+        articles.events.on("sync:success", onsuccess);
+        articles.events.on("sync:error", onerror);
+
         sandbox.stub(articles.db, "getLastModified").returns(Promise.resolve({}));
         sandbox.stub(articles, "pullChanges");
         sandbox.stub(articles, "pushChanges");
       });
 
       it("should send a success event", () => {
-        const callback = sinon.spy();
-        articles.events.on("sync:success", callback);
         return articles.sync()
-          .then(() => expect(callback.called).eql(true));
+          .then(() => {
+            expect(onsuccess.called).eql(true);
+            expect(onerror.called).eql(false);
+          });
       });
 
       it("should send an error event", () => {
-        const callback = sinon.spy();
-        articles.events.on("sync:error", callback);
         articles.pushChanges.throws(new Error("boom"));
         return articles.sync()
-          .catch(() => expect(callback.called).eql(true));
+          .catch(() => {
+            expect(onsuccess.called).eql(false);
+            expect(onerror.called).eql(true);
+          });
       });
     });
   });


### PR DESCRIPTION
That is a trivial addition.

I think it is useful for pluggabilty and flexibility, but I feel I could be convinced otherwise :)

For example:

```js
const kinto = new Kinto();
kinto.events.on("sync:success", function(result) {
  telemetry.count("success");
});
kinto.events.on("sync:error", function(result) {
  telemetry.count("error");
});
collection.sync();
```

Versus:
```js
const kinto = new Kinto();

collection.sync()
  .then(() => telemetry.count("success"))
  .catch(() => telemetry.count("error"));
```


Thoughts ?