### PR TITLE
Fix pullMetadata really

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -1422,12 +1422,13 @@ export default class Collection {
   }
 
   async pullMetadata(client, options = {}) {
-    const { expectedTimestamp } = options;
+    const { expectedTimestamp, headers } = options;
     const query = expectedTimestamp
       ? { query: { _expected: expectedTimestamp } }
       : undefined;
-    const metadata = await client.getData(query, {
-      headers: options.headers,
+    const metadata = await client.getData({
+      ...query,
+      headers,
     });
     return this.db.saveMetadata(metadata);
   }

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -3274,7 +3274,7 @@ describe("Collection", () => {
         getData: sandbox.stub(),
       };
       return articles.pullMetadata(client, { headers }).then(_ => {
-        sinon.assert.calledWithExactly(client.getData, undefined, {
+        sinon.assert.calledWithExactly(client.getData, {
           headers,
         });
       });


### PR DESCRIPTION
The calling convention for `getData` is for everything to be in a single `options` argument. Fix this again.