### PR TITLE
Add indexeddb support in Gecko export (fixes #731)

### DIFF
--- a/fx-src/index.js
+++ b/fx-src/index.js
@@ -16,7 +16,7 @@
 "use strict";
 
 ChromeUtils.import("resource://gre/modules/Timer.jsm");
-Cu.importGlobalProperties(["fetch"]);
+Cu.importGlobalProperties(["fetch", "indexedDB"]);
 const { EventEmitter } = ChromeUtils.import(
   "resource://gre/modules/EventEmitter.jsm",
   {}
@@ -31,14 +31,24 @@ const { KintoHttpClient } = ChromeUtils.import(
 );
 
 import KintoBase from "../src/KintoBase";
+import BaseAdapter from "../src/adapters/base";
+import IDB from "../src/adapters/IDB";
 import { RE_UUID } from "../src/utils";
 
 export default class Kinto extends KintoBase {
+  static get adapters() {
+    return {
+      BaseAdapter,
+      IDB,
+    };
+  }
+
   constructor(options = {}) {
     const events = {};
     EventEmitter.decorate(events);
 
     const defaults = {
+      adapter: IDB,
       events,
       ApiClass: KintoHttpClient,
     };

--- a/fx-src/jsm_prefix.js
+++ b/fx-src/jsm_prefix.js
@@ -30,4 +30,4 @@
 // more details.
 const global = this;
 
-this.EXPORTED_SYMBOLS = ["Kinto"];
+var EXPORTED_SYMBOLS = ["Kinto"];

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,8 @@ export default class Kinto extends KintoBase {
    */
   static get adapters() {
     return {
-      BaseAdapter: BaseAdapter,
-      IDB: IDB,
+      BaseAdapter,
+      IDB,
     };
   }
 


### PR DESCRIPTION
Fixes #731

* [x] POC
* [x] Validate approach by switching blocklist to indexeddb
* [ ] Check shutdown behaviour etc.
* [ ] Update https://wiki.mozilla.org/Firefox/Kinto 