### PR TITLE
Add compressed-size-action workflow

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,15 @@
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: preactjs/compressed-size-action@v1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          build-script: "dist"
+          compression: "brotli"


### PR DESCRIPTION
This PR adds a GitHub workflow that will report the compressed size of our bundles on each PR made from a branch in this repo. (Sadly due to the way GitHub Actions handles forks, it won't report when a PR is made from a fork. I have an idea on how we might make that a little better, but for now this is acceptable.