### PR TITLE
Keep original error name in IDB adapter

### DIFF
--- a/src/adapters/IDB.js
+++ b/src/adapters/IDB.js
@@ -239,12 +239,25 @@ function createListRequest(cid, store, filters, done) {
   return request;
 }
 
+class IDBError extends Error {
+  constructor(method, err) {
+    super(`IndexedDB ${method}() ${err.message}`);
+    this.name = err.name;
+    this.stack = err.stack;
+  }
+}
+
 /**
  * IndexedDB adapter.
  *
  * This adapter doesn't support any options.
  */
 export default class IDB extends BaseAdapter {
+  /* Expose the IDBError class publicly */
+  static get IDBError() {
+    return IDBError;
+  }
+
   /**
    * Constructor.
    *
@@ -264,9 +277,7 @@ export default class IDB extends BaseAdapter {
   }
 
   _handleError(method, err) {
-    const error = new Error(`IndexedDB ${method}() ${err.message}`);
-    error.stack = err.stack;
-    throw error;
+    throw new IDBError(method, err);
   }
 
   /**

--- a/test/adapters/IDB_test.js
+++ b/test/adapters/IDB_test.js
@@ -315,7 +315,9 @@ describe("adapter.IDB", () => {
 
     it("should prefix error encountered", () => {
       sandbox.stub(db, "open").returns(Promise.reject("error"));
-      return db.list().should.be.rejectedWith(Error, /^IndexedDB list()/);
+      return db
+        .list()
+        .should.be.rejectedWith(IDB.IDBError, /^IndexedDB list()/);
     });
 
     it("should reject on transaction error", () => {
@@ -332,7 +334,10 @@ describe("adapter.IDB", () => {
       });
       return db
         .list()
-        .should.be.rejectedWith(Error, "IndexedDB list() transaction error");
+        .should.be.rejectedWith(
+          IDB.IDBError,
+          "IndexedDB list() transaction error"
+        );
     });
 
     it("should isolate records by collection", async () => {
@@ -447,7 +452,7 @@ describe("adapter.IDB", () => {
       });
       return db
         .importBulk([{ foo: "bar" }])
-        .should.be.rejectedWith(Error, /^IndexedDB importBulk()/);
+        .should.be.rejectedWith(IDB.IDBError, /^IndexedDB importBulk()/);
     });
   });
 


### PR DESCRIPTION
I'm working on https://bugzilla.mozilla.org/show_bug.cgi?id=1617133 in Firefox, and there might be a few adjustments to do in kinto.js. So far, draft status :) 