### PR TITLE
Export type Collection, CollectionSyncOptions, and Conflict

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -21,6 +21,7 @@ import {
   Change,
   ConflictsChange,
   Emitter,
+  CollectionSyncOptions,
 } from "./types";
 
 const RECORD_FIELDS_TO_CLEAN = ["_status"];
@@ -1503,16 +1504,7 @@ export default class Collection<
    * @throws {Error} If an invalid remote option is passed.
    */
   async sync(
-    options: {
-      strategy?: string;
-      headers?: Record<string, string>;
-      retry?: number;
-      ignoreBackoff?: boolean;
-      bucket?: string | null;
-      collection?: string | null;
-      remote?: string | null;
-      expectedTimestamp?: string | null;
-    } = {
+    options: CollectionSyncOptions = {
       strategy: Collection.strategy.MANUAL,
       headers: {},
       retry: 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import Api from "kinto-http";
-import BaseAdapter, {
-  AbstractBaseAdapter,
-  StorageProxy,
-} from "./adapters/base";
+import BaseAdapter, { AbstractBaseAdapter } from "./adapters/base";
 import IDB from "./adapters/IDB";
-import KintoBase, { KintoBaseOptions } from "./KintoBase";
-import { RecordStatus } from "./types";
+import KintoBase from "./KintoBase";
 import { getDeepKey } from "./utils";
+
+import type { KintoBaseOptions } from "./KintoBase";
+import type { StorageProxy } from "./adapters/base";
+import type Collection from "./collection";
+import type { CollectionSyncOptions, Conflict, RecordStatus } from "./types";
 
 export default class Kinto<
   B extends { id: string; last_modified?: number; _status?: RecordStatus } = any
@@ -42,5 +43,12 @@ export default class Kinto<
   }
 }
 
-export type { StorageProxy, RecordStatus, KintoBaseOptions };
+export type {
+  StorageProxy,
+  RecordStatus,
+  KintoBaseOptions,
+  Collection,
+  CollectionSyncOptions,
+  Conflict,
+};
 export { KintoBase, BaseAdapter, AbstractBaseAdapter, getDeepKey };

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,3 +136,14 @@ export interface Emitter {
   on(type: string, handler: (event?: any) => void): void;
   off(type: string, handler: (event?: any) => void): void;
 }
+
+export interface CollectionSyncOptions {
+  strategy?: string;
+  headers?: Record<string, string>;
+  retry?: number;
+  ignoreBackoff?: boolean;
+  bucket?: string | null;
+  collection?: string | null;
+  remote?: string | null;
+  expectedTimestamp?: string | null;
+}


### PR DESCRIPTION
This PR exports the following types:

- `Collection`: The class representing a Kinto collection
- `CollectionSyncOptions`: The options provided to the `Collection.sync` method
- `Conflict`: The API response representing a conflict that occurs during a sync operation