### PR TITLE
esdoc: remove esdoc-es7-plugin

### DIFF
--- a/esdoc.json
+++ b/esdoc.json
@@ -5,6 +5,16 @@
     "type": "mocha",
     "source": "./test"
   },
+  "experimentalProposal": {
+    "classProperties": true,
+    "objectRestSpread": true,
+    "decorators": true,
+    "doExpressions": true,
+    "functionBind": true,
+    "asyncGenerators": true,
+    "exportExtensions": true,
+    "dynamicImport": true
+  },
   "plugins": [
     {
       "name": "esdoc-importpath-plugin",
@@ -13,9 +23,6 @@
           {"from": "^src", "to": "lib"}
         ]
       }
-    },
-    {
-      "name": "esdoc-es7-plugin"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "co-task": "^1.0.0",
     "coveralls": "^2.11.15",
     "esdoc": "^0.5.2",
-    "esdoc-es7-plugin": "0.0.3",
     "esdoc-importpath-plugin": "0.1.1",
     "eslint": "3.17.0",
     "estraverse-fb": "^1.3.1",

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -41,8 +41,12 @@ describe("Integration tests", function() {
   this.timeout(0);
 
   before(() => {
+    let kintoConfigPath = __dirname + "/kinto.ini";
+    if (process.env.SERVER && process.env.SERVER !== "master") {
+      kintoConfigPath = `${__dirname}/kinto-${process.env.SERVER}.ini`;
+    }
     server = new KintoServer(TEST_KINTO_SERVER, {
-      kintoConfigPath: __dirname + "/kinto.ini"
+      kintoConfigPath
     });
   });
 

--- a/test/kinto-5.3.6.ini
+++ b/test/kinto-5.3.6.ini
@@ -1,0 +1,16 @@
+[app:main]
+use = egg:kinto
+
+# Required by integration tests
+kinto.flush_endpoint_enabled = true
+
+# Required by basic auth
+kinto.userid_hmac_secret = a-secret-string
+
+# Add default bucket
+kinto.includes = kinto.plugins.default_bucket
+
+[server:main]
+use = egg:waitress#main
+host = 0.0.0.0
+port = 8888

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -9,7 +9,7 @@ kinto.userid_hmac_secret = a-secret-string
 
 # Add default bucket
 kinto.includes = kinto.plugins.default_bucket
-
+                 kinto.plugins.flush
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0


### PR DESCRIPTION
Per https://github.com/esdoc/esdoc/issues/390, esdoc-es7-plugin is
deprecated and esdoc has itself grown functionality equivalent to
it. Now using esdoc-es7-plugin causes esdoc generation to fail.

Following the fix in the linked issue, just turn on all the options,
since I'm not sure which ones we use specifically.

Thanks tiberiuichim for reporting this issue on Slack.