### PR TITLE
Update babel-core to 6.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",
-    "babel-core": "^6.20.0",
+    "babel-core": "^6.22.1",
     "babel-eslint": "^7.0.0",
     "babel-istanbul": "^0.12.1",
     "babel-loader": "^6.2.1",


### PR DESCRIPTION
Deprecates #624, whose failure won't reoccur because of #633.