### PR TITLE
Throw explicit error if data to migrate is found and adapter option is not set

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -10,7 +10,7 @@ This page lists the breaking API changes between major versions of Kinto.js, as 
 
 This version introduces a major change: instead of having one IndexedDB database per collection (named `{bucket}/{collection}`), we now have only one database (called `KintoDB` by default) which stores records indexed by collection.
 
-If you are upgrading and want your data to be manually migrated, set the `adapterOptions.migrateOldData` to `true` in the `Kinto()` constructor.
+If you are upgrading and want your data to be manually migrated, set the `adapterOptions.migrateOldData` to `true` in the `Kinto()` constructor, or `false` otherwise.
 The old database will also be deleted.
 
 ```js

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -8,10 +8,9 @@ This page lists the breaking API changes between major versions of Kinto.js, as 
 
 **Database Schema Change**
 
-This version introduces a major change: instead of having one IndexedDB database per collection (named `{bucket}/{collection}`), we now have only one database (called `KintoDB` by default) which stores records indexed by collection.
+This version introduces a **major change**: instead of having one IndexedDB database per collection (named `{bucket}/{collection}`), we now have only one database (called `KintoDB` by default) which stores records indexed by collection.
 
-If you are upgrading and want your data to be manually migrated, set the `adapterOptions.migrateOldData` to `true` in the `Kinto()` constructor, or `false` otherwise.
-The old database will also be deleted.
+If you are upgrading and want your data to be automatically migrated, set the `adapterOptions.migrateOldData` to `true` in the `Kinto()` constructor, or `false` otherwise. Note that the old database will also be deleted.
 
 ```js
 const db = new Kinto({

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -239,13 +239,16 @@ export default class IDB extends BaseAdapter {
     // Note: the built-in migrations from IndexedDB can only be used if the
     // database name does not change.
     const hasMigrateOption = this._options.hasOwnProperty("migrateOldData");
-    const toMigrate = this._options.migrateOldData || !hasMigrateOption
-      ? await migrationRequired(this.cid)
-      : null;
+    const toMigrate =
+      this._options.migrateOldData || !hasMigrateOption
+        ? await migrationRequired(this.cid)
+        : null;
 
     if (!!toMigrate && !hasMigrateOption) {
-      throw new Error("An old IndexedDB database was found, but the `migrateOldData` option was not set. " +
-                      "Check out ugprade notes https://kintojs.readthedocs.io/en/latest/upgrading/");
+      throw new Error(
+        "An old IndexedDB database was found, but the `migrateOldData` option was not set. " +
+          "Check out ugprade notes https://kintojs.readthedocs.io/en/latest/upgrading/"
+      );
     }
 
     this._db = await open(this.dbName, {

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -238,19 +238,9 @@ export default class IDB extends BaseAdapter {
     // Check if it exists, and migrate data once new schema is in place.
     // Note: the built-in migrations from IndexedDB can only be used if the
     // database name does not change.
-    const hasMigrateOption = this._options.hasOwnProperty("migrateOldData");
-    const dataToMigrate =
-      this._options.migrateOldData || !hasMigrateOption
-        ? await migrationRequired(this.cid)
-        : null;
-
-    if (dataToMigrate && !hasMigrateOption) {
-      throw new Error(
-        "An old IndexedDB database with data was found, but the `migrateOldData` option " +
-          "was not explicitly set. Check out upgrade notes " +
-          "https://kintojs.readthedocs.io/en/latest/upgrading/#11x-to-12x"
-      );
-    }
+    const dataToMigrate = this._options.migrateOldData
+      ? await migrationRequired(this.cid)
+      : null;
 
     this._db = await open(this.dbName, {
       version: 1,
@@ -628,11 +618,9 @@ async function migrationRequired(dbName) {
 
     // Those will be inserted in the new database/schema.
     return { records, timestamp };
-
   } catch (e) {
     console.error(e);
     return null;
-
   } finally {
     db.close();
   }

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -593,7 +593,7 @@ async function migrationRequired(dbName) {
     return null;
   }
 
-  console.warn(`${dbName}: old IDB database found."`);
+  console.warn(`${dbName}: old IndexedB database found.`);
   // Scan all records.
   let records;
   await execute(db, dbName, store => {
@@ -602,7 +602,7 @@ async function migrationRequired(dbName) {
       res => (records = res)
     );
   });
-  console.log(`${dbName}: found ${records.length} records."`);
+  console.log(`${dbName}: found ${records.length} records.`);
 
   // Check if there's a entry for this.
   let timestamp;

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -247,8 +247,8 @@ export default class IDB extends BaseAdapter {
     if (dataToMigrate && !hasMigrateOption) {
       throw new Error(
         "An old IndexedDB database with data was found, but the `migrateOldData` option " +
-          "was not explicitly set. " +
-          "Check out upgrade notes https://kintojs.readthedocs.io/en/latest/upgrading/"
+          "was not explicitly set. Check out upgrade notes " +
+          "https://kintojs.readthedocs.io/en/latest/upgrading/#11x-to-12x"
       );
     }
 

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -239,12 +239,12 @@ export default class IDB extends BaseAdapter {
     // Note: the built-in migrations from IndexedDB can only be used if the
     // database name does not change.
     const hasMigrateOption = this._options.hasOwnProperty("migrateOldData");
-    const toMigrate =
+    const dataToMigrate =
       this._options.migrateOldData || !hasMigrateOption
         ? await migrationRequired(this.cid)
         : null;
 
-    if (!!toMigrate && !hasMigrateOption) {
+    if (dataToMigrate && !hasMigrateOption) {
       throw new Error(
         "An old IndexedDB database was found, but the `migrateOldData` option was not set. " +
           "Check out ugprade notes https://kintojs.readthedocs.io/en/latest/upgrading/"
@@ -275,8 +275,8 @@ export default class IDB extends BaseAdapter {
       },
     });
 
-    if (toMigrate) {
-      const { records, timestamp } = toMigrate;
+    if (dataToMigrate) {
+      const { records, timestamp } = dataToMigrate;
       await this.loadDump(records);
       await this.saveLastModified(timestamp);
       console.log(`${this.cid}: data was migrated successfully.`);

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -238,9 +238,15 @@ export default class IDB extends BaseAdapter {
     // Check if it exists, and migrate data once new schema is in place.
     // Note: the built-in migrations from IndexedDB can only be used if the
     // database name does not change.
-    const toMigrate = this._options.migrateOldData
+    const hasMigrateOption = this._options.hasOwnProperty("migrateOldData");
+    const toMigrate = this._options.migrateOldData || !hasMigrateOption
       ? await migrationRequired(this.cid)
       : null;
+
+    if (!!toMigrate && !hasMigrateOption) {
+      throw new Error("An old IndexedDB database was found, but the `migrateOldData` option was not set. " +
+                      "Check out ugprade notes https://kintojs.readthedocs.io/en/latest/upgrading/");
+    }
 
     this._db = await open(this.dbName, {
       version: 1,

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -246,7 +246,8 @@ export default class IDB extends BaseAdapter {
 
     if (dataToMigrate && !hasMigrateOption) {
       throw new Error(
-        "An old IndexedDB database was found, but the `migrateOldData` option was not set. " +
+        "An old IndexedDB database with data was found, but the `migrateOldData` option " +
+          "was not explicitly set. " +
           "Check out ugprade notes https://kintojs.readthedocs.io/en/latest/upgrading/"
       );
     }
@@ -596,7 +597,7 @@ async function migrationRequired(dbName) {
     return null;
   }
 
-  console.warn(`${dbName}: old IndexedB database found.`);
+  console.warn(`${dbName}: old IndexedDB database found.`);
   // Scan all records.
   let records;
   await execute(db, dbName, store => {

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -248,7 +248,7 @@ export default class IDB extends BaseAdapter {
       throw new Error(
         "An old IndexedDB database with data was found, but the `migrateOldData` option " +
           "was not explicitly set. " +
-          "Check out ugprade notes https://kintojs.readthedocs.io/en/latest/upgrading/"
+          "Check out upgrade notes https://kintojs.readthedocs.io/en/latest/upgrading/"
       );
     }
 

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -652,10 +652,5 @@ describe("adapter.IDB", () => {
       const idb = new IDB("some/db", { migrateOldData: true });
       return idb.open().should.eventually.be.fulfilled;
     });
-
-    it("should throw an error if database exists and option is not set", () => {
-      const idb = new IDB("another/not-migrated");
-      return idb.open().should.eventually.be.rejectedWith("readthedocs");
-    });
   });
 });

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -640,9 +640,7 @@ describe("adapter.IDB", () => {
     });
 
     it("should not migrate if option is set to false", () => {
-      const idb = new IDB("another/not-migrated", {
-        adapterOptions: { migrateOldData: false },
-      });
+      const idb = new IDB("another/not-migrated", { migrateOldData: false });
       return idb.list().should.eventually.become([]);
     });
 

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -639,9 +639,14 @@ describe("adapter.IDB", () => {
       }).should.eventually.be.fulfilled;
     });
 
-    it("should not migrate if option is not set", () => {
-      const idb = new IDB("another/not-migrated");
+    it("should not migrate if option is set to false", () => {
+      const idb = new IDB("another/not-migrated", { adapterOptions: { migrateOldData: false } });
       return idb.list().should.eventually.become([]);
+    });
+
+    it("should throw an error if database exists and option is not set", () => {
+      const idb = new IDB("another/not-migrated");
+      return idb.open().should.eventually.be.rejectedWith("readthedocs");
     });
   });
 });

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -640,7 +640,9 @@ describe("adapter.IDB", () => {
     });
 
     it("should not migrate if option is set to false", () => {
-      const idb = new IDB("another/not-migrated", { adapterOptions: { migrateOldData: false } });
+      const idb = new IDB("another/not-migrated", {
+        adapterOptions: { migrateOldData: false },
+      });
       return idb.list().should.eventually.become([]);
     });
 

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -644,6 +644,15 @@ describe("adapter.IDB", () => {
       return idb.list().should.eventually.become([]);
     });
 
+    it("should not fail if old database is broken or incomplete", async () => {
+      await open("some/db", {
+        version: 1,
+        onupgradeneeded: event => {},
+      });
+      const idb = new IDB("some/db", { migrateOldData: true });
+      return idb.open().should.eventually.be.fulfilled;
+    });
+
     it("should throw an error if database exists and option is not set", () => {
       const idb = new IDB("another/not-migrated");
       return idb.open().should.eventually.be.rejectedWith("readthedocs");


### PR DESCRIPTION
We realized that most developers will probably upgrade without reading the release notes. 

So to avoid that, we now raise an explicit error if an old database is found and the `migrateOldData` is not explicitly set.