### PR TITLE
Run browser tests on Linux

### DIFF
--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -8,13 +8,17 @@ name: Browser Tests
 jobs:
   chore:
     name: Browser Tests
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         browser: [chrome, firefox]
 
     steps:
       - uses: actions/checkout@master
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
 
       - name: Print environment
         run: |
@@ -32,10 +36,10 @@ jobs:
       - name: Pin ChromeDriver version
         shell: pwsh
         run: |
-          $ver = Get-Content "$($env:ChromeWebDriver)\versioninfo.txt" | Out-String
-          $con = Get-Content .\intern.json | Out-String | ConvertFrom-Json
+          $ver = chromedriver --version | Out-String | Select-String -Pattern "ChromeDriver (\d+(\.\d+)+)" | % { $_.Matches.Groups[1].Value }
+          $con = Get-Content (Join-Path -Path '.' -ChildPath 'intern.json') | Out-String | ConvertFrom-Json
           $con | Add-Member -MemberType NoteProperty -Name "tunnelOptions" -Value @{drivers=@(@{name="chrome"; version=$ver.trim()})}
-          $con | ConvertTo-Json -Depth 10 | Set-Content -Path .\intern.json
+          $con | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path -Path '.' -ChildPath 'intern.json')
 
       - name: Run tests
         run: npm run test:${{ matrix.browser }}


### PR DESCRIPTION
Fixes #1466 

Firefox tests are flaky on Windows, so this PR switches to running our browser integration tests on Linux for better stability.