### PR TITLE
Prefix error messages in IndexedDB adapter

### DIFF
--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -234,7 +234,7 @@ export default class IDB extends BaseAdapter {
   }
 
   _handleError(method, err) {
-    const error = new Error(method + "() " + err.message);
+    const error = new Error(`IndexedDB ${method}() ${err.message}`);
     error.stack = err.stack;
     throw error;
   }

--- a/src/collection.js
+++ b/src/collection.js
@@ -1002,7 +1002,7 @@ export default class Collection {
     const serverChanged = unquoted > options.lastModified;
     const emptyCollection = data.length === 0;
     if (!options.exclude && localSynced && serverChanged && emptyCollection) {
-      let e = new ServerWasFlushedError(
+      const e = new ServerWasFlushedError(
         localSynced,
         unquoted,
         "Server has been flushed. Client Side Timestamp: " +

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -304,7 +304,7 @@ describe("adapter.IDB", () => {
 
     it("should prefix error encountered", () => {
       sandbox.stub(db, "open").returns(Promise.reject("error"));
-      return db.list().should.be.rejectedWith(Error, /^list()/);
+      return db.list().should.be.rejectedWith(Error, /^IndexedDB list()/);
     });
 
     it("should reject on transaction error", () => {
@@ -319,7 +319,9 @@ describe("adapter.IDB", () => {
           },
         });
       });
-      return db.list().should.be.rejectedWith(Error, "transaction error");
+      return db
+        .list()
+        .should.be.rejectedWith(Error, "IndexedDB list() transaction error");
     });
 
     it("should isolate records by collection", async () => {
@@ -436,7 +438,7 @@ describe("adapter.IDB", () => {
       });
       return db
         .importBulk([{ foo: "bar" }])
-        .should.be.rejectedWith(Error, /^importBulk()/);
+        .should.be.rejectedWith(Error, /^IndexedDB importBulk()/);
     });
   });
 


### PR DESCRIPTION
I was playing with IndexedDB, trying to punch it in the guts to see how errors would come out for real.

Since we use the error message to detect the type of error we are facing, I thought that prefixing could help us tag the ones coming from the IDB adapter.
![screenshot from 2019-02-25 13-57-37](https://user-images.githubusercontent.com/546692/53340094-65166980-3908-11e9-8999-10e77d3c7fad.png)

![screenshot from 2019-02-25 12-03-35](https://user-images.githubusercontent.com/546692/53340097-65af0000-3908-11e9-83c1-4d13f76451b2.png)
