### PR TITLE
Ref #862: use getAll() with indexed fields too

### DIFF
--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -194,6 +194,13 @@ function createListRequest(cid, store, filters, done) {
     return request;
   }
 
+  // If no filters on custom attribute, get all results in one bulk.
+  if (remainingFilters.length == 0) {
+    const request = store.index(indexField).getAll(IDBKeyRange.only([cid, value]));
+    request.onsuccess = event => done(event.target.result);
+    return request;
+  }
+
   // WHERE field = value clause
   const request = store
     .index(indexField)

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -196,7 +196,9 @@ function createListRequest(cid, store, filters, done) {
 
   // If no filters on custom attribute, get all results in one bulk.
   if (remainingFilters.length == 0) {
-    const request = store.index(indexField).getAll(IDBKeyRange.only([cid, value]));
+    const request = store
+      .index(indexField)
+      .getAll(IDBKeyRange.only([cid, value]));
     request.onsuccess = event => done(event.target.result);
     return request;
   }


### PR DESCRIPTION
I realized that in #865 I could also have gone further and use `.getAll()` when no filter is used on custom field.
For example, when we gather local changes we want all records whose is status is not "sync".