### PR TITLE
Add support for deleteAll method

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -611,6 +611,23 @@ export default class Collection {
   }
 
   /**
+   * Soft Delete all records from the local database.
+   *
+   * @return {Promise}
+   */
+  async deleteAll() {
+    const records = await this.db.list();
+    // await results.forEach( (record) => {
+    //     delete(record.id);
+    // });
+    // this._queueEvent("deleteAll", { data: [] });
+    // return { data: [], permissions: {} };
+    return this.execute(transaction => {
+      return transaction.deleteAll(records);
+    }, {});
+  }
+
+  /**
    * The same as {@link CollectionTransaction#deleteAny}, but wrapped
    * in its own transaction.
    *
@@ -1420,6 +1437,19 @@ export class CollectionTransaction {
     }
     this._queueEvent("delete", { data: existing });
     return { data: existing, permissions: {} };
+  }
+
+  /**
+   * Soft Delete all records from the local database.
+   * @param  {Object} allRecords       All the records in the collection.
+   * @return {Object}
+   */
+  deleteAll(allRecords) {
+    allRecords.forEach(record => {
+      delete record.id;
+    });
+    this._queueEvent("deleteAll", { data: [] });
+    return { data: [], permissions: {} };
   }
 
   /**

--- a/src/collection.js
+++ b/src/collection.js
@@ -617,11 +617,12 @@ export default class Collection {
    */
   async deleteAll() {
     const { data } = await this.list({}, { includeDeleted: false });
+    const recordIds = data.map(record => record.id);
     return this.execute(
       transaction => {
-        return transaction.deleteAll(data.map(record => record.id));
+        return transaction.deleteAll(recordIds);
       },
-      { preloadIds: data.map(record => record.id) }
+      { preloadIds: recordIds }
     );
   }
 

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -1183,14 +1183,22 @@ describe("Collection", () => {
     });
 
     it("should be able to soft delete all articles", () => {
-      return articles.deleteAll().then(res => {
-        res.data.forEach(record => {
-          articles
-            .get(record.id)
-            .then(res => res.data._status)
-            .should.eventually.eql("deleted");
-        });
-      });
+      return articles
+        .deleteAll()
+        .then(res => articles.list())
+        .then(res => res.data)
+        .should.eventually.have.length.of(0)
+        .then(() => articles.list({}, { includeDeleted: true }))
+        .then(res => res.data)
+        .should.eventually.have.length.of(5);
+    });
+
+    it("should not delete anything when there are no records", () => {
+      return articles
+        .clear()
+        .then(res => articles.deleteAll())
+        .then(res => res.data)
+        .should.eventually.have.length.of(0);
     });
   });
 

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2859,6 +2859,13 @@ describe("Collection", () => {
         .then(result => expect(result.data._status).eql("deleted"));
     });
 
+    it("should support deleteAll", () => {
+      articles.deleteAll();
+      articles
+        .list({ filters: { _status: "deleted" } }, { includeDeleted: true })
+        .then(result => expect(result.data._status).eql("deleted"));
+    });
+
     it("should support deleteAny", () => {
       let id;
       return articles
@@ -2997,6 +3004,11 @@ describe("Collection", () => {
     it("should emit an event on delete", done => {
       articles.events.on("delete", () => done());
       articles.delete(article.id);
+    });
+
+    it("should emit an event on deleteAll", done => {
+      articles.events.on("deleteAll", () => done());
+      articles.deleteAll();
     });
 
     it("should emit an event on deleteAny", done => {


### PR DESCRIPTION
Fixes: #556

Changes the following Files:
1. src/collection.js: Added deleteAll function in two places:
   a. As an async function inside Collections class - Takes no parameters -
   b. As a function inside CollectionTransaction class - Takes records parameter - to execute the delete transaction and emit "deleteAll" event

2. test/collection_test.js: Added two tests:
   a. Inside Events test suite to test for "deleteAll" event
   b. Inside #execute test suite to test for the soft delete
   All tests are passing.

Also ran cs-format to follow coding style and added the git pre-commit hook

Signed-off-by: Amr Gawish <amr.gawish@gmail.com>