### PR TITLE
collection: No need to push "deleted" resolution

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -774,7 +774,9 @@ export default class Collection {
         // batch.js:aggregate.
         transaction.delete(conflict.local.id);
         accepted = null;
-        status = "deleted";
+        // The record was deleted, but that status is "synced" with
+        // the server, so we don't need to push the change.
+        status = "synced";
         id = conflict.local.id;
       } else {
         const updated = this._resolveRaw(conflict, resolution);

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1629,7 +1629,7 @@ describe("Integration tests", function() {
           it("should list resolved records", () => {
             expect(syncResult.resolved).to.have.length.of(1);
             expect(syncResult.resolved[0].accepted).eql(null);
-            expect(syncResult.resolved[0]).property("_status", "deleted");
+            expect(syncResult.resolved[0]).property("_status", "synced");
             expect(syncResult.resolved[0].rejected.title).eql("task1-local");
           });
 


### PR DESCRIPTION
It seems strange to say that this record is "synced", but "deleted" would mean that it was deleted locally and needed the delete to be replicated remotely.