### PR TITLE
Add IDB#resetSyncStatus

### DIFF
--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -490,4 +490,43 @@ describe("adapter.IDB", () => {
         .should.eventually.become(1458796543);
     });
   });
+
+  describe("#resetSyncStatus", () => {
+    it("should forget the last modified value.", () => {
+      return db
+        .saveLastModified(42)
+        .then(_ => db.resetSyncStatus())
+        .then(_ => db.getLastModified())
+        .should.eventually.become(null);
+    });
+
+    it("should clear last_modified from a record.", () => {
+      return db
+        .loadDump([
+          { id: uuid4(), title: "foo", last_modified: 1457896541 },
+          { id: uuid4(), title: "bar", last_modified: 1458796542 },
+        ])
+        .then(_ => db.resetSyncStatus())
+        .then(_ => db.list())
+        .then(records => records.map(record => record.last_modified))
+        .should.eventually.eql([undefined, undefined]);
+    });
+
+    it("should reset _status to created on updated records.", () => {
+      return db
+        .loadDump([{ id: uuid4(), title: "bar", _status: "updated" }])
+        .then(_ => db.resetSyncStatus())
+        .then(_ => db.list())
+        .then(records => records[0]._status)
+        .should.eventually.eql("created");
+    });
+
+    it("should delete records with deleted _status.", () => {
+      return db
+        .loadDump([{ id: uuid4(), title: "bar", _status: "deleted" }])
+        .then(_ => db.resetSyncStatus())
+        .then(_ => db.list())
+        .should.eventually.eql([]);
+    });
+  });
 });

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -99,7 +99,7 @@ describe("Integration tests", function() {
 
   after(() => {
     const logLines = server.logs.toString().split("\n");
-    const serverDidCrash = logLines.some(l => l.startsWith("Traceback"));
+    const serverDidCrash = logLines.some(l => l.includes("Traceback"));
     if (serverDidCrash) {
       // Server errors have been encountered, raise to break the build
       const trace = logLines.join("\n");


### PR DESCRIPTION
This is a semiprivate method modeled on the method of the same name in
the Firefox storage adapter.

This is useful when implementing encryption schemes that have
unrecoverable states -- you can wipe the server and resetSyncStatus()
to resend everything you have.