### PR TITLE
Update babel-cli to 6.22.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "uuid": "^3.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.18.0",
+    "babel-cli": "^6.22.2",
     "babel-core": "^6.20.0",
     "babel-eslint": "^7.0.0",
     "babel-istanbul": "^0.12.1",


### PR DESCRIPTION
babel 6.22.0 and 6.22.1 have a bug that got fixed in 6.22.2 -- see https://github.com/babel/babel/blob/85eec9ffef9f2defbcc4cce29440c5ef230708d2/CHANGELOG.md#bug-bug-fix. I don't see a Greenkeeper PR for this version, so I'm opening my own.

Deprecates: #623, #631.