### PR TITLE
Update tests for sinon 2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "mocha": "^3.2.0",
     "prettier": "^1.2.2",
     "prettier-check": "^1.0.0",
-    "sinon": "^2.0.0",
+    "sinon": "^2.3.2",
     "uglifyify": "^3.0.3"
   }
 }

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2501,12 +2501,12 @@ describe("Collection", () => {
 
     beforeEach(() => {
       articles = testCollection();
-      sandbox.stub(api, "batch").returns({
+      sandbox.stub(api, "batch").get(() => () => ({
         errors: [],
         published: [],
         conflicts: [],
         skipped: [],
-      });
+      }));
       return Promise.all(
         fixtures.map(fixture => articles.create(fixture))
       ).then(res => (ids = res.map(r => r.data.id)));


### PR DESCRIPTION
2.3.0 introduced some improvements to stubs of descriptors. `batch` is a
descriptor because of being decorated with @nobatch. But it's a
descriptor whose `get` function itself returns a function, so things are
a little strange.

The fix works on 2.3.2 and on < 2.3.0 but not on [2.3.0, 2.3.1], so bump
the dependency too I guess.

Fixes #708. Supersedes #704.