### PR TITLE
Replace EventEmitter with interface and make it optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,30 @@
 
 This document describes changes between each past release.
 
+## v14.0.0 (unreleased)
+
+**Breaking changes**
+
+- We've removed the automatically-included EventEmitter polyfill, making the `events` option for `Kinto` optional. You'll now need to bring your own emitter. We suggest [mitt](https://github.com/developit/mitt), but anything that conforms to the `EventEmitter` interface will do.
+
 ## v13.0.0 (2020-05-09)
 
 This release is the culmination of almost ten months of work to migrate [kinto-http.js](https://github.com/Kinto/kinto-http.js) and [kinto.js](https://github.com/Kinto/kinto.js) to TypeScript! In the process, we've modernized the build system for both libraries. For more information on what this means for you, checkout the [migration guide](https://github.com/Kinto/kinto.js/blob/master/docs/upgrading.md#12x-to-13x).
 
 **Breaking changes**
 
-* Full rewrite in TypeScript (Thanks @dstaley!)
+- Full rewrite in TypeScript (Thanks @dstaley!)
 
 **Internal changes**
 
-* Improve error wrapping of IndexedDB errors (#1205)
-* Update build scripts to support Windows (#1120)
-* removed unused variables (#1094)
-* Update documentation examples with arrow functions and const (#1084)
-* Remove timestamp from IDB instead storing null (#1082)
-* Rewrite examples with promises to async/await (#1075)
-* Replace Browserify and Babel with TypeScript and Rollup (#1061)
-* Updates api.md to have more concise code examples (#1073)
-
+- Improve error wrapping of IndexedDB errors (#1205)
+- Update build scripts to support Windows (#1120)
+- removed unused variables (#1094)
+- Update documentation examples with arrow functions and const (#1084)
+- Remove timestamp from IDB instead storing null (#1082)
+- Rewrite examples with promises to async/await (#1075)
+- Replace Browserify and Babel with TypeScript and Rollup (#1061)
+- Updates api.md to have more concise code examples (#1073)
 
 ## v12.7.0 (2019-08-28)
 

--- a/src/KintoBase.ts
+++ b/src/KintoBase.ts
@@ -1,8 +1,13 @@
-import { EventEmitter } from "events";
 import Api from "kinto-http";
 import Collection from "./collection";
 import BaseAdapter from "./adapters/base";
-import { IdSchema, RemoteTransformer, Hooks, RecordStatus } from "./types";
+import {
+  IdSchema,
+  RemoteTransformer,
+  Hooks,
+  RecordStatus,
+  Emitter,
+} from "./types";
 
 const DEFAULT_BUCKET_NAME = "default";
 const DEFAULT_REMOTE = "http://localhost:8888/v1";
@@ -11,7 +16,7 @@ const DEFAULT_RETRY = 1;
 export interface KintoBaseOptions {
   remote?: string;
   bucket?: string;
-  events?: EventEmitter;
+  events?: Emitter;
   adapter?: (
     dbName: string,
     options?: { dbName?: string; migrateOldData?: boolean }
@@ -31,7 +36,7 @@ export default class KintoBase<
 > {
   private _options: KintoBaseOptions;
   private _api: Api | null;
-  public events?: EventEmitter;
+  public events?: Emitter;
   /**
    * Provides a public access to the base adapter class. Users can create a
    * custom DB adapter by extending {@link BaseAdapter}.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from "events";
 import Api from "kinto-http";
 import BaseAdapter from "./adapters/base";
 import IDB from "./adapters/IDB";
@@ -33,7 +32,6 @@ export default class Kinto<
       ) => {
         return new Kinto.adapters.IDB<B>(dbName, options);
       },
-      events: new EventEmitter(),
     };
 
     super({ ...defaults, ...options });

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,3 +130,9 @@ export type Change<T> =
   | ConflictsChange<T>
   | SkippedChange<T>
   | VoidChange;
+
+export interface Emitter {
+  emit(type: string, event?: any): void;
+  on(type: string, handler: (event?: any) => void): void;
+  off(type: string, handler: (event?: any) => void): void;
+}

--- a/test/index_test.ts
+++ b/test/index_test.ts
@@ -63,12 +63,13 @@ describe("Kinto", () => {
       expect(new Kinto({ events }).events).to.eql(events);
     });
 
-    it("should create an events property if none passed", () => {
-      expect(new Kinto().events).to.be.an.instanceOf(EventEmitter);
+    it("should not create an events property if none passed", () => {
+      expect(new Kinto().events).to.equal(undefined);
     });
 
     it("should propagate its events property to child dependencies", () => {
-      const kinto = new Kinto();
+      const events = new EventEmitter();
+      const kinto = new Kinto({ events });
       expect(kinto.collection("x").events).eql(kinto.events);
       expect(kinto.collection("x").api.events).eql(kinto.events);
       expect(kinto.collection("x").api.http.events).eql(kinto.events);

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -2,6 +2,7 @@ import { v4 as uuid4 } from "uuid";
 import sinon from "sinon";
 import KintoServer from "kinto-node-test-server";
 import { Collection as KintoClientCollection, KintoIdObject } from "kinto-http";
+import { EventEmitter } from "events";
 import Kinto from "../src";
 import Collection, {
   recordsEqual,
@@ -133,6 +134,7 @@ describe("Integration tests", function (__test) {
     kinto = new Kinto({
       remote: TEST_KINTO_SERVER,
       headers: { Authorization: "Basic " + btoa("user:pass") },
+      events: new EventEmitter(),
     });
     tasks = kinto.collection("tasks");
     tasksTransformed = kinto.collection("tasks-transformer", {


### PR DESCRIPTION
This PR replaces our usage of EventEmitter with an interface with the following shape:

```ts
interface Emitter {
  emit(type: string, event?: any): void;
  on(type: string, handler: (event?: any) => void): void;
  off(type: string, handler: (event?: any) => void): void;
}
```

This allows the consumer to provide their own emitter, or opt not to. For users who opt to use a small emitter like [mitt](https://github.com/developit/mitt), this should result in a decently smaller bundle size.

Fixes #1301