### PR TITLE
Remove IDB#resetSyncStatus

### DIFF
--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -409,47 +409,6 @@ export default class IDB extends BaseAdapter {
   }
 
   /**
-   * Reset the sync status of this collection.
-   * This is useful when a server has been wiped, for instance.
-   *
-   * This is a semi-private method that is not part of the Adapter
-   * interface. The Firefox storage adapter offers a method
-   * like this, but that method resets sync status for *all*
-   * collections, which we can't do.
-   */
-  async resetSyncStatus() {
-    await this.open();
-    const resetLastModified = new Promise((resolve, reject) => {
-      const { transaction, store } = this.prepare("readwrite", "__meta__");
-      store.delete("lastModified");
-      transaction.onerror = event => reject(event.target.error);
-      transaction.oncomplete = event => resolve();
-    });
-    const resetStatuses = new Promise((resolve, reject) => {
-      const { transaction, store } = this.prepare("readwrite");
-      createListRequest(store, undefined, undefined, {}, results => {
-        results.forEach(record => {
-          if (record._status === "deleted") {
-            // Garbage collect deleted records.
-            store.delete(record.id);
-          } else {
-            const newRecord = {
-              ...record,
-              _status: "created",
-              last_modified: undefined,
-            };
-            store.put(newRecord);
-          }
-        });
-      });
-      transaction.onerror = event => reject(new Error(event.target.error));
-      transaction.oncomplete = event => resolve();
-    });
-
-    return Promise.all([resetLastModified, resetStatuses]);
-  }
-
-  /**
    * Load a dump of records exported from a server.
    *
    * @abstract

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -490,43 +490,4 @@ describe("adapter.IDB", () => {
         .should.eventually.become(1458796543);
     });
   });
-
-  describe("#resetSyncStatus", () => {
-    it("should forget the last modified value.", () => {
-      return db
-        .saveLastModified(42)
-        .then(_ => db.resetSyncStatus())
-        .then(_ => db.getLastModified())
-        .should.eventually.become(null);
-    });
-
-    it("should clear last_modified from a record.", () => {
-      return db
-        .loadDump([
-          { id: uuid4(), title: "foo", last_modified: 1457896541 },
-          { id: uuid4(), title: "bar", last_modified: 1458796542 },
-        ])
-        .then(_ => db.resetSyncStatus())
-        .then(_ => db.list())
-        .then(records => records.map(record => record.last_modified))
-        .should.eventually.eql([undefined, undefined]);
-    });
-
-    it("should reset _status to created on updated records.", () => {
-      return db
-        .loadDump([{ id: uuid4(), title: "bar", _status: "updated" }])
-        .then(_ => db.resetSyncStatus())
-        .then(_ => db.list())
-        .then(records => records[0]._status)
-        .should.eventually.eql("created");
-    });
-
-    it("should delete records with deleted _status.", () => {
-      return db
-        .loadDump([{ id: uuid4(), title: "bar", _status: "deleted" }])
-        .then(_ => db.resetSyncStatus())
-        .then(_ => db.list())
-        .should.eventually.eql([]);
-    });
-  });
 });


### PR DESCRIPTION
Revert 3017452aca9672681c9328ec93853ce472d31faf.

It turns out that there's already a Collection#resetSyncStatus, so
IDB#resetSyncStatus just serves to confuse the user.

The place where I intended to use this, I already accidentally used
Collection#resetSyncStatus, so there truly isn't any need for this
method.

The commit that this reverts got squashed as part of #767, so the
commit ID in this commit may not exist in this repository. Instead,
see 7a23ff9b16f3f85dcc92c1d998b2faa86d367006.