### PR TITLE
Updated required Node version

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## NodeJS
 
-If you're using [NodeJS](https://nodejs.org) and [npm](https://www.npmjs.com/) as a frontend package manager, you'll need [NodeJS v0.12.x](https://nodejs.org/download/) installed on your system. Then:
+If you're using [NodeJS](https://nodejs.org) and [npm](https://www.npmjs.com/) as a frontend package manager, you'll need [NodeJS v6.x.x or higher](https://nodejs.org/download/) installed on your system. Then:
 
 ```js
 $ npm install kinto --save


### PR DESCRIPTION
I noticed that the install information stating `NodeJS v0.12.x]` is not congruent with what is stated in the `package.json` file,

```
  "engines": {
    "node": ">=6"
  },
```