### PR TITLE
Optimize sync result code

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -140,6 +140,21 @@ export class SyncResultObject {
     delete this._cached[type];
     return this;
   }
+
+  toObject() {
+    return {
+      ok: this.ok,
+      lastModified: this.lastModified,
+      errors: this.errors,
+      created: this.created,
+      updated: this.updated,
+      deleted: this.deleted,
+      skipped: this.skipped,
+      published: this.published,
+      conflicts: this.conflicts,
+      resolved: this.resolved,
+    };
+  }
 }
 
 export class ServerWasFlushedError extends Error {

--- a/src/collection.js
+++ b/src/collection.js
@@ -143,6 +143,7 @@ export class SyncResultObject {
   }
 
   toObject() {
+    // Only used in tests.
     return {
       ok: this.ok,
       lastModified: this.lastModified,

--- a/src/collection.js
+++ b/src/collection.js
@@ -30,23 +30,6 @@ export function recordsEqual(a, b, localFields = []) {
  */
 export class SyncResultObject {
   /**
-   * Object default values.
-   * @type {Object}
-   */
-  static get defaults() {
-    return {
-      errors: [],
-      created: [],
-      updated: [],
-      deleted: [],
-      published: [],
-      conflicts: [],
-      skipped: [],
-      resolved: [],
-    };
-  }
-
-  /**
    * Public constructor.
    */
   constructor() {
@@ -56,7 +39,17 @@ export class SyncResultObject {
      * @type {Boolean}
      */
     this.lastModified = null;
-    this._lists = { ...SyncResultObject.defaults };
+    this._lists = {};
+    [
+      "errors",
+      "created",
+      "updated",
+      "deleted",
+      "published",
+      "conflicts",
+      "skipped",
+      "resolved",
+    ].forEach(l => (this._lists[l] = []));
     this._cached = {};
   }
 
@@ -143,7 +136,7 @@ export class SyncResultObject {
    * @return {SyncResultObject}
    */
   reset(type) {
-    this._lists[type] = SyncResultObject.defaults[type];
+    this._lists[type] = [];
     delete this._cached[type];
     return this;
   }

--- a/src/collection.js
+++ b/src/collection.js
@@ -49,6 +49,7 @@ export class SyncResultObject {
       "conflicts",
       "skipped",
       "resolved",
+      "void",
     ].forEach(l => (this._lists[l] = []));
     this._cached = {};
   }

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -3279,7 +3279,7 @@ describe("Collection", () => {
         Authorization: "Basic 123",
       };
 
-      let client = {
+      const client = {
         getData: sandbox.stub(),
       };
       return articles.pullMetadata(client, { headers }).then(_ => {

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -2226,18 +2226,7 @@ describe("Collection", () => {
 
         return articles
           .pullChanges(client, result)
-          .then(result => ({
-            ok: result.ok,
-            lastModified: result.lastModified,
-            errors: result.errors,
-            created: result.created,
-            updated: result.updated,
-            deleted: result.deleted,
-            skipped: result.skipped,
-            published: result.published,
-            conflicts: result.conflicts,
-            resolved: result.resolved,
-          }))
+          .then(result => result.toObject())
           .should.eventually.become({
             ok: false,
             lastModified: 42,
@@ -2281,18 +2270,7 @@ describe("Collection", () => {
         return articles
           .resolve(conflict, resolution)
           .then(() => articles.pullChanges(client, syncResult))
-          .then(result => ({
-            ok: result.ok,
-            lastModified: result.lastModified,
-            errors: result.errors,
-            created: result.created,
-            updated: result.updated,
-            deleted: result.deleted,
-            skipped: result.skipped,
-            published: result.published,
-            conflicts: result.conflicts,
-            resolved: result.resolved,
-          }))
+          .then(result => result.toObject())
           .should.eventually.become({
             ok: true,
             lastModified: 42,
@@ -2329,18 +2307,7 @@ describe("Collection", () => {
       it("should resolve with solved changes", () => {
         return articles
           .pullChanges(client, result)
-          .then(result => ({
-            ok: result.ok,
-            lastModified: result.lastModified,
-            errors: result.errors,
-            created: result.created,
-            updated: result.updated,
-            deleted: result.deleted,
-            skipped: result.skipped,
-            published: result.published,
-            conflicts: result.conflicts,
-            resolved: result.resolved,
-          }))
+          .then(result => result.toObject())
           .should.eventually.become({
             ok: true,
             lastModified: 42,


### PR DESCRIPTION
Before:
https://perfht.ml/2Xthz1c

After:
https://perfht.ml/2WVRfsq

--> Time spent in `importChanges()` becomes ridiculous.