### PR TITLE
Turn eslint dependency into range dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "coveralls": "^2.11.15",
     "esdoc": "^1.0.1",
     "esdoc-importpath-plugin": "1.0.1",
-    "eslint": "4.7.1",
+    "eslint": "^4.7.2",
     "estraverse-fb": "^1.3.1",
     "fake-indexeddb": "2.0.3",
     "gh-pages": "^1.0.0",


### PR DESCRIPTION
This got pinned to a specific version in
3dc778baa1373384a438129a2dcddd62ef402c56 to work around a temporary
breakage that seems to have been resolved at some point in the
intervening 18 months. Most eslint versions have not caused breakage.

Closes #758.