### PR TITLE
Make omitKeys more type-safe

### DIFF
--- a/src/adapters/IDB.ts
+++ b/src/adapters/IDB.ts
@@ -262,7 +262,7 @@ function createListRequest(
   }
 
   // If no filters on custom attribute, get all results in one bulk.
-  if (remainingFilters.length === 0) {
+  if (Object.keys(remainingFilters).length === 0) {
     const request = indexStore.getAll(IDBKeyRange.only([cid, value]));
     request.onsuccess = (event: Event) =>
       done((event.target as IDBRequest).result);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,10 +134,10 @@ export function deepEqual(a: any, b: any): boolean {
  * @param  {Array}  keys       The list of keys to exclude.
  * @return {Object}            A copy without the specified keys.
  */
-export function omitKeys<T extends { [key: string]: any }>(
-  obj: T,
-  keys: string[] = []
-): Partial<T> {
+export function omitKeys<
+  T extends { [key: string]: unknown },
+  K extends string
+>(obj: T, keys: K[] = []): Omit<T, K> {
   const result = { ...obj };
   for (const key of keys) {
     delete result[key];

--- a/test/adapters/IDB_test.ts
+++ b/test/adapters/IDB_test.ts
@@ -387,6 +387,13 @@ describe("adapter.IDB", () => {
             list.should.deep.equal([]);
           });
         });
+
+        describe("combined with indexed fields", () => {
+          it("should filter list on both indexed and non-indexed columns", async () => {
+            const list = await db.list({ filters: { name: "#4", id: "4" } });
+            list.should.deep.equal([{ id: "4", name: "#4" }]);
+          });
+        });
       });
 
       describe("on indexed fields", () => {


### PR DESCRIPTION
This PR updates the signature for `omitKeys` from

```ts
export function omitKeys<
  T extends { [key: string]: any }
>(obj: T, keys: string[] = []): Partial<T>
```

to

```ts
export function omitKeys<
  T extends { [key: string]: unknown },
  K extends string
>(obj: T, keys: K[] = []): Omit<T, K>
```

After this change, the compiler detected that we were incorrectly accessing a `length` property on an object:

```
if (remainingFilters.length === 0) {
// Property 'length' does not exist on type 'Pick<{ [key: string]: any; }, number>'
```

Because JavaScript objects don't have a `length` property, I was curious how this worked. After checking test coverage, I saw that this particular statement would always evaluate to `false` given that the `remainingFilters` object never had a `length` property to check against. I believe the intent was to call `Object.keys(remainingFilters).length === 0`, so it's been updated to that.

Additionally, I added a new test case that filters on both an indexed and non-indexed field, which correctly triggers both the above if statement and the "else" condition (that is, the code below the if statement).