### PR TITLE
Update documentation examples with arrow functions and const

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -14,13 +14,13 @@ When there are incoming changes, we can import them to our local store using
 [`collection.importChanges()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-importChanges):
 
 ```javascript
-var pusher = new Pusher('pusherKey', {
+const pusher = new Pusher('pusherKey', {
   encrypted: true
 });
 
-var collectionName = 'tasks';
-var channelName = 'mybucket-tasks-record'; // Should match the setting `kinto.event_listeners.pusher.channel`
-var channel = pusher.subscribe(channelName);
+const collectionName = 'tasks';
+const channelName = 'mybucket-tasks-record'; // Should match the setting `kinto.event_listeners.pusher.channel`
+const channel = pusher.subscribe(channelName);
 
 channel.bind_all((evtName, data) => {
   if (evtName === 'pusher:subscription_succeeded') {
@@ -30,14 +30,14 @@ channel.bind_all((evtName, data) => {
 });
 
 function applyChanges(collectionName, evtName, data) {
-  var changes = data.map(record => record.new);
-  var timestamps = changes.map(record => ecord.last_modified)
-  var changeObj = {
+  const changes = data.map(record => record.new);
+  const timestamps = changes.map(record => ecord.last_modified)
+  const changeObj = {
     changes: changes,
     lastModified: Math.max.apply(null, timestamps)
   };
 
-  var syncResultObject = new SyncResultObject();
+  const syncResultObject = new SyncResultObject();
   tasks.importChanges(syncResultObject, changeObj);
 }
 ```

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -22,7 +22,7 @@ var collectionName = 'tasks';
 var channelName = 'mybucket-tasks-record'; // Should match the setting `kinto.event_listeners.pusher.channel`
 var channel = pusher.subscribe(channelName);
 
-channel.bind_all(function(evtName, data) {
+channel.bind_all((evtName, data) => {
   if (evtName === 'pusher:subscription_succeeded') {
     return;
   }
@@ -30,8 +30,8 @@ channel.bind_all(function(evtName, data) {
 });
 
 function applyChanges(collectionName, evtName, data) {
-  var changes = data.map(function(record) { return record.new; });
-  var timestamps = changes.map(function(record) { return record.last_modified; })
+  var changes = data.map(record => record.new);
+  var timestamps = changes.map(record => ecord.last_modified)
   var changeObj = {
     changes: changes,
     lastModified: Math.max.apply(null, timestamps)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -31,7 +31,7 @@ channel.bind_all((evtName, data) => {
 
 function applyChanges(collectionName, evtName, data) {
   const changes = data.map(record => record.new);
-  const timestamps = changes.map(record => ecord.last_modified)
+  const timestamps = changes.map(record => record.last_modified)
   const changeObj = {
     changes: changes,
     lastModified: Math.max.apply(null, timestamps)

--- a/docs/api.md
+++ b/docs/api.md
@@ -779,7 +779,7 @@ The `backoff` event notifies what's the backoff release timestamp you should wai
 ```js
 const kinto = new Kinto();
 
-kinto.events.on("backoff", function(releaseTime) {
+kinto.events.on("backoff", releaseTime => {
   const releaseDate = new Date(releaseTime).toLocaleString();
   alert(`Backed off; wait until ${releaseDate} to retry`);
 });
@@ -796,7 +796,7 @@ Triggered when an `Alert` HTTP header is received from the server, meaning that 
 ```js
 const kinto = new Kinto();
 
-kinto.events.on("deprecated", function(event) {
+kinto.events.on("deprecated", event => {
   console.log(event.message);
 });
 ```
@@ -815,7 +815,7 @@ The `event` argument contains the following information:
 const kinto = new Kinto();
 const articles = kinto.collection("articles");
 
-articles.events.on("change", function(event) {
+articles.events.on("change", event => {
   const first = event.targets[0];
   console.log(first.action);
   console.log(first.data.id);
@@ -841,7 +841,7 @@ The ``update`` event contains an additional attribute:
 const kinto = new Kinto();
 const articles = kinto.collection("articles");
 
-articles.events.on("update", function(event) {
+articles.events.on("update", event => {
   console.log(`Title was changed from "${event.oldRecord.title}" to "${event.data.title}"`);
 });
 
@@ -870,9 +870,7 @@ A transformer object is basically an object literal having and `encode` and a `d
 ```js
 import Kinto from "kinto";
 
-function update(obj1, obj2) {
-  return {...obj1, ...obj2};
-}
+const update = (obj1, obj2) => ({ ...obj1, ...obj2 });
 
 const exclamationMarkTransformer = {
   encode(record) {
@@ -1032,7 +1030,7 @@ You can define a custom ID schema on a collection by passing it to `Kinto#collec
 ```js
 import Kinto from "kinto";
 
-function createIntegerIdSchema() {
+const createIntegerIdSchema = () => ({
   generate() {
     return _next++;
   },
@@ -1040,7 +1038,7 @@ function createIntegerIdSchema() {
   validate(id) {
     return (typeof id == "number");
   }
-};
+});
 
 const kinto = new Kinto({remote: "https://my.server.tld/v1"});
 coll = kinto.collection("articles", {
@@ -1051,8 +1049,7 @@ coll = kinto.collection("articles", {
 The `generate` function can also optionally accept the record being created as an argument, allowing you to use any or all of the data to generate an ID.
 
 ```js
-function urlBase64IdSchema() {
-  return {
+const urlBase64IdSchema = () => ({
     generate(record) {
       return btoa(record.url);
     },
@@ -1060,8 +1057,7 @@ function urlBase64IdSchema() {
     validate(id) {
       return !!atob(id).match("http");
     }
-  };
-};
+});
 ```
 
 > #### Notes
@@ -1073,10 +1069,10 @@ function urlBase64IdSchema() {
 For ids chosen by your application (like "config", "last-save", etc.), you'll want a NOP id generator:
 ```js
 const nopSchema = {
-    generate: function() {
+    generate() {
         throw new Error("can't generate keys");
     },
-    validate: function(id) {
+    validate(id) {
         return true;
     }
 };

--- a/docs/api.md
+++ b/docs/api.md
@@ -121,12 +121,12 @@ undefined
 ## Updating a record
 
 ```js
-var existing = {
+const existing = {
   id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f8",
   title: "bar"
 };
 
-var updated = {...existing, title: "baz"};
+const updated = {...existing, title: "baz"};
 
 await articles.update(updated);
 ```
@@ -155,14 +155,14 @@ Result is:
 `upsert()` will create a record or replace the one that exists (equivalent to «put»).
 
 ```js
-var existing = {
+const existing = {
   id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f7",
   title: "bar"
 };
 
 await articles.upsert(existing);
 
-var updated = {...existing, title: "baz"};
+const updated = {...existing, title: "baz"};
 
 await articles.upsert(updated);
 ```
@@ -650,7 +650,7 @@ By default, kinto.js sends every record attribute stored locally.
 In order to store some field only locally, and never publish them to the server, you can provide a list of field names in the `localFields` option of `Kinto#collection`:
 
 ```js
-collection = kinto.collection("articles", {
+const collection = kinto.collection("articles", {
   localFields: ["captain", "age"]
 });
 ```
@@ -666,10 +666,10 @@ stripped = collection.cleanLocalFields(record);
 During synchronization, the collection metadata is fetched and stored in storage. It can be accessed with the ``.metadata()`` method.
 
 ```js
-collection = kinto.collection("articles");
+const collection = kinto.collection("articles");
 await collection.sync();
 
-metadata = collection.metadata();
+const metadata = collection.metadata();
 ```
 
 The result is:
@@ -883,7 +883,7 @@ const exclamationMarkTransformer = {
 };
 
 const kinto = new Kinto({remote: "https://my.server.tld/v1"});
-coll = kinto.collection("articles", {
+const coll = kinto.collection("articles", {
   remoteTransformers: [ exclamationMarkTransformer ]
 });
 ```
@@ -980,7 +980,7 @@ const exclamationMarkTransformer = {
   }
 };
 
-coll = kinto.collection("articles", {
+const coll = kinto.collection("articles", {
   remoteTransformers: [ exclamationMarkTransformer ]
 });
 ```
@@ -1000,7 +1000,7 @@ function createTitleCharTransformer(char) {
   }
 }
 
-coll = kinto.collection("articles", {
+const coll = kinto.collection("articles", {
   remoteTransformers: [
     createTitleCharTransformer("!"),
     createTitleCharTransformer("?")
@@ -1041,7 +1041,7 @@ const createIntegerIdSchema = () => ({
 });
 
 const kinto = new Kinto({remote: "https://my.server.tld/v1"});
-coll = kinto.collection("articles", {
+const coll = kinto.collection("articles", {
   idSchema: createIntegerIdSchema()
 });
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -46,8 +46,8 @@ For now, our `demo.js` file content is simply:
 
 ```js
 function main() {
-  var db = new Kinto();
-  var tasks = db.collection("tasks");
+  const db = new Kinto();
+  const tasks = db.collection("tasks");
 }
 
 window.addEventListener("DOMContentLoaded", main);
@@ -63,8 +63,8 @@ We want to listen to form submission events to add tasks into our local database
 
 ```js
 function main() {
-  var db = new Kinto();
-  var tasks = db.collection("tasks");
+  const db = new Kinto();
+  const tasks = db.collection("tasks");
 
   document.getElementById("form")
     .addEventListener("submit", async event => {
@@ -103,8 +103,8 @@ All that is great, though we badly want to render our list of tasks now. Let's d
 
 ```js
 function main() {
-  var db = new Kinto();
-  var tasks = db.collection("tasks");
+  const db = new Kinto();
+  const tasks = db.collection("tasks");
 
   document.getElementById("form")
     .addEventListener("submit", async event => {
@@ -124,14 +124,14 @@ function main() {
     });
 
   function renderTask(task) {
-    var li = document.createElement("li");
+    const li = document.createElement("li");
     li.classList.add("list-group-item");
     li.innerHTML = task.title;
     return li;
   }
 
   function renderTasks(tasks) {
-    var ul = document.getElementById("tasks");
+    const ul = document.getElementById("tasks");
     ul.innerHTML = "";
     tasks.forEach(task => {
       ul.appendChild(renderTask(task));
@@ -195,8 +195,8 @@ Our `renderTask()` function becomes:
 
 ```js
   function renderTask(task) {
-    var tpl = document.getElementById("task-tpl");
-    var li = tpl.content.cloneNode(true);
+    const tpl = document.getElementById("task-tpl");
+    const li = tpl.content.cloneNode(true);
     li.querySelector(".title").textContent = task.title;
     li.querySelector(".done").checked = task.done;
     return li;
@@ -211,11 +211,11 @@ But that's not enough. We need to listen to clicks made on the checkbox, so we c
 
 ```js
   function renderTask(task) {
-    var tpl = document.getElementById("task-tpl");
-    var li = tpl.content.cloneNode(true);
+    const tpl = document.getElementById("task-tpl");
+    const li = tpl.content.cloneNode(true);
     li.querySelector(".title").textContent = task.title;
     // retrieve a reference to the checkbox element
-    var checkbox = li.querySelector(".done");
+    const checkbox = li.querySelector(".done");
     // initialize it with task status
     checkbox.checked = task.done;
     // listen to clicks
@@ -315,7 +315,7 @@ Now back to our web page: let's add a shiny *Synchronize* button and a textarea 
 Then, update the JavaScript:
 
 ```js
-var syncOptions = {
+const syncOptions = {
   remote: "https://kinto.dev.mozaws.net/v1",
   headers: {Authorization: "Basic " + btoa("user:pass")}
 };

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -67,7 +67,7 @@ function main() {
   var tasks = db.collection("tasks");
 
   document.getElementById("form")
-    .addEventListener("submit", async function(event) {
+    .addEventListener("submit", async event => {
       event.preventDefault();
       try {
         await tasks.create({
@@ -107,7 +107,7 @@ function main() {
   var tasks = db.collection("tasks");
 
   document.getElementById("form")
-    .addEventListener("submit", async function(event) {
+    .addEventListener("submit", async event => {
       event.preventDefault();
       try {
         await tasks.create({
@@ -133,7 +133,7 @@ function main() {
   function renderTasks(tasks) {
     var ul = document.getElementById("tasks");
     ul.innerHTML = "";
-    tasks.forEach(function(task) {
+    tasks.forEach(task => {
       ul.appendChild(renderTask(task));
     });
   }
@@ -219,7 +219,7 @@ But that's not enough. We need to listen to clicks made on the checkbox, so we c
     // initialize it with task status
     checkbox.checked = task.done;
     // listen to clicks
-    checkbox.addEventListener("click", async function(event) {
+    checkbox.addEventListener("click", async event => {
       // prevent the click to actually toggle the checkbox
       event.preventDefault();
       // invert the task status
@@ -260,16 +260,16 @@ Then the JavaScript:
 
 ```js
   document.getElementById("clearCompleted")
-    .addEventListener("click", async function(event) {
+    .addEventListener("click", async event => {
       event.preventDefault();
       try {
         const res = await tasks.list();
         // Filter tasks according to their done status
-        const completed = res.data.filter(function(task) {
+        const completed = res.data.filter(task => {
           return task.done;
         });
         // Delete all completed tasks
-        await Promise.all(completed.map(function(task) {
+        await Promise.all(completed.map(task => {
           return tasks.delete(task.id);
         }));
         await render();
@@ -321,7 +321,7 @@ var syncOptions = {
 };
 
 document.getElementById("sync")
-  .addEventListener("click", async function(event) {
+  .addEventListener("click", async event => {
     event.preventDefault();
     try {
       const res = await tasks.sync(syncOptions)
@@ -464,14 +464,14 @@ Your take really. Let's take the former approach:
 
 ```js
   async function handleConflicts(conflicts) {
-    await Promise.all(conflicts.map(function(conflict) {
+    await Promise.all(conflicts.map(conflict => {
       return tasks.resolve(conflict, conflict.remote);
     }))
     return tasks.sync(syncOptions);
   }
 
   document.getElementById("sync")
-    .addEventListener("click", async function(event) {
+    .addEventListener("click", async event => {
       event.preventDefault();
       try {
         const res = tasks.sync(syncOptions)


### PR DESCRIPTION
Hi,

As promised in my previous PR, I updated documentation examples with arrow functions. I left normal `function`s when I thought it was clearer.

I also updated `var` with `const` and added `const` to some global variable declarations.

I hope you find it useful.