### PR TITLE
Fixed esdoc generation

### DIFF
--- a/esdoc.json
+++ b/esdoc.json
@@ -3,6 +3,14 @@
   "destination": "./esdoc",
   "plugins": [
     {
+      "name": "esdoc-importpath-plugin",
+      "option": {
+        "replaces": [
+          {"from": "^src", "to": "lib"}
+        ]
+      }
+    },
+    {
       "name": "esdoc-ecmascript-proposal-plugin", 
       "option": {"all": true}
     },

--- a/esdoc.json
+++ b/esdoc.json
@@ -14,11 +14,6 @@
       "name": "esdoc-ecmascript-proposal-plugin", 
       "option": {"all": true}
     },
-    {
-      "name": "esdoc-standard-plugin",
-      "options": {
-        "typeInference": {"enable": false}
-      }
-    }
+    { "name": "esdoc-publish-html-plugin" }
   ]
 }

--- a/esdoc.json
+++ b/esdoc.json
@@ -13,6 +13,9 @@
     {
       "name": "esdoc-ecmascript-proposal-plugin", 
       "option": {"all": true}
+    },
+    {
+      "name": "esdoc-node"
     }
   ]
 }

--- a/esdoc.json
+++ b/esdoc.json
@@ -5,16 +5,6 @@
     "type": "mocha",
     "source": "./test"
   },
-  "experimentalProposal": {
-    "classProperties": true,
-    "objectRestSpread": true,
-    "decorators": true,
-    "doExpressions": true,
-    "functionBind": true,
-    "asyncGenerators": true,
-    "exportExtensions": true,
-    "dynamicImport": true
-  },
   "plugins": [
     {
       "name": "esdoc-importpath-plugin",
@@ -23,6 +13,10 @@
           {"from": "^src", "to": "lib"}
         ]
       }
+    },
+    {
+      "name": "esdoc-ecmascript-proposal-plugin", 
+      "option": {"all": true}
     }
   ]
 }

--- a/esdoc.json
+++ b/esdoc.json
@@ -13,6 +13,9 @@
     {
       "name": "esdoc-ecmascript-proposal-plugin", 
       "option": {"all": true}
+    },
+    {
+      "name": "esdoc-standard-plugin"
     }
   ]
 }

--- a/esdoc.json
+++ b/esdoc.json
@@ -13,9 +13,6 @@
     {
       "name": "esdoc-ecmascript-proposal-plugin", 
       "option": {"all": true}
-    },
-    {
-      "name": "esdoc-node"
     }
   ]
 }

--- a/esdoc.json
+++ b/esdoc.json
@@ -19,5 +19,6 @@
       "option": {
         "source": "./test"
       }
+    }
   ]
 }

--- a/esdoc.json
+++ b/esdoc.json
@@ -1,10 +1,6 @@
 {
   "source": "./src",
   "destination": "./esdoc",
-  "test": {
-    "type": "mocha",
-    "source": "./test"
-  },
   "plugins": [
     {
       "name": "esdoc-importpath-plugin",
@@ -17,6 +13,11 @@
     {
       "name": "esdoc-ecmascript-proposal-plugin", 
       "option": {"all": true}
-    }
+    },
+    {
+      "name": "esdoc-integrate-test-plugin",
+      "option": {
+        "source": "./test"
+      }
   ]
 }

--- a/esdoc.json
+++ b/esdoc.json
@@ -3,14 +3,6 @@
   "destination": "./esdoc",
   "plugins": [
     {
-      "name": "esdoc-importpath-plugin",
-      "option": {
-        "replaces": [
-          {"from": "^src", "to": "lib"}
-        ]
-      }
-    },
-    {
       "name": "esdoc-ecmascript-proposal-plugin", 
       "option": {"all": true}
     },

--- a/esdoc.json
+++ b/esdoc.json
@@ -17,10 +17,7 @@
     {
       "name": "esdoc-standard-plugin",
       "options": {
-        "typeInference": {"enable": false},
-        "test": {
-          "source": "./test"
-        }
+        "typeInference": {"enable": false}
       }
     }
   ]

--- a/esdoc.json
+++ b/esdoc.json
@@ -13,6 +13,12 @@
     {
       "name": "esdoc-ecmascript-proposal-plugin", 
       "option": {"all": true}
+    },
+    {
+      "name": "esdoc-integrate-test-plugin",
+      "option": {
+        "source": "./test"
+      }
     }
   ]
 }

--- a/esdoc.json
+++ b/esdoc.json
@@ -13,12 +13,6 @@
     {
       "name": "esdoc-ecmascript-proposal-plugin", 
       "option": {"all": true}
-    },
-    {
-      "name": "esdoc-integrate-test-plugin",
-      "option": {
-        "source": "./test"
-      }
     }
   ]
 }

--- a/esdoc.json
+++ b/esdoc.json
@@ -15,7 +15,13 @@
       "option": {"all": true}
     },
     {
-      "name": "esdoc-standard-plugin"
+      "name": "esdoc-standard-plugin",
+      "options": {
+        "typeInference": {"enable": false},
+        "test": {
+          "source": "./test"
+        }
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "esdoc": "^1.0.1",
     "esdoc-importpath-plugin": "1.0.1",
     "esdoc-ecmascript-proposal-plugin": "1.0.0",
-    "esdoc-standard-plugin": "1.0.0",
     "esdoc-integrate-test-plugin": "1.0.0",
     "eslint": "^4.7.2",
     "estraverse-fb": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
     "esdoc-importpath-plugin": "1.0.1",
     "esdoc-ecmascript-proposal-plugin": "1.0.0",
     "esdoc-integrate-test-plugin": "1.0.0",
-    "esdoc-node": "1.0.2",
     "eslint": "^4.7.2",
     "estraverse-fb": "^1.3.1",
     "fake-indexeddb": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "esdoc-importpath-plugin": "1.0.1",
     "esdoc-ecmascript-proposal-plugin": "1.0.0",
     "esdoc-standard-plugin": "1.0.0",
+    "esdoc-integrate-test-plugin": "1.0.0",
     "eslint": "^4.7.2",
     "estraverse-fb": "^1.3.1",
     "fake-indexeddb": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "esdoc": "^1.0.1",
     "esdoc-importpath-plugin": "1.0.1",
     "esdoc-ecmascript-proposal-plugin": "1.0.0",
+    "esdoc-standard-plugin": "1.0.0",
     "eslint": "^4.7.2",
     "estraverse-fb": "^1.3.1",
     "fake-indexeddb": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "esdoc": "^1.0.1",
     "esdoc-importpath-plugin": "1.0.1",
     "esdoc-ecmascript-proposal-plugin": "1.0.0",
-    "esdoc-standard-plugin": "1.0.0",
+    "esdoc-publish-html-plugin": "1.1.0",
     "esdoc-integrate-test-plugin": "1.0.0",
     "eslint": "^4.7.2",
     "estraverse-fb": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "esdoc-importpath-plugin": "1.0.1",
     "esdoc-ecmascript-proposal-plugin": "1.0.0",
     "esdoc-integrate-test-plugin": "1.0.0",
-    "esdoc-node", "1.0.2",
+    "esdoc-node": "1.0.2",
     "eslint": "^4.7.2",
     "estraverse-fb": "^1.3.1",
     "fake-indexeddb": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "coveralls": "^3.0.0",
     "esdoc": "^1.0.1",
     "esdoc-importpath-plugin": "1.0.1",
+    "esdoc-ecmascript-proposal-plugin": "1.0.0",
     "eslint": "^4.7.2",
     "estraverse-fb": "^1.3.1",
     "fake-indexeddb": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "esdoc": "^1.0.1",
     "esdoc-importpath-plugin": "1.0.1",
     "esdoc-ecmascript-proposal-plugin": "1.0.0",
+    "esdoc-standard-plugin": "1.0.0",
     "esdoc-integrate-test-plugin": "1.0.0",
     "eslint": "^4.7.2",
     "estraverse-fb": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "esdoc-importpath-plugin": "1.0.1",
     "esdoc-ecmascript-proposal-plugin": "1.0.0",
     "esdoc-integrate-test-plugin": "1.0.0",
+    "esdoc-node", "1.0.2",
     "eslint": "^4.7.2",
     "estraverse-fb": "^1.3.1",
     "fake-indexeddb": "2.0.3",


### PR DESCRIPTION
See https://doc.esdoc.org/github.com/zakaluka/kinto.js/ for what is now being generated.

Had to remove the 'testing' configuration as I don't understand why it is failing.  

I've left esdoc-integrate-test-plugin as a dev dependency on the off-chance that someone knows how to integrate it into the "new" esdoc configuration file (and hosting service).