### PR TITLE
Prepare 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,10 @@
     {
       "name": "Eric Le Lay",
       "url": "https://github.com/elelay"
+    },
+    {
+      "name": "markellisdev",
+      "url": "https://github.com/markellisdev"
     }
   ],
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinto",
-  "version": "9.0.2",
+  "version": "10.0.0",
   "description": "An Offline-First JavaScript client for Kinto.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
# Breaking changes

- Remove async/await transpilation for Firefox (#732)

# New features

- Add IDB#resetSyncStatus (#767).
- Allow ID schemae to use the record itself when generating its ID (#727).

# Bug fixes

- Update requirements and dependencies: Sinon is now 4.0.0 or greater (#760, #748, #709), ESLint is now `^4.7.2` (#759, #757, #756, #753, #749, #746, #745, #739, #734, #721), Mocha is now 4.0.0 or greater (#768), Coveralls is now 3.0.0 or greater (#766), Prettier is now 1.7.2 (#765, #762, #751, #725, #714), esdoc-importpath-plugin is now 1.0.1 (#754, #742, #722), babel-eslint is now 8.0.0 or greater (#755), esdoc itself is now 1.0.1 or greater (#741), kinto-node-test-server is now a range dependency of `^1.0.0` (#736), uglifyify is now 4.0.1 or greater (#717), chai is 4.0.1 or greater (#712) and chai-as-promised is now 7.0.0 or greater (#715).
- Move off of husky and lint-staged to pre-commit, because it works better on partial commits (see https://github.com/Kinto/kinto-admin/issues/419) (#737, #720, #719).
- docs: update docs to match explicit requirement on Node v6 or greater (#716, #730), add some information about use with WebSockets (#728), and note that we use Greenkeeper (#706).
- Fix strange test failures around 2017-10-10 (#770).
- Expose Kinto tracebacks when they occur, as we do in kinto-http (#729).
- Add a test for Firefox bug 1376618 (#726).
- Alphabetize a couple of object keys (#711).
