### PR TITLE
Infrastructure updates for v14

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -8,8 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: preactjs/compressed-size-action@v1
+      - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           build-script: "dist"
           compression: "brotli"
+          minimum-change-threshold: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 This document describes changes between each past release.
 
-## v14.0.0 (unreleased)
+## v14.0.0 (2020-06-18)
+
+This version is the first version to ship with our official TypeScript types! If you run into any issues using the library in your TypeScript project, please open an issue.
 
 **Breaking changes**
 
-- We've removed the automatically-included EventEmitter polyfill, making the `events` option for `Kinto` optional. You'll now need to bring your own emitter. We suggest [mitt](https://github.com/developit/mitt), but anything that conforms to the `EventEmitter` interface will do.
+- We've removed the automatically-included EventEmitter polyfill, making the `events` option for `Kinto` optional. You'll now need to bring your own emitter if you want to subscribe to events (which is not necessary for the vast majority of functionality). We suggest [mitt](https://github.com/developit/mitt), but anything that conforms to the `EventEmitter` interface will do.
+- Both our CommonJS and bundled browser versions are now using ES2017 features. If you need to support older browsers, please ensure you're using something like Babel to transpile ES2017 to your desired target.
+
+**Bug fixes**
+
+- Fixed an issue where the emitted browser bundle referenced `global.process`, which only exists in Node environments. (#1352)
 
 ## v13.0.0 (2020-05-09)
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,20 @@
 {
   "name": "kinto",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "description": "An Offline-First JavaScript client for Kinto.",
-  "main": "lib/cjs-es5/index.js",
-  "module": "lib/esm/index.js",
+  "main": "lib/cjs/index.js",
+  "module": "lib/index.js",
   "unpkg": "dist/kinto.min.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "/lib",
+    "/dist",
+    "!/dist/test-suite.{js,js.map}"
+  ],
   "scripts": {
-    "build": "npm run build:es && npm run build:cjs-es5",
+    "build": "npm run build:es && npm run build:cjs",
     "build:es": "tsc -p .",
-    "build:cjs-es5": "tsc -p . --outDir lib/cjs-es5 --module commonjs --target es5",
+    "build:cjs": "tsc -p . --outDir lib/cjs --module commonjs --declaration false",
     "build:test-browser": "rollup --environment BROWSER_TESTING -c",
     "build-demo": "npm run dist && shx cp dist/kinto.min.js demo/kinto.min.js && shx cp dist/kinto.min.js.map demo/kinto.min.js.map",
     "compute-sri": "version=$(npm view kinto version); printf \"| Filename %-14s | Hash %-66s |\\n\" \"\" \"(for version $version)\"; printf \"|-------------------------|-------------------------------------------------------------------------|\\n\"; cd dist; for file in kinto*.js; do printf \"| %-23s | %-71s |\\n\" ${file} $(echo -n 'sha384-' && curl --silent https://unpkg.com/kinto@$version/dist/${file} | openssl dgst -sha384 -binary | openssl enc -base64); done",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,13 @@ const browserBuild = {
       format: "umd",
       name: "Kinto",
       sourcemap: true,
+      plugins: [terser()],
+    },
+    {
+      file: "dist/kinto.js",
+      format: "umd",
+      name: "Kinto",
+      sourcemap: true,
     },
   ],
   plugins: [
@@ -23,12 +30,11 @@ const browserBuild = {
       preferBuiltins: true,
     }),
     typescript({
-      target: "es5",
+      target: "es2017",
       include: ["*.ts+(|x)", "**/*.ts+(|x)", "*.js", "**/*.js"],
     }),
     builtins(),
     commonjs(),
-    terser(),
   ],
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "outDir": "./lib/esm/",
+    "outDir": "./lib/",
     "module": "esnext",
     "target": "es2017",
     "allowJs": true,
@@ -13,7 +13,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "declaration": true
   },
   "ts-node": {
     "compilerOptions": {


### PR DESCRIPTION
This PR makes a few packaging updates to support our v14 release.

- Emit TypeScript declarations
- Use ES2017 for our browser and CommonJS builds
- Only package important files for npm
- Emit non-minified version of browser bundle