### PR TITLE
Updated required Node version in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Hacking on Kinto.js
 
-Hacking on Kinto.js requires a working [NodeJS v0.12x environment](https://nodejs.org/download/).
+Hacking on Kinto.js requires a working [NodeJS v6.x.x or higher](https://nodejs.org/download/).
 
 ## Installation
 


### PR DESCRIPTION
Same as my previous PR regarding installation.md, I noticed that the information stating which version is required, [NodeJS v0.12.x] is not congruent with what is stated in the package.json file,
```
  "engines": {
    "node": ">=6"
  },
```