### PR TITLE
Bump v12.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinto",
-  "version": "12.4.0",
+  "version": "12.4.1",
   "description": "An Offline-First JavaScript client for Kinto.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## Bug fixes

* `pullMetadata` now passes `headers`. This should fix failures in syncing where authentication appeared to "go missing" in the middle of syncing, for example https://bugzilla.mozilla.org/show_bug.cgi?id=1551952.