### PR TITLE
Migrate Travis CI steps to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,11 @@ on:
       - master
   pull_request:
 
-name: CI
+name: Build and bundle
 jobs:
   chore:
-    name: Windows Integration Tests
-    runs-on: windows-latest
+    name: Build
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -31,8 +31,8 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
-      - name: Install Python dependencies
-        run: pip install kinto kinto-attachment
+      - name: Compile with TypeScript
+        run: npm run build
 
-      - name: Run tests
-        run: npm test
+      - name: Bundle with Rollup
+        run: npm run dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
 name: CI
 jobs:
   chore:
-    name: Windows Integration Tests
-    runs-on: windows-latest
+    name: Integration Tests
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
         run: npm ci
 
       - name: Install Python dependencies
-        run: pip install kinto kinto-attachment
+        run: pip install kinto
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,11 +4,11 @@ on:
       - master
   pull_request:
 
-name: CI
+name: Lint
 jobs:
   chore:
-    name: Windows Integration Tests
-    runs-on: windows-latest
+    name: Lint and check format
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -31,8 +31,8 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
-      - name: Install Python dependencies
-        run: pip install kinto kinto-attachment
+      - name: ESLint
+        run: npm run lint
 
-      - name: Run tests
-        run: npm test
+      - name: Prettier
+        run: npm run cs-check


### PR DESCRIPTION
This PR adds new GHA workflows to mirror what we're testing in Travis (basically a new Linux integration workflow and a workflow to check Prettier/ESLint).