### PR TITLE
Add missing `localFields` option when creating new collection

### DIFF
--- a/src/KintoBase.js
+++ b/src/KintoBase.js
@@ -103,6 +103,7 @@ export default class KintoBase {
    * @param  {Object} [options.idSchema]           IdSchema instance (default: UUID)
    * @param  {Object} [options.remoteTransformers] Array<RemoteTransformer> (default: `[]`])
    * @param  {Object} [options.hooks]              Array<Hook> (default: `[]`])
+   * @param  {Object} [options.localFields]        Array<Field> (default: `[]`])
    * @return {Collection}
    */
   collection(collName, options = {}) {
@@ -113,7 +114,7 @@ export default class KintoBase {
       ...this._options,
       ...options,
     };
-    const { idSchema, remoteTransformers, hooks } = options;
+    const { idSchema, remoteTransformers, hooks, localFields } = options;
 
     return new Collection(bucket, collName, this.api, {
       events,
@@ -123,6 +124,7 @@ export default class KintoBase {
       idSchema,
       remoteTransformers,
       hooks,
+      localFields,
     });
   }
 }

--- a/test/kintobase_test.js
+++ b/test/kintobase_test.js
@@ -1,6 +1,8 @@
 "use strict";
 
 import { expect } from "chai";
+import Api from "kinto-http";
+import { EventEmitter } from "events";
 
 import KintoBase from "../src/KintoBase.js";
 import BaseAdapter from "../src/adapters/base.js";
@@ -24,6 +26,25 @@ describe("KintoBase", () => {
       expect(() => {
         new KintoBase();
       }).to.Throw(Error, /No adapter provided/);
+    });
+  });
+
+  describe("collection options", () => {
+    let kinto;
+
+    beforeEach(() => {
+      kinto = new KintoBase({
+        adapter: KintoBase.adapters.BaseAdapter,
+        events: new EventEmitter(),
+        ApiClass: Api,
+      });
+    });
+
+    it("should pass localFields option", () => {
+      const collection = kinto.collection('my_collection', {
+        localFields: ['_myLocalField']
+      });
+      expect(collection.localFields).eql(['_myLocalField']);
     });
   });
 });


### PR DESCRIPTION
I've noticed that when creating new collection from `KintoBase` it's impossible to define `localFields` option, My change fixes it.

Example usage:
```js
const kinto = new Kinto()
const collection = kinto.collection('my_collection', {
  localFields: ['_status']
})
```