### PR TITLE
Ref #870: better bulk insert for IDB loadDump()

### DIFF
--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -534,8 +534,10 @@ export default class IDB extends BaseAdapter {
   async loadDump(records) {
     try {
       await this.execute(transaction => {
+        // Since the put operations are asynchronous, we chain
+        // them together. The last one will be waited for the
+        // `transaction.oncomplete` callback.
         let i = 0;
-
         putNext();
 
         function putNext() {

--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -534,7 +534,17 @@ export default class IDB extends BaseAdapter {
   async loadDump(records) {
     try {
       await this.execute(transaction => {
-        records.forEach(record => transaction.update(record));
+        let i = 0;
+
+        putNext();
+
+        function putNext() {
+          if (i == records.length) {
+            return;
+          }
+          transaction.update(records[i]).onsuccess = putNext;
+          ++i;
+        }
       });
       const previousLastModified = await this.getLastModified();
       const lastModified = Math.max(
@@ -567,7 +577,7 @@ function transactionProxy(adapter, store, preloaded = []) {
     },
 
     update(record) {
-      store.put({ ...record, _cid });
+      return store.put({ ...record, _cid });
     },
 
     delete(id) {


### PR DESCRIPTION
Ref #870 

This doesn't entirely fix the #870 since we have another place (`Collection.importChanges()`) where the «chaining» could be leveraged. However, because we have an abstraction around storage adapters, we can't do it the same way as for loadDump.

In Gecko RemoteSettings we have a use-case where the dump contains around 1K entries. This PR should help greatly. However we have another use-case where the server contains 1K entries but no dump. For that one, the bottleneck will be in `importChanges`. I propose that we solve it in another PR after we've seen some improvements with this one. 