### PR TITLE
Update to current location of EventEmitter

### DIFF
--- a/fx-src/index.js
+++ b/fx-src/index.js
@@ -19,7 +19,7 @@ const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 
 Cu.import("resource://gre/modules/Timer.jsm");
 Cu.importGlobalProperties(["fetch"]);
-const { EventEmitter } = Cu.import("resource://devtools/shared/event-emitter.js", {});
+const { EventEmitter } = Cu.import("resource://gre/modules/EventEmitter.js", {});
 const { generateUUID } = Cc["@mozilla.org/uuid-generator;1"].getService(Ci.nsIUUIDGenerator);
 
 // Use standalone kinto-http module landed in FFx.


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1356231, devtools is
going away.

This is the same as https://github.com/Kinto/kinto-http.js/pull/190, but for this project.