### PR TITLE
Fix #862: Use getAll() in IDB if no filter is set

### DIFF
--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -316,7 +316,7 @@ describe("adapter.IDB", () => {
         return callback({
           index() {
             return {
-              openCursor() {
+              getAll() {
                 throw new Error("transaction error");
               },
             };


### PR DESCRIPTION
Fix #862 

I also want to investigate the performance impact depending on the collection size (eg. 100, 1K, 10K records)