### PR TITLE
pullMetadata does not pass auth

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -1426,7 +1426,9 @@ export default class Collection {
     const query = expectedTimestamp
       ? { query: { _expected: expectedTimestamp } }
       : undefined;
-    const metadata = await client.getData(query);
+    const metadata = await client.getData(query, {
+      headers: options.headers,
+    });
     return this.db.saveMetadata(metadata);
   }
 

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2764,6 +2764,28 @@ describe("Collection", () => {
         .should.eventually.have.length.of(3);
     });
 
+    it("should pullMetadata with options", () => {
+      const pullMetadata = sandbox.stub(articles, "pullMetadata");
+      sandbox.stub(KintoClientCollection.prototype, "listRecords").returns(
+        Promise.resolve({
+          last_modified: "42",
+          next: () => {},
+          data: [],
+        })
+      );
+      const options = {
+        headers: {
+          Authorization: "Basic 123",
+        },
+      };
+      return articles.sync(options).then(res => {
+        expect(pullMetadata.callCount).equal(1);
+        // First argument is the client, which we don't care too much about
+        // Second argument is the options
+        expect(pullMetadata.getCall(0).args[1]).include(options);
+      });
+    });
+
     it("should fetch latest changes from the server", () => {
       sandbox.stub(articles, "pullMetadata");
       const listRecords = sandbox
@@ -3234,6 +3256,28 @@ describe("Collection", () => {
           );
         })
         .then(result => expect(createdArticle.title).eql("foo"));
+    });
+  });
+
+  /** @test {Collection#pullMetadata} */
+  describe("#pullMetadata", () => {
+    let articles;
+
+    beforeEach(() => (articles = testCollection()));
+
+    it.only("passes headers to underlying client", () => {
+      const headers = {
+        Authorization: "Basic 123",
+      };
+
+      let client = {
+        getData: sandbox.stub(),
+      };
+      return articles.pullMetadata(client, { headers }).then(_ => {
+        sinon.assert.calledWithExactly(client.getData, undefined, {
+          headers,
+        });
+      });
     });
   });
 


### PR DESCRIPTION
I think this is the cause of https://bugzilla.mozilla.org/show_bug.cgi?id=1551952.

There's an underlying issue here about how options can be passed anywhere but aren't required anywhere, including headers, but fixing that is more complicated. For now, just explicitly pass headers, as is done in e.g. `pullChanges`.