### PR TITLE
Merge kinto-http into kinto.js

### DIFF
--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -16,6 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
       - name: Print environment
         run: |
           node --version
@@ -24,7 +31,7 @@ jobs:
         run: npm ci
 
       - name: Install Python dependencies
-        run: pip install kinto
+        run: pip install kinto kinto-attachment
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
       - name: Print environment
         run: |
           node --version

--- a/README.md
+++ b/README.md
@@ -6,21 +6,20 @@
 
 An [Offline-First](http://offlinefirst.org/) JavaScript client for [Kinto](https://kinto.readthedocs.io/).
 
-> Note: If you're looking for a pure HTTP js client for Kinto, check out [kinto-http.js](https://github.com/Kinto/kinto-http.js).
+> Note: This library also includes a pure JS HTTP client for Kinto. You can learn more in [the docs](https://kintojs.readthedocs.io/en/latest/http/).
 
 The idea is to persist data locally in the browser by default, then synchronizing them with the server explicitly when connectivity is guaranteed:
 
 ```js
-const kinto = new Kinto({remote: "https://kinto.dev.mozaws.net/v1/"});
+const kinto = new Kinto({ remote: "https://kinto.dev.mozaws.net/v1/" });
 const posts = kinto.collection("posts");
 
 // Create and store a new post in the browser local database
-await posts.create({title: "first post"});
+await posts.create({ title: "first post" });
 
 // Publish all local data to the server, import remote changes
 await posts.sync();
 ```
-
 
 ## Documentation
 

--- a/bin/dist-fx.ts
+++ b/bin/dist-fx.ts
@@ -1,0 +1,24 @@
+import { mkdir, cp, exec, echo, cat, rm } from "shelljs";
+import { readFileSync } from "fs";
+
+function getVersionFromPackageJson(): string {
+  const pkgJson = readFileSync("package.json", "utf8");
+  const { version } = JSON.parse(pkgJson);
+  return version;
+}
+
+const rollupOutput = "dist/temp.js";
+const destination = "dist/moz-kinto-http-client.js";
+
+mkdir("-p", "dist");
+
+cp("fx-src/jsm_prefix.js", destination);
+
+const gitRev = exec("git rev-parse --short HEAD", {
+  silent: true,
+}).stdout.trim();
+const version = getVersionFromPackageJson();
+
+echo(`\n/*\n * Version ${version} - ${gitRev}\n */\n`).toEnd(destination);
+cat(rollupOutput).toEnd(destination);
+rm(rollupOutput);

--- a/blob.ts
+++ b/blob.ts
@@ -1,0 +1,5 @@
+export default function Blob(
+  dataArray: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>[]
+) {
+  return Buffer.from(dataArray[0]);
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,7 @@ const db = new Kinto(options);
 
 `options` is an object defining the following option values:
 
-- `remote`: The remote Kinto server endpoint root URL (eg. `"https://server/v1"`). Not that you *must* define a URL matching the version of the protocol the client supports, otherwise you'll get an error;
+- `remote`: The remote Kinto server endpoint root URL (eg. `"https://server/v1"`). Not that you _must_ define a URL matching the version of the protocol the client supports, otherwise you'll get an error;
 - `headers`: The default headers to pass for every HTTP request performed to the Kinto server (eg. `{"Authorization": "Basic bWF0Og=="}`);
 - `retry`: Number of retries when the server fails to process the request (default: `1`)
 - `adapter`: A function that returns the persistence layer adapter to use for saving data locally (default: `Kinto.adapters.IDB`); if you plan on writing your own adapter, you can read more about how to do so in the [Extending Kinto.js](extending.md) section.
@@ -38,7 +38,7 @@ const articles = db.collection("articles");
 
 The collection object has the following (read-only) attribute:
 
-* **lastModified**: last synchronization timestamp, `null` if never synced.
+- **lastModified**: last synchronization timestamp, `null` if never synced.
 
 > #### Notes
 >
@@ -48,7 +48,7 @@ The collection object has the following (read-only) attribute:
 ## Creating a record
 
 ```js
-await articles.create({title: "foo"});
+await articles.create({ title: "foo" });
 ```
 
 Result is:
@@ -66,7 +66,7 @@ Result is:
 > #### Notes
 >
 > - By default, record identifiers are generated locally using [UUID v4](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29);
-but you can also define a [custom ID schema](#id-schemas));
+>   but you can also define a [custom ID schema](#id-schemas));
 > - Trying to create a record with the ID of a record that already exists results in an error;
 > - As deletions are [performed virtually by default](#deleting-records), attempting at creating a record reusing the id of a virtually deleted record will fail;
 > - Detailed API documentation for `Collection#create()` is available [here](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-create).
@@ -84,9 +84,9 @@ Result:
   data: [
     {
       id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f8",
-      title: "bar"
-    }
-  ]
+      title: "bar",
+    },
+  ];
 }
 ```
 
@@ -109,7 +109,7 @@ try {
 Result:
 
 ```js
-undefined
+undefined;
 ```
 
 > #### Notes
@@ -123,10 +123,10 @@ undefined
 ```js
 const existing = {
   id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f8",
-  title: "bar"
+  title: "bar",
 };
 
-const updated = {...existing, title: "baz"};
+const updated = { ...existing, title: "baz" };
 
 await articles.update(updated);
 ```
@@ -157,12 +157,12 @@ Result is:
 ```js
 const existing = {
   id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f7",
-  title: "bar"
+  title: "bar",
 };
 
 await articles.upsert(existing);
 
-const updated = {...existing, title: "baz"};
+const updated = { ...existing, title: "baz" };
 
 await articles.upsert(updated);
 ```
@@ -189,7 +189,7 @@ Result:
 
 ## Deleting records
 
-By default, local deletion is performed *virtually*, until the collection is actually synced to the remote server.
+By default, local deletion is performed _virtually_, until the collection is actually synced to the remote server.
 
 ```js
 await articles.delete("2dcd0e65-468c-4655-8015-30c8b3a1c8f8");
@@ -203,9 +203,9 @@ Result:
     {
       id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f8",
       title: "foo",
-      _status: "deleted"
-    }
-  ]
+      _status: "deleted",
+    },
+  ];
 }
 ```
 
@@ -225,7 +225,7 @@ Result:
 
 ```js
 {
-  data: undefined
+  data: undefined;
 }
 ```
 
@@ -251,22 +251,22 @@ Result:
       id: "705b17be-e957-4c14-8f4c-86f8eaac29c0",
       title: "foo",
       rank: 2,
-      _status: "created"
+      _status: "created",
     },
     {
       id: "68e63131-3859-40cc-a4f7-b237ca179329",
       last_modified: 1432222889336,
       title: "Web page",
       rank: 3,
-      _status: "synced"
+      _status: "synced",
     },
     {
       id: "86f8baac-4d12-4957-805c-8f4c17bc29c0",
       title: "Another page",
       rank: 1,
-      _status: "created"
+      _status: "created",
     },
-  ]
+  ];
 }
 ```
 
@@ -275,13 +275,13 @@ Result:
 The `#list()` method accepts an object argument allowing to define filters and ordering:
 
 ```js
-await articles.list({filters: {_status: "created"}, order: "rank"});
+await articles.list({ filters: { _status: "created" }, order: "rank" });
 ```
 
 Filters accepts an object where a key is the column name and the property value the pattern to filter the column with. For now this pattern can be either a single value or an array of values; in the latter case, results will contain all records having the filtered column value containing any of the provided ones:
 
 ```js
-await articles.list({filters: {_status: ["created", "updated"]}});
+await articles.list({ filters: { _status: ["created", "updated"] } });
 ```
 
 > #### Notes
@@ -295,21 +295,20 @@ await articles.list({filters: {_status: ["created", "updated"]}});
 Records can be filtered using the `filters` parameter mentioning field names and their expected value:
 
 ```js
-await articles.list({filters: {unread: true}});
+await articles.list({ filters: { unread: true } });
 ```
 
 > #### Notes
 >
-> - If several fields are specified, an implicit *and* is used.
+> - If several fields are specified, an implicit _and_ is used.
 > - As mentioned in the [limitations](limitations.md) section, until [local DB indices are implemented](https://github.com/Kinto/kinto.js/issues/66), the filter is performed in memory.
-
 
 ### Sorting
 
 Records can be sorted using the `order` parameter:
 
 ```js
-await articles.list({order: "-title"});
+await articles.list({ order: "-title" });
 ```
 
 > #### Notes
@@ -331,8 +330,8 @@ const records = await articles.importBulk([
   {
     id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f8",
     title: "baz",
-    last_modified: 1432222889337
-  }
+    last_modified: 1432222889337,
+  },
 ]);
 console.log(records);
 ```
@@ -379,11 +378,14 @@ conflicts with the changes you've made as part of a transaction.
 To initiate a transaction, call `Collection#execute()` like this:
 
 ```js
-const articles = await articles.execute(txn => {
-  let article1 = txn.get(id1);
-  let article2 = txn.get(id2);
-  return [article1, article2];
-}, {preloadIds: [id1, id2]});
+const articles = await articles.execute(
+  (txn) => {
+    let article1 = txn.get(id1);
+    let article2 = txn.get(id2);
+    return [article1, article2];
+  },
+  { preloadIds: [id1, id2] }
+);
 
 console.log(articles);
 ```
@@ -404,19 +406,19 @@ Result:
 
 ```js
 [
-    {
-      data: {
-        id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f8",
-        title: "foo",
-      }
+  {
+    data: {
+      id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f8",
+      title: "foo",
     },
-    {
-      data: {
-        id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f7",
-        title: "bar",
-      }
-    }
-]
+  },
+  {
+    data: {
+      id: "2dcd0e65-468c-4655-8015-30c8b3a1c8f7",
+      title: "bar",
+    },
+  },
+];
 ```
 
 ## Authentication
@@ -435,22 +437,21 @@ const password = "my_password";
 const kinto = new Kinto({
   remote: "https://my.server.tld/v1",
   headers: {
-    Authorization: "Basic " + btoa(`${username}:${password}`)
-  }
+    Authorization: "Basic " + btoa(`${username}:${password}`),
+  },
 });
 ```
 
 You can also provide this authentication header to [`#sync()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-sync):
 
 ```js
-await kinto.collection("articles")
-  .sync({
-    headers: {Authorization: "Basic " + btoa(`${username}:${password}`)}
-  });
+await kinto.collection("articles").sync({
+  headers: { Authorization: "Basic " + btoa(`${username}:${password}`) },
+});
 // ...
 ```
 
->#### Notes
+> #### Notes
 >
 > - You're not obliged to use the `username:password` format; basically whatever unique string gets you covered.
 
@@ -470,10 +471,9 @@ const kinto = new Kinto({
 As with Basic Auth, you can pass the header to [`#sync()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-sync) as well:
 
 ```js
-await kinto.collection("articles")
-  .sync({
-    headers: {Authorization: "Basic " + oauthBearerToken}
-  });
+await kinto.collection("articles").sync({
+  headers: { Authorization: "Basic " + oauthBearerToken },
+});
 // ...
 ```
 
@@ -491,13 +491,13 @@ Synopsis:
 
 1. Fetch remote changes since last synchronization;
 2. Fail on any conflict encountered;
-    - The developer has to handle them manually using [`#resolve()`](#resolving-conflicts-manually), and call [`#sync()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-sync) again when done;
+   - The developer has to handle them manually using [`#resolve()`](#resolving-conflicts-manually), and call [`#sync()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-sync) again when done;
 3. If everything went fine, publish local changes;
-    - Fail on any publication conflict detected;
-        * If `strategy` is set to `Kinto.syncStrategy.SERVER_WINS`, no client data will overwrite the remote data;
-        * If `strategy` is set to `Kinto.syncStrategy.CLIENT_WINS`, conflicting server records will be overwritten with local changes;
-        * If `strategy` is set to `Kinto.syncStrategy.PULL_ONLY`, the local changes are never pushed, and overwritten by remote data;
-        * If `strategy` is set to `Kinto.syncStrategy.MANUAL`, both incoming and outgoing conflicts will be reported in a dedicated array.
+   - Fail on any publication conflict detected;
+     - If `strategy` is set to `Kinto.syncStrategy.SERVER_WINS`, no client data will overwrite the remote data;
+     - If `strategy` is set to `Kinto.syncStrategy.CLIENT_WINS`, conflicting server records will be overwritten with local changes;
+     - If `strategy` is set to `Kinto.syncStrategy.PULL_ONLY`, the local changes are never pushed, and overwritten by remote data;
+     - If `strategy` is set to `Kinto.syncStrategy.MANUAL`, both incoming and outgoing conflicts will be reported in a dedicated array.
 
 ```js
 try {
@@ -505,12 +505,13 @@ try {
   console.log(result);
 } catch (err) {
   if (err.response && err.response.status === 401) {
-    console.error('HTTP status code indicates auth problem');
+    console.error("HTTP status code indicates auth problem");
   }
 }
 ```
 
 > #### Notes
+>
 > - By default, it uses the collection name as the collection id on the remove server. A different name can be specified in `sync()` options.
 > - Detailed API documentation for `Collection#sync()` is available [here](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-sync).
 
@@ -518,10 +519,10 @@ try {
 
 If anything goes wrong during sync, `collection.sync()` will reject its promise with an `error` object, as follows:
 
-* If an unexpected HTTP status is received from the server, `error.response` will contain that response, for you to inspect
-    (see the example above for detecting 401 Unauthorized errors).
-* If the server is unreachable, `error.response` will be undefined, but `error.message` will equal
-    `'HTTP 0; TypeError: NetworkError when attempting to fetch resource.'`.
+- If an unexpected HTTP status is received from the server, `error.response` will contain that response, for you to inspect
+  (see the example above for detecting 401 Unauthorized errors).
+- If the server is unreachable, `error.response` will be undefined, but `error.message` will equal
+  `'HTTP 0; TypeError: NetworkError when attempting to fetch resource.'`.
 
 ### Synchronization strategies
 
@@ -533,7 +534,7 @@ For publication conflicts, the `sync()` method accepts a `strategy` option, whic
 - `Kinto.syncStrategy.PULL_ONLY`: Server data will always be preserved and local data never pushed.
 
 > Note:
-> `strategy` only applies to *outgoing* conflicts. *Incoming* conflicts will still
+> `strategy` only applies to _outgoing_ conflicts. _Incoming_ conflicts will still
 > be reported in the `conflicts` array. See [`resolving conflicts section`](#resolving-conflicts-manually).
 
 You can override default options by passing [`#sync()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-sync) a new `options` object; Kinto.js will merge these new values with the default ones:
@@ -545,8 +546,8 @@ try {
   const result = await articles.sync({
     strategy: Kinto.syncStrategy.CLIENT_WINS,
     remote: "https://alt.server.tld/v1",
-    headers: {Authorization: "Basic bWF0Og=="},
-    retry: 3
+    headers: { Authorization: "Basic bWF0Og==" },
+    retry: 3,
   });
   console.log(result);
 } catch (error) {
@@ -579,16 +580,17 @@ The synchronization result object exposes the following properties:
 
 - `ok`: The boolean status of the synchronization operation; `true` if no unresolved conflicts and no errors were encountered.
 - `lastModified`: The timestamp of the latest known successful synchronization operation (no error and no conflict encountered).
-- `conflicts`: The list of unresolved conflicts encountered during both import and export operations (see *[Resolving conflicts manually](#resolving-conflicts-manually)*);
-- `errors`:    The list of encountered errors, if any. Each error has a `type` property, which value can either be `incoming` or `outgoing` depending on which part of the sync flow it's been caught from;
-- `created`:   The list of remote records which have been successfully imported into the local database.
-- `updated`:   The list of updates with old and new record which have been successfully reflected into the local database.
-- `deleted`:   The list of remotely deleted records which have been successfully deleted as well locally.
-- `skipped`:   The list of remotely deleted records that were missing or also deleted locally.
+- `conflicts`: The list of unresolved conflicts encountered during both import and export operations (see _[Resolving conflicts manually](#resolving-conflicts-manually)_);
+- `errors`: The list of encountered errors, if any. Each error has a `type` property, which value can either be `incoming` or `outgoing` depending on which part of the sync flow it's been caught from;
+- `created`: The list of remote records which have been successfully imported into the local database.
+- `updated`: The list of updates with old and new record which have been successfully reflected into the local database.
+- `deleted`: The list of remotely deleted records which have been successfully deleted as well locally.
+- `skipped`: The list of remotely deleted records that were missing or also deleted locally.
 - `published`: The list of locally modified records (created, updated, or deleted) which have been successfully pushed to the remote server.
-- `resolved`:  The list of resolutions produced by applying the selected [strategy](#synchronization-strategies) as {accepted, rejected} objects (note that when using the default `MANUAL` strategy, this list is always empty).
+- `resolved`: The list of resolutions produced by applying the selected [strategy](#synchronization-strategies) as {accepted, rejected} objects (note that when using the default `MANUAL` strategy, this list is always empty).
 
 > #### Notes
+>
 > - Detailed API documentation for `SyncResultObject` is available [here](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~SyncResultObject.html).
 
 ## Resolving conflicts manually
@@ -611,9 +613,9 @@ The `conflicts` array is in this form:
       remote: {
         id: "233a018a-fd2b-4d39-ba85-8bf3e13d73ec",
         title: "remote title",
-      }
-    }
-  ]
+      },
+    },
+  ];
 }
 ```
 
@@ -630,9 +632,11 @@ async function sync() {
     }
 
     // If conflicts, take remote version and sync again.
-    await Promise.all(res.conflicts.map(conflict => {
-      return articles.resolve(conflict, conflict.remote);
-    }))
+    await Promise.all(
+      res.conflicts.map((conflict) => {
+        return articles.resolve(conflict, conflict.remote);
+      })
+    );
 
     return sync();
   } catch (error) {
@@ -651,7 +655,7 @@ In order to store some field only locally, and never publish them to the server,
 
 ```js
 const collection = kinto.collection("articles", {
-  localFields: ["captain", "age"]
+  localFields: ["captain", "age"],
 });
 ```
 
@@ -663,7 +667,7 @@ stripped = collection.cleanLocalFields(record);
 
 ## Collection Metadata
 
-During synchronization, the collection metadata is fetched and stored in storage. It can be accessed with the ``.metadata()`` method.
+During synchronization, the collection metadata is fetched and stored in storage. It can be accessed with the `.metadata()` method.
 
 ```js
 const collection = kinto.collection("articles");
@@ -684,11 +688,11 @@ The result is:
 
 ## Raw HTTP calls
 
-Every CRUD operations are performed locally using the *database adapter* and the HTTP calls to the remote API are performed automatically during *synchronization*.
+Every CRUD operations are performed locally using the _database adapter_ and the HTTP calls to the remote API are performed automatically during _synchronization_.
 
 However, in some situations — like setting permissions on objects or checking server capabilities — it may be useful to interact with the remote API manually.
 
-A [kinto-http.js instance](https://github.com/Kinto/kinto-http.js) is available on the Kinto object:
+A [KintoClient instance](https://kintojs.readthedocs.io/en/latest/http/) is available on the Kinto object:
 
 ```js
 const kinto = new Kinto({
@@ -706,22 +710,21 @@ On a collection, the `api` instance must be set to a bucket and a collection nam
 
 ```js
 const kinto = new Kinto({
-  bucket: "blog"
+  bucket: "blog",
 });
 const collection = kinto.collection("articles");
 
 // List records from "articles" collection in "blog" bucket:
-const { data } = await collection.api
+const { data } = await collection.api
   .bucket(collection.bucket)
   .collection(collection.name)
   .listRecords();
 // ...
 ```
 
-
 ## The case of a new/flushed server
 
-In case a pristine or [flushed](http://kinto.readthedocs.io/en/latest/configuration/settings.html?highlight=flush#activating-the-flush-endpoint) server is used against an existing local database, [`#sync()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-sync) will reject with a *«Server has been flushed»* error. That means the remote server doesn't hold any data, while your local database is marked as synchronized and probably contains records you don't want to lose.
+In case a pristine or [flushed](http://kinto.readthedocs.io/en/latest/configuration/settings.html?highlight=flush#activating-the-flush-endpoint) server is used against an existing local database, [`#sync()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-sync) will reject with a _«Server has been flushed»_ error. That means the remote server doesn't hold any data, while your local database is marked as synchronized and probably contains records you don't want to lose.
 
 So instead of wiping your local database to reflect this new remote state, you're notified about the situation with a proper error :) You'll most likely want to republish your local database to the server; this is very easy to achieve by calling [`#resetSyncStatus()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-resetSyncStatus), then [`#sync()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-sync) again:
 
@@ -747,7 +750,7 @@ When this happens, Kinto.js will reject calls to [`#sync()`](https://doc.esdoc.o
 While not necessarily recommended, if you ever want to bypass this restriction, you can pass the `ignoreBackoff` option set to `true`:
 
 ```js
-await articles.sync({ignoreBackoff: true});
+await articles.sync({ ignoreBackoff: true });
 // ...
 ```
 
@@ -757,18 +760,15 @@ await articles.sync({ignoreBackoff: true});
 
 Using the `events` property you can subscribe to public events from a `Kinto` instance. The `events` property implements the [EventEmitter interface](https://nodejs.org/api/events.html#events_class_eventemitter).
 
-
 #### The `sync:success` and `sync:error` events
 
 Triggered on [`#sync()`](https://doc.esdoc.org/github.com/Kinto/kinto.js/class/src/collection.js~Collection.html#instance-method-sync) call, whether it succeeds or not.
-
 
 #### The `retry-after` event
 
 Triggered when a `Retry-After` HTTP header has been received from the last received response from the server, meaning clients should retry the same request after the specified amount of time.
 
-> Note: With *kinto-http.js* 2.7 and above, the requests are transparently retried. This event is thus only useful for tracking such situations.
-
+> Note: With _kinto.js_ 8.0.0 and above, the requests are transparently retried. This event is thus only useful for tracking such situations.
 
 #### The `backoff` event
 
@@ -779,7 +779,7 @@ The `backoff` event notifies what's the backoff release timestamp you should wai
 ```js
 const kinto = new Kinto();
 
-kinto.events.on("backoff", releaseTime => {
+kinto.events.on("backoff", (releaseTime) => {
   const releaseDate = new Date(releaseTime).toLocaleString();
   alert(`Backed off; wait until ${releaseDate} to retry`);
 });
@@ -796,7 +796,7 @@ Triggered when an `Alert` HTTP header is received from the server, meaning that 
 ```js
 const kinto = new Kinto();
 
-kinto.events.on("deprecated", event => {
+kinto.events.on("deprecated", (event) => {
   console.log(event.message);
 });
 ```
@@ -815,7 +815,7 @@ The `event` argument contains the following information:
 const kinto = new Kinto();
 const articles = kinto.collection("articles");
 
-articles.events.on("change", event => {
+articles.events.on("change", (event) => {
   const first = event.targets[0];
   console.log(first.action);
   console.log(first.data.id);
@@ -826,26 +826,27 @@ articles.delete(recordId);
 
 #### Per action event
 
-Atomic events are sent for ``create``, ``update`` and ``delete``.
+Atomic events are sent for `create`, `update` and `delete`.
 
 Every event contains the following attributes:
 
-- ``data``: the record that was created, updated or deleted
+- `data`: the record that was created, updated or deleted
 
-The ``update`` event contains an additional attribute:
+The `update` event contains an additional attribute:
 
-- ``oldRecord``: the previous version of the updated record.
-
+- `oldRecord`: the previous version of the updated record.
 
 ```js
 const kinto = new Kinto();
 const articles = kinto.collection("articles");
 
-articles.events.on("update", event => {
-  console.log(`Title was changed from "${event.oldRecord.title}" to "${event.data.title}"`);
+articles.events.on("update", (event) => {
+  console.log(
+    `Title was changed from "${event.oldRecord.title}" to "${event.data.title}"`
+  );
 });
 
-articles.upsert({id, title: "Holà!"});
+articles.upsert({ id, title: "Holà!" });
 ```
 
 > #### Notes
@@ -854,12 +855,11 @@ articles.upsert({id, title: "Holà!"});
 > - The `deleteAny()` does not fire any event if the record does not exist;
 > - A transaction will fire as many atomic events as executed operations.
 
-
 ## Transformers
 
 Transformers are basically hooks for encoding and decoding records, which can work synchronously or asynchronously.
 
-For now, only *remote transformers* and *hooks* have been implemented, but there are plans to implement local transformers in a next version.
+For now, only _remote transformers_ and _hooks_ have been implemented, but there are plans to implement local transformers in a next version.
 
 ### Remote transformers
 
@@ -874,17 +874,17 @@ const update = (obj1, obj2) => ({ ...obj1, ...obj2 });
 
 const exclamationMarkTransformer = {
   encode(record) {
-    return update(record, {title: record.title + "!"});
+    return update(record, { title: record.title + "!" });
   },
 
   decode(record) {
-    return update(record, {title: record.title.slice(0, -1)});
-  }
+    return update(record, { title: record.title.slice(0, -1) });
+  },
 };
 
-const kinto = new Kinto({remote: "https://my.server.tld/v1"});
+const kinto = new Kinto({ remote: "https://my.server.tld/v1" });
 const coll = kinto.collection("articles", {
-  remoteTransformers: [ exclamationMarkTransformer ]
+  remoteTransformers: [exclamationMarkTransformer],
 });
 ```
 
@@ -899,7 +899,7 @@ const coll = kinto.collection("articles", {
 Calling `coll.sync()` here will store encoded records on the server; when pulling for changes, the client will decode remote data before importing them, so you're always guaranteed to have the local database containing data in clear:
 
 ```js
-await coll.create({title: "foo"});
+await coll.create({ title: "foo" });
 await coll.sync();
 // remotely saved:
 // {id: "125b3bff-e80f-4823-8b8f-bfae10bfc3e8", title: "foo!"}
@@ -921,9 +921,9 @@ const transformer = {
     if (record._status == "deleted") {
       if (record.title.includes("preserve-on-send")) {
         if (record.last_modified) {
-          return {...record, _status: "updated", wasDeleted: true};
+          return { ...record, _status: "updated", wasDeleted: true };
         }
-        return {...record, _status: "created", wasDeleted: true};
+        return { ...record, _status: "created", wasDeleted: true };
       }
     }
     return record;
@@ -933,10 +933,10 @@ const transformer = {
     // server with `wasDeleted` so that we know they're
     // supposed to be deleted on the client.
     if (record.wasDeleted) {
-      return {...record, deleted: true};
+      return { ...record, deleted: true };
     }
     return record;
-  }
+  },
 };
 ```
 
@@ -950,6 +950,7 @@ In order for this to work:
 There are two possible transformations like this: local deletes become remote keeps, or local keeps become remote deletes. Remote deletes cause Kinto to delete the record, and subsequently Kinto will only serve a tombstone which doesn't have any information besides an ID and a "deleted" flag. Because decoding anything useful out of a tombstone is impossible, we don't support transforming local keeps into remote deletes.
 
 > #### Notes
+>
 > - Once a local delete is "sent", the locally-deleted record will be deleted for real, so you can't really keep information in a locally deleted record.
 > - This feature might be useful to avoid "leaking" the fact that a record was deleted in an encryption scheme.
 
@@ -964,24 +965,24 @@ Transformers can also work asynchronously by returning a [Promise](https://devel
 ```js
 const exclamationMarkTransformer = {
   encode(record) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       setTimeout(() => {
-        resolve(update(record, {title: record.title + "!"}));
+        resolve(update(record, { title: record.title + "!" }));
       }, 10);
     });
   },
 
   decode(record) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       setTimeout(() => {
-        resolve(update(record, {title: record.title.slice(0, -1)}));
+        resolve(update(record, { title: record.title.slice(0, -1) }));
       }, 10);
     });
-  }
+  },
 };
 
 const coll = kinto.collection("articles", {
-  remoteTransformers: [ exclamationMarkTransformer ]
+  remoteTransformers: [exclamationMarkTransformer],
 });
 ```
 
@@ -1036,13 +1037,13 @@ const createIntegerIdSchema = () => ({
   },
 
   validate(id) {
-    return (typeof id == "number");
-  }
+    return typeof id == "number";
+  },
 });
 
-const kinto = new Kinto({remote: "https://my.server.tld/v1"});
+const kinto = new Kinto({ remote: "https://my.server.tld/v1" });
 const coll = kinto.collection("articles", {
-  idSchema: createIntegerIdSchema()
+  idSchema: createIntegerIdSchema(),
 });
 ```
 
@@ -1050,13 +1051,13 @@ The `generate` function can also optionally accept the record being created as a
 
 ```js
 const urlBase64IdSchema = () => ({
-    generate(record) {
-      return btoa(record.url);
-    },
+  generate(record) {
+    return btoa(record.url);
+  },
 
-    validate(id) {
-      return !!atob(id).match("http");
-    }
+  validate(id) {
+    return !!atob(id).match("http");
+  },
 });
 ```
 
@@ -1067,18 +1068,19 @@ const urlBase64IdSchema = () => ({
 > - In a real application, you want to make sure you do not generate twice the same record ID on a collection. This dummy example doesn't take care of ID unicity. In case of ID conflict you may loose data.
 
 For ids chosen by your application (like "config", "last-save", etc.), you'll want a NOP id generator:
+
 ```js
 const nopSchema = {
-    generate() {
-        throw new Error("can't generate keys");
-    },
-    validate(id) {
-        return true;
-    }
+  generate() {
+    throw new Error("can't generate keys");
+  },
+  validate(id) {
+    return true;
+  },
 };
-const kinto = new Kinto({remote: "https://my.server.tld/v1"});
+const kinto = new Kinto({ remote: "https://my.server.tld/v1" });
 coll = kinto.collection("articles", {
-  idSchema: nopSchema
+  idSchema: nopSchema,
 });
 ```
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -1,0 +1,1593 @@
+# Kinto HTTP Client
+
+`kinto` comes with a fully-featured Kinto HTTP client that powers all interactions with a Kinto instance.
+
+## Requirements
+
+- Kinto server v6.0.0+
+
+## Installation
+
+In the browser, you can load prebuilt scripts hosted on unpkg:
+
+- [kinto.min.js](https://unpkg.com/kinto/dist/kinto.min.js)
+
+```html
+<script src="https://unpkg.com/kinto/dist/kinto.min.js"></script>
+```
+
+From npm:
+
+```
+$ npm install kinto --save
+```
+
+**Note:** If you plan to use the HTTP client from `kinto` in Node (as opposed to the browser), you'll also need to install polyfills for `fetch`, `FormData`, and `btoa`.
+
+```
+$ npm install node-fetch form-data btoa
+```
+
+Then (ES6):
+
+```js
+import { KintoClient } from "kinto";
+```
+
+Or (ES5):
+
+```js
+var { KintoClient } = require("kinto");
+```
+
+Note that this HTTP client can be transparently used server side or in a regular browser page. In the browser, creating an instance is achieved with the following:
+
+```js
+const client = new KintoClient("http://");
+```
+
+## Changelog
+
+See [upgrading docs](#upgrading) and the full [detailed changelog on Github](https://github.com/Kinto/kinto.js/releases).
+
+## Usage
+
+A client instance is created using the `KintoClient` constructor, passing it the remote Kinto server root URL, including the version:
+
+```js
+const client = new KintoClient("https://demo.kinto-storage.org/v1");
+```
+
+#### Options
+
+- `safe`: Adds concurrency headers to every requests. (default: `false`)
+- `events`: The events handler. If none provided an `EventEmitter` instance will be created
+- `headers`: The key-value headers to pass to each request. (default: `{}`)
+- `retry`: Number of retries to make when the server responds with a `Retry-After` response. (default: `0`)
+- `bucket`: The default bucket to use. (default: `"default"`)
+- `requestMode`: The HTTP [CORS](https://fetch.spec.whatwg.org/#concept-request-mode) mode. (default: `"cors"`)
+- `timeout`: The requests timeout in milliseconds. (default: `null`, which means "no timeout")
+
+## Authentication
+
+Authenticating against a Kinto server can be achieved by adding an `Authorization` header to the request.
+
+By default Kinto server supports Basic Auth authentication, but others mechanisms can be activated such as OAuth (eg. [Firefox Account](https://accounts.firefox.com/))
+
+### Using Basic Auth
+
+Simply provide an `Authorization` header option to the `Kinto` constructor:
+
+```js
+const secretString = `${username}:${password}`;
+const kinto = new KintoClient("https://my.server.tld/v1", {
+  headers: {
+    Authorization: "Basic " + btoa(secretString),
+  },
+});
+```
+
+> #### Notes
+>
+> - As explained in the [server docs](http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html#basic-auth), any string is accepted. You're not obliged to use the `username:password` format.
+
+### Using an OAuth Bearer Token
+
+As for Basic Auth, once you have retrieved a valid OAuth Bearer Token, simply pass it in an `Authorization` header:
+
+```js
+const kinto = new KintoClient("https://my.server.tld/v1", {
+  headers: {
+    Authorization: `Bearer ` + oauthBearerToken)
+  }
+});
+```
+
+### Change headers
+
+Requests headers can be altered using `setHeaders()`.
+
+```js
+const kinto = new KintoClient("https://my.server.tld/v1");
+
+// Login somewhere...
+// [...]
+
+kinto.setHeaders({
+  Authorization: `Bearer ` + accessToken,
+});
+```
+
+## Server information
+
+A Kinto server exposes some of its internal settings, information about authenticated user, the HTTP API version and the API capabilities (e.g. plugins).
+
+```js
+const info = await client.fetchServerInfo([options]);
+```
+
+Sample result:
+
+```js
+{
+    "project_name": "kinto",
+    "project_version": "3.0.2",
+    "url": "http://0.0.0.0:8889/v1/",
+    "project_docs": "https://kinto.readthedocs.io/",
+    "http_api_version": "1.6",
+    "settings": {
+        "batch_max_requests": 25,
+        "readonly": false
+    },
+    "user": {
+        "bucket": "2f9b1aaa-552d-48e8-1b78-371dd08688b3",
+        "id": "basicauth:f505765817a6b4ea46278be0620ddedd83b10f71f7695683719fe001cf0871d7"
+    },
+    "capabilities": {
+        "default_bucket": {
+            "description": "The default bucket is an alias for a personal bucket where collections are created implicitly.",
+            "url": "http://kinto.readthedocs.io/en/latest/api/1.x/buckets.html#personal-bucket-default"
+        }
+    }
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+#### Helpers
+
+- `fetchServerSettings([options])`: server settings
+- `fetchServerCapabilities([options])`: API capabilities
+- `fetchUser()`: authenticated user information
+- `fetchHTTPApiVersion([options])`: HTTP API version
+
+## Buckets
+
+### Listing buckets
+
+```js
+const { data } = await client.listBuckets([options]);
+```
+
+Sample result:
+
+```js
+{
+  data: [
+    {
+      id: "comments",
+      last_modified: 1456182233221,
+    },
+    {
+      id: "blog",
+      last_modified: 1456181213214,
+    },
+  ];
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+This method accepts the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
+
+### Creating a new bucket
+
+```js
+const result = await client.createBucket("blog"[, options]);
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456182233221,
+    "id": "blog"
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+    ]
+  }
+}
+```
+
+It's alternatively possible to create a bucket without specifying an `id`, so the
+Kinto server will create one for you:
+
+```js
+const result = await client.createBucket();
+```
+
+Note: if you plan on providing options along id autogeneration, you have to specify
+`null` as the first argument:
+
+```js
+const result = await client.createBucket(null, { data: { foo: 42 }, retry: 3 });
+```
+
+#### Options
+
+- `data`: Arbitrary data to attach to the bucket
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: Whether to override existing resource if it already exists (default: `false`)
+
+### Selecting a bucket
+
+```js
+client.bucket("blog");
+```
+
+### Getting bucket data
+
+```js
+const result = await client.bucket("blog").getData();
+```
+
+Sample result:
+
+```js
+{
+  "last_modified": 1456182336242,
+  "id": "blog",
+  "foo": "bar"
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+This method accepts the [generic parameters for singular operations](#generic-options-for-singular-operations).
+
+### Setting bucket data
+
+```js
+const result = await client.bucket("blog").setData({ foo: "bar" });
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456182336242,
+    "id": "blog",
+    "foo": "bar"
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+    ]
+  }
+}
+```
+
+#### Options
+
+- `patch`: Patches existing bucket data instead of replacing them (default: `false`)
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: Whether to override existing resource if it already exists (default: `false`)
+
+### Getting bucket permissions
+
+```js
+const result = client.bucket("blog").getPermissions();
+```
+
+Sample result:
+
+```js
+{
+  "write": [
+    "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+  ]
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+### Setting bucket permissions
+
+```js
+const permissions = {
+  read:  ["github:bob"],
+  write: ["github:bob", "github:john"]
+};
+
+const result = await client.bucket("blog").setPermissions(permissions[, options]);
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456182888466,
+    "id": "blog"
+  },
+  "permissions": {
+    "read": ["github:bob"],
+    "write": [
+      "github:bob",
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8",
+      "github:john"
+    ]
+  }
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: If `last_modified` is provided, ensures the resource hasn't been modified since that timestamp. Otherwise ensures no existing resource with the provided id will be overriden (default: `false`);
+- `last_modified`: The last timestamp we know the resource has been updated on the server.
+
+#### Notes
+
+- This operation replaces any previously set permissions;
+- Owners will always keep their `write` permission bit, as per the Kinto protocol.
+
+### Deleting a bucket
+
+```js
+const result = await client.deleteBucket("testbucket"[, options]);
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "deleted": true,
+    "last_modified": 1456182931974,
+    "id": "blog"
+  }
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: Ensures the resource hasn't been modified in the meanwhile if `last_modified` is provided (default: `false`)
+- `last_modified`: The last timestamp we know the resource has been updated on the server
+
+### Creating a collection
+
+#### Named collection
+
+```js
+const result = await client.bucket("blog").createCollection("posts");
+```
+
+Sample result:
+
+```js
+
+{
+  "data": {
+    "last_modified": 1456183004372,
+    "id": "posts"
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+    ]
+  }
+}
+```
+
+#### With an ID generated automatically
+
+```js
+const result = await client.bucket("blog").createCollection();
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456183040592,
+    "id": "OUh5VEDa"
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+    ]
+  }
+}
+```
+
+Note that `OUh5VEDa` is the collection ID automatically generated by the server.
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: Whether to override existing resource if it already exists (default: `false`)
+
+> Note: For generated names, options can be specified only if the first parameters are provided: `createCollection(undefined, {safe: true})`
+
+### Listing bucket collections
+
+```js
+const { data } = await client.bucket("blog").listCollections();
+```
+
+Sample result:
+
+```js
+{
+  data: [
+    {
+      last_modified: 1456183153840,
+      id: "posts",
+    },
+    {
+      last_modified: 1456183159386,
+      id: "comments",
+    },
+  ];
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+This method accepts the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
+
+### Collections list timestamp
+
+The timestamp of the collections list is used for the `since` option in the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
+
+```js
+const result = await client.bucket("blog").getCollectionsTimestamp();
+```
+
+Sample result:
+
+```js
+"1548699177099";
+```
+
+#### Options
+
+- `headers`: custom headers object to send along the HTTP request
+- `retry`: number of retries when request fails (default: 0)
+
+### Deleting a collection
+
+```js
+const result = await client.bucket("blog").deleteCollection("test");
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "deleted": true,
+    "last_modified": 1456183116571,
+    "id": "posts"
+  }
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: Ensures the resource hasn't been modified in the meanwhile if `last_modified` is provided (default: `false`)
+- `last_modified`: The last timestamp we know the resource has been updated on the server
+
+### Creating a user group
+
+Kinto has a concept of groups of users. A group has a list of members and belongs to a bucket.
+
+Permissions can refer to the group instead of an individuals - this makes it easy to define «roles», especially if the same set of permissions is applied to several objects.
+
+When used in permissions definitions, the full group URI has to be used:
+
+```js
+    {
+      data: {
+        title: "My article"
+      },
+      permissions: {
+        write: ["/buckets/blog/groups/authors", "github:lili"],
+        read: ["system.Everyone"]
+      }
+    }
+```
+
+#### Named group
+
+```js
+const result = await client.bucket("blog").createGroup("admins");
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456183004372,
+    "id": "admins",
+    "members": []
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+    ]
+  }
+}
+```
+
+#### With a list of members and attributes
+
+```js
+const result = await client
+  .bucket("blog")
+  .createGroup("admins", ["system.Authenticated"], { data: { pi: 3.14 } });
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456183004372,
+    "id": "admins",
+    "members": ["system.Authenticated"],
+    "pi": 3.14
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+    ]
+  }
+}
+```
+
+#### With an ID generated automatically
+
+```js
+const result = await client.bucket("blog").createGroup();
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456183040592,
+    "members": [],
+    "id": "7YHFF565"
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+    ]
+  }
+}
+```
+
+Note that `7YHFF565` is the group ID automatically generated by the server.
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: Whether to override existing resource if it already exists (default: `false`)
+- `data`: Extra group attributes
+- `permissions`: Permissions to be set on the created group
+
+> Note: For generated names, options can be specified only if the first parameters are provided: `createGroup(undefined, [], {safe: true})`
+
+### Listing bucket groups
+
+```js
+const { data } = await client.bucket("blog").listGroups();
+```
+
+Sample result:
+
+```js
+{
+  "data": [
+    {
+      "last_modified": 1456183153840,
+      "id": "admins",
+      "members": ["system.Authenticated"],
+      "pi": 3.14
+    },
+    {
+      "last_modified": 1456183159386,
+      "id": "moderators",
+      "members": ["github:lili"]
+    }
+  ]
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+This method accepts the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
+
+### Groups list timestamp
+
+The timestamp of the groups list is used for the `since` option in the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
+
+```js
+const result = await client.bucket("blog").getGroupsTimestamp();
+```
+
+Sample result:
+
+```js
+"1548699177099";
+```
+
+#### Options
+
+- `headers`: custom headers object to send along the HTTP request
+- `retry`: number of retries when request fails (default: 0)
+
+### Getting a bucket group
+
+```js
+const { data } = await client.bucket("blog").getGroup("admins");
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+      "last_modified": 1456183153840,
+      "id": "admins",
+      "members": ["system.Authenticated"],
+      "pi": 3.14
+  }
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+This method accepts the [generic parameters for singular operations](#generic-options-for-singular-operations).
+
+### Updating an existing group
+
+```js
+const updated = {
+  id: "cb0f7b2b-e78f-41a8-afad-92a56f8c88db",
+  members: ["system.Everyone", "github:lili"],
+  pi: 3.141592,
+};
+
+const result = await client
+  .bucket("blog")
+  .updateGroup(updated, { permissions: { write: ["fxa:35478"] } });
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456183778891,
+    "id": "cb0f7b2b-e78f-41a8-afad-92a56f8c88db",
+    "members": ["system.Everyone", "github:lili"],
+    "pi": 3.141592
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8",
+      "fxa:35478"
+    ]
+  }
+}
+```
+
+#### Options
+
+- `patch`: Patches the existing record instead of replacing it (default: `false`)
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: If `last_modified` is provided, ensures the resource hasn't been modified since that timestamp. Otherwise ensures no existing resource with the provided id will be overriden (default: `false`)
+- `permissions`: Permissions to be set on the group
+
+### Deleting a group
+
+```js
+const result = await client.bucket("blog").deleteGroup("admins");
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "deleted": true,
+    "last_modified": 1456183116571,
+    "id": "admins"
+  }
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: Ensures the resource hasn't been modified in the meanwhile if `last_modified` is provided (default: `false`)
+- `last_modified`: The last timestamp we know the resource has been updated on the server
+
+### Listing bucket history
+
+```js
+const { data } = await client.bucket("blog").listHistory();
+```
+
+Sample result:
+
+```js
+{
+  "data": [
+    {
+      "action": "update",
+      "collection_id": "articles",
+      "date": "2016-07-20T11:18:36.530281",
+      "id": "cb98ecd7-a66f-4f9d-82c5-73d06930f4f2",
+      "last_modified": 1469006316530,
+      "record_id": "b3b76c56-b6df-4195-8189-d79da4a128e1",
+      "resource_name": "record",
+      "target": {
+          "data": {
+              "id": "b3b76c56-b6df-4195-8189-d79da4a128e1",
+              "last_modified": 1469006316529,
+              "title": "Modified title"
+          },
+          "permissions": {
+              "write": [
+                  "basicauth:43181ac0ae7581a23288c25a98786ef9db86433c62a04fd6071d11653ee69089"
+              ]
+          }
+      },
+      "timestamp": 1469006098757,
+      "uri": "/buckets/blog/collections/articles/records/b3b76c56-b6df-4195-8189-d79da4a128e1",
+      "user_id": "basicauth:43181ac0ae7581a23288c25a98786ef9db86433c62a04fd6071d11653ee69089",
+    }
+  ]
+}
+
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+This method accepts the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
+
+## Collections
+
+### Selecting a collection
+
+```js
+const posts = client.bucket("blog").collection("posts");
+```
+
+### Getting collection data
+
+```js
+const result = await client.bucket("blog").collection("posts").getData();
+```
+
+Sample result:
+
+```js
+{
+  "last_modified": 1456183561206,
+  "id": "posts",
+  "preferedAuthor": "@chucknorris"
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+This method accepts the [generic parameters for singular operations](#generic-options-for-singular-operations).
+
+### Setting collection data
+
+```js
+const result = await client
+  .bucket("blog")
+  .collection("posts")
+  .setData({ preferedAuthor: "@chucknorris" });
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456183561206,
+    "id": "posts",
+    "preferedAuthor": "@chucknorris"
+  },
+  "permissions": {
+    "write": [
+      "github:bob",
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8",
+      "github:john"
+    ]
+  }
+}
+```
+
+#### Options
+
+- `patch`: Patches the existing data instead of replacing them (default: `false`)
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: If `last_modified` is provided, ensures the resource hasn't been modified since that timestamp. Otherwise ensures no existing resource with the provided id will be overriden (default: `false`)
+- `last_modified`: The last timestamp we know the resource has been updated on the server
+
+### Getting collection permissions
+
+```js
+const result = await client.bucket("blog").collection("posts").getPermissions();
+```
+
+Sample result:
+
+```js
+{
+  "write": [
+    "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8",
+  ]
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+### Setting collection permissions
+
+```js
+const result = await client
+  .bucket("blog")
+  .collection("posts")
+  .setPermissions({
+    read: ["github:bob"],
+    write: ["github:john", "github:bob"],
+  });
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "last_modified": 1456183508926,
+    "id": "posts"
+  },
+  "permissions": {
+    "read": ["github:bob"],
+    "write": [
+      "github:bob",
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8",
+      "github:john"
+    ]
+  }
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: If `last_modified` is provided, ensures the resource hasn't been modified since that timestamp. Otherwise ensures no existing resource with the provided id will be overriden (default: `false`)
+- `last_modified`: The last timestamp we know the resource has been updated on the server.
+
+#### Notes
+
+- This operation replaces any previously set permissions;
+- Owners will always keep their `write` permission bit, as per the Kinto protocol.
+
+### Creating a new record
+
+```js
+const result = await client
+  .bucket("blog")
+  .collection("posts")
+  .createRecord({ title: "My first post", content: "Hello World!" });
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "content": "Hello World!",
+    "last_modified": 1456183657846,
+    "id": "cb0f7b2b-e78f-41a8-afad-92a56f8c88db",
+    "title": "My first post"
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+    ]
+  }
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request;
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: Whether to override existing resource if it already exists and if an id is provided (default: `false`)
+
+### Retrieving an existing record
+
+```js
+const result = await client
+  .bucket("blog")
+  .collection("posts")
+  .getRecord("cb0f7b2b-e78f-41a8-afad-92a56f8c88db");
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "content": "Hello World!",
+    "last_modified": 1456183657846,
+    "id": "cb0f7b2b-e78f-41a8-afad-92a56f8c88db",
+    "title": "My first post"
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+    ]
+  }
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+This method accepts the [generic parameters for singular operations](#generic-options-for-singular-operations).
+
+### Updating an existing record
+
+```js
+const updated = {
+  id: "cb0f7b2b-e78f-41a8-afad-92a56f8c88db",
+  title: "My first post, edited",
+  content: "Hello World, again!",
+};
+
+const result = await client
+  .bucket("blog")
+  .collection("posts")
+  .updateRecord(updated);
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "content": "Hello World, again!",
+    "last_modified": 1456183778891,
+    "id": "cb0f7b2b-e78f-41a8-afad-92a56f8c88db",
+    "title": "My first post, edited"
+  },
+  "permissions": {
+    "write": [
+      "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8"
+    ]
+  }
+}
+```
+
+#### Options
+
+- `patch`: Patches the existing record instead of replacing it (default: `false`)
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: If `last_modified` is provided, ensures the resource hasn't been modified since that timestamp. Otherwise ensures no existing resource with the provided id will be overriden (default: `false`);
+
+### Deleting record
+
+```js
+const result = await client
+  .bucket("blog")
+  .collection("posts")
+  .deleteRecord("cb0f7b2b-e78f-41a8-afad-92a56f8c88db");
+```
+
+Sample result:
+
+```js
+{
+  "data": {
+    "deleted": true,
+    "last_modified": 1456183877287,
+    "id": "cb0f7b2b-e78f-41a8-afad-92a56f8c88db"
+  }
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: Ensures the resource hasn't been modified in the meanwhile if `last_modified` is provided (default: `false`);
+- `last_modified`: When `safe` is true, the last timestamp we know the resource has been updated on the server.
+
+### Listing records
+
+```js
+const result = await client.bucket("blog").collection("posts").listRecords();
+```
+
+Sample result:
+
+```js
+{
+  last_modified: "1456183930780",
+  next: <Function>,
+  totalRecords: 2,
+  data: [
+    {
+      "content": "True.",
+      "last_modified": 1456183930780,
+      "id": "a89dd4b2-d597-4192-bc2b-834116244d29",
+      "title": "I love cheese"
+    },
+    {
+      "content": "Yo",
+      "last_modified": 1456183914275,
+      "id": "63c1805a-565a-46cc-bfb3-007dfad54065",
+      "title": "Another post"
+    }
+  ]
+}
+```
+
+The result object exposes the following properties:
+
+- `last_modified`: the [collection's timestamp](http://kinto.readthedocs.io/en/stable/api/1.x/timestamps.html). (Note: this value is the same as the one returned by [`getRecordsTimestamp()`](#records-list-timestamp))
+- `next`: the [pagination](#paginating-results) helper to access the next page of results, if any
+- `totalRecords`: the total number of records in the **entire collection**. This number can alternatively be retrieved using the `getTotalRecords()` method of the collection API
+- `data`: the list of records
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `at`: Retrieve the records list at at a given timestamp back in time (note: full list is always returned, this option doesn't support pagination and will reject if the [History plugin](http://kinto.readthedocs.io/en/stable/api/1.x/history.html) isn't enabled or has been enabled after the creation of the collection.)
+
+This method accepts the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
+
+### Total number of records
+
+```js
+const result = await client
+  .bucket("blog")
+  .collection("posts")
+  .getTotalRecords();
+```
+
+Sample result:
+
+```js
+42;
+```
+
+#### Options
+
+- `headers`: custom headers object to send along the HTTP request
+- `retry`: number of retries when request fails (default: 0)
+
+### Records list timestamp
+
+The timestamp of the records list is used for the `since` option in the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
+
+```js
+const result = await client
+  .bucket("blog")
+  .collection("posts")
+  .getRecordsTimestamp();
+```
+
+Sample result:
+
+```js
+"1548699177099";
+```
+
+#### Options
+
+- `headers`: custom headers object to send along the HTTP request
+- `retry`: number of retries when request fails (default: 0)
+
+### Batching operations
+
+This allows performing multiple operations in a single HTTP request.
+
+```js
+const result = await client
+  .bucket("blog")
+  .collection("posts")
+  .batch((batch) => {
+    batch.deleteRecord("cb0f7b2b-e78f-41a8-afad-92a56f8c88db");
+    batch.createRecord({ title: "new post", content: "yo" });
+    batch.createRecord({ title: "another", content: "yo again" });
+  });
+```
+
+Sample result:
+
+```js
+[
+  {
+    status: 200,
+    path: "/v1/buckets/blog/collections/posts/records/a89dd4b2-d597-4192-bc2b-834116244d29",
+    body: {
+      data: {
+        deleted: true,
+        last_modified: 1456184078090,
+        id: "a89dd4b2-d597-4192-bc2b-834116244d29",
+      },
+    },
+    headers: {
+      "Content-Length": "99",
+      "Content-Type": "application/json; charset=UTF-8",
+      "Access-Control-Expose-Headers":
+        "Retry-After, Content-Length, Alert, Backoff",
+    },
+  },
+  {
+    status: 201,
+    path: "/v1/buckets/blog/collections/posts/records",
+    body: {
+      data: {
+        content: "yo",
+        last_modified: 1456184078096,
+        id: "afd650b3-1625-42f6-8994-860e52d39201",
+        title: "new post",
+      },
+      permissions: {
+        write: [
+          "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8",
+        ],
+      },
+    },
+    headers: {
+      "Content-Length": "221",
+      "Content-Type": "application/json; charset=UTF-8",
+      "Access-Control-Expose-Headers":
+        "Retry-After, Content-Length, Alert, Backoff",
+    },
+  },
+  {
+    status: 201,
+    path: "/v1/buckets/blog/collections/posts/records",
+    body: {
+      data: {
+        content: "yo again",
+        last_modified: 1456184078102,
+        id: "22c1319e-7b09-46db-bec4-c240bdf4e3e9",
+        title: "another",
+      },
+      permissions: {
+        write: [
+          "basicauth:0f7c1b72cdc89b9d42a2d48d5f0b291a1e8afd408cc38a2197cdf508269cecc8",
+        ],
+      },
+    },
+    headers: {
+      "Content-Length": "226",
+      "Content-Type": "application/json; charset=UTF-8",
+      "Access-Control-Expose-Headers":
+        "Retry-After, Content-Length, Alert, Backoff",
+    },
+  },
+];
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: Ensures operations won't override existing resources on the server if their associated `last_modified` value or option are provided; otherwise ensures resources won't be overriden if they already exist on the server
+- `aggregate`: Produces an aggregated result object, grouped by operation types; the result object has the following structure:
+
+```js
+{
+  "errors":    [], // Encountered errors (HTTP 400, >=500)
+  "published": [], // Successfully published resources (HTTP 200, 201)
+  "conflicts": [], // Conflicting resources (HTTP 412)
+  "skipped":   []  // Missing target resources on the server (HTTP 404)
+}
+```
+
+## Listing all resource permissions
+
+If the [`permissions_endpoint` capability](http://kinto.readthedocs.io/en/stable/api/1.x/permissions.html#list-every-permissions) is installed on the server, you can retrieve the list of all permissions set for the authenticated user using the `listPermissions()` method:
+
+```js
+const result = await client.listPermissions([options]);
+```
+
+Sample result:
+
+```js
+{
+  "data": [
+    {
+      "bucket_id": "mybucket",
+      "id": "mybucket",
+      "permissions": [
+        "write",
+        "read",
+        "group:create",
+        "collection:create"
+      ],
+      "resource_name": "bucket",
+      "uri": "/buckets/mybucket"
+    },
+    ...
+  ]
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+
+#### Result object properties
+
+- `last_modified`: the last modified value for the list of permissions
+- `hasNextPage`: a boolean informing if a next page is available; when that's the case, you can call `next()`
+- `next`: the [pagination](#paginating-results) helper to access the next page of results, if any
+- `data`: the list of permissions
+- `totalRecords`: the total number of permissions listed in the `data` property array
+
+## Attachments
+
+If the [attachment](https://github.com/Kinto/kinto-attachment) capability is available from the Kinto server, you can attach files to records. Files must be passed as [data urls](http://dataurl.net/#about), which can be generated using the [FileReader API](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL) in the browser.
+
+### Adding an attachment to a record
+
+```js
+client
+  .bucket("blog")
+  .collection("posts")
+  .addAttachment(dataURL, { title: "First post" });
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request
+- `retry`: Number of retries when request fails (default: 0)
+- `safe`: Ensures operations won't override existing resources on the server if their associated `last_modified` value or option are provided; otherwise ensures resources won't be overriden if they already exist on the server
+- `last_modified`: When `safe` is true, the last timestamp we know the resource has been updated on the server
+- `permissions`: Permissions to be set on the record
+- `filename`: Allows to specify the attachment filename, in case the data URI does not contain any, or if the file has to be renamed on upload
+
+### Updating an attachment
+
+```js
+client
+  .bucket("blog")
+  .collection("posts")
+  .addAttachment(dataURL, { id: "22c1319e-7b09-46db-bec4-c240bdf4e3e9" });
+```
+
+### Deleting an attachment
+
+```js
+client
+  .bucket("blog")
+  .collection("posts")
+  .removeAttachment("22c1319e-7b09-46db-bec4-c240bdf4e3e9");
+```
+
+## Generic bucket and collection options
+
+Both `bucket()` and `collection()` methods accept an `options` object as a second arguments where you can define the following options:
+
+- `{Object} headers`: Custom headers to send along the request;
+- `{Boolean} safe`: Ensure safe transactional operations; read more about that below.
+- `{Number} retry`: Default number of times to retry requests when faced with transient errors.
+
+Sample usage:
+
+```js
+client.bucket("blog", {
+  headers: { "X-Hello": "Hello!" },
+  safe: true,
+  retry: 2,
+});
+```
+
+Here the `X-Hello` header and the `safe` option will be used for building every outgoing request sent to the server, for every collection attached to this bucket.
+
+This works at the collection level as well:
+
+```js
+client.bucket("blog").collection("posts", {
+  headers: { "X-Hello": "Hello!" },
+  safe: true,
+  retry: 2,
+});
+```
+
+Every request sent for this collection will have the options applied.
+
+Last, you can of course pass these options at the atomic operation level:
+
+```js
+client
+  .bucket("blog")
+  .collection("posts")
+  .updateRecord(updatedRecord, {
+    headers: { "X-Hello": "Hello!" },
+    safe: true,
+    retry: 2,
+  });
+```
+
+The cool thing being you can always override the default defined options at the atomic operation level:
+
+```js
+client
+  .bucket("blog", { safe: true })
+  .collection("posts")
+  .updateRecord(updatedRecord, { safe: false });
+```
+
+## The `safe` option explained
+
+The `safe` option can be used:
+
+- when creating or updating a resource, to ensure that any already existing record matching the provided ID won't be overridden if it exists on the server;
+- when updating or deleting a resource, to ensure it won't be overridden remotely if it has changed in the meanwhile on the server (requires a `last_modified` value to be provided).
+
+### Safe creations
+
+When creating a new ressource, using the `safe` option will ensure the resource will be created only if it doesn't already exist on the server.
+
+### Safe updates
+
+If a `last_modified` property value is set in the resource object being updated, the `safe` option will ensure it won't be overriden if it's been modified on the server since that `last_modified` timestamp, raising an `HTTP 412` response describing the conflict when that happens:
+
+```js
+const updatedRecord = {
+  id: "fbd2a565-8c10-497a-95b8-ce4ea6f474e1",
+  title: "new post, modified",
+  content: "yoyo",
+  last_modified: 1456184189160,
+};
+
+client
+  .bucket("blog")
+  .collection("posts")
+  .updateRecord(updatedRecord, { safe: true });
+```
+
+If this record has been modified on the server already, meaning its `last_modified` is greater than the one we provide , we'll get a `412` error response.
+
+If no `last_modified` value is provided at all, a safe update will simply guarantee that an existing resource with the provided ID won't be overriden.
+
+### Safe deletions
+
+The same applies for deletions, where you can pass both a `safe` and `last_modified` options:
+
+```js
+client
+  .bucket("blog")
+  .collection("posts")
+  .deleteRecord("fbd2a565-8c10-497a-95b8-ce4ea6f474e1", {
+    safe: true,
+    last_modified: 1456184189160,
+  });
+```
+
+## Generic options for list operations
+
+Every list operations like [listBuckets()](#listing-buckets), [listCollections](#listing-bucket-collections), [listHistory](#listing-bucket-history), [listGroups()](#list-bucket-groups) or [listRecords()](#listing-records) accept parameters to sort, filter and paginate the results:
+
+- `sort`: The order field (default: `-last_modified`);
+- `pages`: The number of result pages to retrieve (default: `1`);
+- `limit`: The number of records to retrieve per page: unset by default, uses default server configuration;
+- `filters`: An object defining the filters to apply; read more about [what's supported](http://kinto.readthedocs.io/en/stable/api/1.x/filtering.html);
+- `since`: The ETag header value received from the last response from the server.
+- `fields`: The set of fields to return for each record (see the [selecting fields](https://kinto.readthedocs.io/en/stable/api/1.x/selecting_fields.html) documentation).
+
+### Sorting
+
+By default, results are listed by `last_modified` descending order. You can set the `sort` option to order by another field:
+
+```js
+const { data, next } = await client
+  .bucket("blog")
+  .collection("posts")
+  .listRecords({ sort: "title" });
+```
+
+### Polling for changes
+
+To retrieve the results modified since a given timestamp, use the `since` option:
+
+```js
+const { data, next } = await client
+  .bucket("blog")
+  .collection("posts")
+  .listRecords({ since: "1456183930780" });
+```
+
+### Paginating results
+
+By default, all results of the first page are retrieved, and the default configuration of the server defines no limit. To specify a max number of results to retrieve, you can use the `limit` option:
+
+```js
+const { data, hasNextPage, next } = await client
+  .bucket("blog")
+  .collection("posts")
+  .listRecords({ limit: 20 });
+```
+
+To check if a next page of results is available, you can check for the `hasNextPage` boolean property. To actually fetch the next page of results, call the `next()` function obtained:
+
+```js
+let { data, hasNextPage, next } = await client
+  .bucket("blog")
+  .collection("posts")
+  .listRecords({ limit: 20 });
+while (hasNextPage) {
+  const result = await next();
+  data = data.concat(result.data);
+  hasNextPage = result.hasNextPage;
+}
+```
+
+Last, if you just want to retrieve and aggregate a given number of result pages, instead of dealing with calling `next()` recursively you can simply specify the `pages` option:
+
+```js
+const { data, hasNextPage, next } = await client
+  .bucket("blog")
+  .collection("posts")
+  .listRecords({ limit: 20, pages: 3 }); // A maximum of 60 results will be retrieved here
+```
+
+> ##### Notes
+>
+> If you plan on fetching all the available pages, you can set the `pages` option to `Infinity`. Be aware that for large datasets this strategy can possibly issue an excessive number of HTTP requests.
+
+## Generic options for singular operations
+
+"Singular" operations such as [Bucket#getData()](#getting-bucket-data), [Bucket#getGroup](#getting-a-bucket-group), [Collection#getData](#getting-collection-data), and [Collection#getRecord](#retrieving-an-existing-record) support some shared options:
+
+- `fields`: The set of fields to return for each record (see the [selecting fields](https://kinto.readthedocs.io/en/stable/api/1.x/selecting_fields.html) documentation).
+- `query`: Any extra query arguments to pass. This might be handy if you want to use a feature that this library doesn't support yet, or for implementing cache-busting URLs.
+
+## Events
+
+The `KintoClient` exposes an `events` property you can subscribe public events from. That `events` property implements nodejs' [EventEmitter interface](https://nodejs.org/api/events.html#events_class_events_eventemitter).
+
+### The `backoff` event
+
+Triggered when a `Backoff` HTTP header has been received from the last received response from the server, meaning clients should hold on performing further requests during a given amount of time.
+
+The `backoff` event notifies what's the backoff release timestamp you should wait until before performing another operation:
+
+```js
+const client = new KintoClient();
+
+client.events.on("backoff", function (releaseTime) {
+  const releaseDate = new Date(releaseTime).toLocaleString();
+  alert(`Backed off; wait until ${releaseDate} to retry`);
+});
+```
+
+### The `deprecated` event
+
+Triggered when an `Alert` HTTP header is received from the server, meaning that a feature has been deprecated; the `event` argument received by the event listener contains the following deprecation information:
+
+- `type`: The type of deprecation, which in ou case is always `soft-eol` (`hard-eol` alerts trigger an `HTTP 410 Gone` error);
+- `message`: The deprecation alert message;
+- `url`: The URL you can get information about the related deprecation policy.
+
+```js
+const client = new KintoClient();
+
+client.events.on("deprecated", function (event) {
+  console.log(event.message);
+});
+```
+
+### The `retry-after` event
+
+Some errors on the server side are transient (service unavailable or integrity errors). A `Retry-After` HTTP header in the response indicates the duration in seconds that clients should wait before retrying the request.
+
+The `retry-after` event notifies what is the timestamp you should wait until before performing another operation:
+
+```js
+const client = new KintoClient();
+
+client.events.on("retry-after", function (releaseTime) {
+  const releaseDate = new Date(releaseTime).toLocaleString();
+  alert(`Wait until ${releaseDate} to retry`);
+});
+```
+
+> #### Note:
+>
+> We also automatically retry all requests that have a Retry-After response.
+
+## Browser Compatibility
+
+This library uses some features that are not supported on Internet Explorer or older versions of Safari.
+
+- Javascript [`Promise`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise#Browser_compatibility)
+- [`Object.assign()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Browser_compatibility)
+- [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#Browser_compatibility)
+
+Please [add polyfills](https://polyfill.io/v2/docs/features/) for these to get full functionality.

--- a/fx-src/jsm_prefix.js
+++ b/fx-src/jsm_prefix.js
@@ -15,7 +15,7 @@
 "use strict";
 
 /*
- * This file is generated from kinto-http.js - do not modify directly.
+ * This file is generated from kinto.js - do not modify directly.
  */
 
 const global = this;

--- a/fx-src/jsm_prefix.js
+++ b/fx-src/jsm_prefix.js
@@ -1,0 +1,28 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+/*
+ * This file is generated from kinto-http.js - do not modify directly.
+ */
+
+const global = this;
+const globalThis = this;
+
+var EXPORTED_SYMBOLS = ["KintoHttpClient"];
+
+const { setTimeout, clearTimeout } = ChromeUtils.import("resource://gre/modules/Timer.jsm");
+const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+XPCOMUtils.defineLazyGlobalGetters(global, ["fetch"]);

--- a/intern.json
+++ b/intern.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/intern/schemas/config.json",
   "bail": true,
-  "coverage": ["src/**/*.ts", "!src/index.browser.ts"],
+  "coverage": ["src/**/*.ts", "!src/http/index.{browser,fx}.ts"],
   "environments": "node",
   "node": {
     "suites": "./test/**/*_test.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "btoa": "^1.2.1",
-        "kinto-http": "^5.3.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -48,6 +47,7 @@
         "http-server": "^14.0.0",
         "intern": "^4.10.0",
         "kinto-node-test-server": "^2.0.0",
+        "mitt": "^3.0.0",
         "node-fetch": "^2.6.6",
         "nyc": "^15.1.0",
         "open-cli": "^7.0.1",
@@ -1622,13 +1622,13 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -2450,7 +2450,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3058,7 +3058,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4395,7 +4395,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5942,33 +5942,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/kinto-http": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/kinto-http/-/kinto-http-5.3.0.tgz",
-      "integrity": "sha512-3TduChdWjlqCaae6VVwSk0faD3O2mMMkGcd/C0aDL5V0d45ovv3imHs1gl5MctphmuAci8UfGvCojxM/2ysqYw==",
-      "dependencies": {
-        "uuid": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "atob": ">=2.1.2",
-        "form-data": ">=3.0.0",
-        "node-fetch": ">=2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "atob": {
-          "optional": true
-        },
-        "form-data": {
-          "optional": true
-        },
-        "node-fetch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/kinto-node-test-server": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kinto-node-test-server/-/kinto-node-test-server-2.0.0.tgz",
@@ -6597,7 +6570,7 @@
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
       "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6606,7 +6579,7 @@
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "mime-db": "1.51.0"
       },
@@ -6667,6 +6640,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
+      "dev": true
+    },
     "node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -6726,7 +6705,7 @@
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
       "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -8854,7 +8833,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/trim-newlines": {
       "version": "4.0.2",
@@ -9327,7 +9306,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -9347,7 +9326,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -10835,13 +10814,13 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "devOptional": true
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "devOptional": true
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -11517,7 +11496,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -12020,7 +11999,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "devOptional": true
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -13090,7 +13069,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -14308,14 +14287,6 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
-    "kinto-http": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/kinto-http/-/kinto-http-5.3.0.tgz",
-      "integrity": "sha512-3TduChdWjlqCaae6VVwSk0faD3O2mMMkGcd/C0aDL5V0d45ovv3imHs1gl5MctphmuAci8UfGvCojxM/2ysqYw==",
-      "requires": {
-        "uuid": "^8.0.0"
-      }
-    },
     "kinto-node-test-server": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kinto-node-test-server/-/kinto-node-test-server-2.0.0.tgz",
@@ -14858,13 +14829,13 @@
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
       "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "devOptional": true
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "mime-db": "1.51.0"
       }
@@ -14912,6 +14883,12 @@
         "is-plain-obj": "^1.1.0",
         "kind-of": "^6.0.3"
       }
+    },
+    "mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -14968,7 +14945,7 @@
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
       "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -16609,7 +16586,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "devOptional": true
+      "dev": true
     },
     "trim-newlines": {
       "version": "4.0.2",
@@ -16971,7 +16948,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -16981,7 +16958,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "devOptional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "cs-check": "prettier -l \"{src,test,bin}/**/*.{js,ts}\"",
     "cs-format": "prettier \"{src,test,bin}/**/*.{js,ts}\" --write",
     "demo": "npm run build-demo && http-server demo",
-    "dist": "cross-env NODE_ENV=production rollup -c",
-    "dist:dev": "rollup -c",
+    "dist": "npx cross-env NODE_ENV=production rollup -c && npm run dist:fx",
+    "dist:dev": "npx rollup -c && npm run dist:fx",
+    "dist:fx": "npx ts-node --skip-project bin/dist-fx.ts",
     "lint": "eslint \"src/**/*.{js,ts}\" \"test/**/*.{js,ts}\"",
     "publish-demo": "npm run dist-prod && cp dist/kinto.js demo/kinto.js && gh-pages -d demo",
     "publish-to-npm": "npm run dist && npm run build && npm publish",
@@ -146,7 +147,6 @@
   },
   "dependencies": {
     "btoa": "^1.2.1",
-    "kinto-http": "^5.3.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -184,6 +184,7 @@
     "http-server": "^14.0.0",
     "intern": "^4.10.0",
     "kinto-node-test-server": "^2.0.0",
+    "mitt": "^3.0.0",
     "node-fetch": "^2.6.6",
     "nyc": "^15.1.0",
     "open-cli": "^7.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,27 @@ import { terser } from "rollup-plugin-terser";
 import multi from "@rollup/plugin-multi-entry";
 import replace from "@rollup/plugin-replace";
 
+const geckoBuild = {
+  input: "./src/http/index.fx.ts",
+  output: [
+    {
+      file: "dist/temp.js",
+      format: "umd",
+      name: "KintoHttpClient",
+    },
+  ],
+  plugins: [
+    resolve({
+      mainFields: ["module", "main", "browser"],
+      preferBuiltins: true,
+    }),
+    typescript({
+      include: ["*.ts+(|x)", "**/*.ts+(|x)", "*.js", "**/*.js"],
+    }),
+    commonjs({ ignoreGlobal: true }),
+  ],
+};
+
 const browserBuild = {
   input: "./src/index.ts",
   output: [
@@ -83,6 +104,6 @@ const browserTestBuild = {
 
 const bundles = process.env.BROWSER_TESTING
   ? [browserTestBuild]
-  : [browserBuild];
+  : [geckoBuild, browserBuild];
 
 export default bundles;

--- a/src/KintoBase.ts
+++ b/src/KintoBase.ts
@@ -1,4 +1,4 @@
-import Api from "kinto-http";
+import Api from "./http";
 import Collection from "./collection";
 import BaseAdapter from "./adapters/base";
 import {

--- a/src/adapters/IDB.ts
+++ b/src/adapters/IDB.ts
@@ -7,7 +7,7 @@ import {
   transformSubObjectFilters,
 } from "../utils";
 import { RecordStatus } from "../types";
-import { KintoObject } from "kinto-http";
+import { KintoObject } from "../http";
 
 const INDEXED_FIELDS = ["id", "_status", "last_modified"];
 

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -4,7 +4,7 @@ import { waterfall, deepEqual } from "./utils";
 import { v4 as uuid4 } from "uuid";
 import { omitKeys, RE_RECORD_ID } from "./utils";
 import KintoBase from "./KintoBase";
-import { AggregateResponse, Collection as KintoCollection } from "kinto-http";
+import { AggregateResponse, Collection as KintoCollection } from "./http";
 import {
   KintoRepresentation,
   IdSchema,

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1042,7 +1042,7 @@ export default class Collection<
         // This only happens during SERVER_WINS because the local
         // version of a record can never be null.
         // We can get "null" from the remote side if we got a conflict
-        // and there is no remote version available; see kinto-http.js
+        // and there is no remote version available; see src/http
         // batch.js:aggregate.
         transaction.delete(conflict.local.id);
         accepted = null;
@@ -1388,7 +1388,7 @@ export default class Collection<
       const safeLocal = (local && local.data) || { id: remote.id };
       const realLocal = await this._decodeRecord("remote", safeLocal);
       // We can get "null" from the remote side if we got a conflict
-      // and there is no remote version available; see kinto-http.js
+      // and there is no remote version available; see src/http
       // batch.js:aggregate.
       const realRemote = remote && (await this._decodeRecord("remote", remote));
       const conflict = { type, local: realLocal, remote: realRemote };

--- a/src/http/base.ts
+++ b/src/http/base.ts
@@ -1,0 +1,996 @@
+import {
+  partition,
+  qsify,
+  support,
+  nobatch,
+  toDataBody,
+  cleanUndefinedProperties,
+} from "./utils";
+import HTTP, { HttpResponse } from "./http";
+import endpoints from "./endpoints";
+import * as requests from "./requests";
+import { aggregate, AggregateResponse } from "./batch";
+import Bucket from "./bucket";
+import { addEndpointOptions, capable } from "./utils";
+import {
+  HelloResponse,
+  KintoRequest,
+  BatchResponse,
+  OperationResponse,
+  DataResponse,
+  Permission,
+  KintoIdObject,
+  MappableObject,
+  KintoObject,
+  PermissionData,
+  KintoResponse,
+  ServerSettings,
+  ServerCapability,
+  User,
+  Emitter,
+  HttpMethod,
+  FetchFunction,
+} from "./types";
+import Collection from "./collection";
+
+/**
+ * Currently supported protocol version.
+ * @type {String}
+ */
+export const SUPPORTED_PROTOCOL_VERSION = "v1";
+
+export interface KintoClientOptions {
+  safe?: boolean;
+  events?: Emitter;
+  headers?: Record<string, string>;
+  retry?: number;
+  bucket?: string;
+  requestMode?: RequestMode;
+  timeout?: number;
+  batch?: boolean;
+  fetchFunc?: FetchFunction;
+}
+
+export interface PaginatedParams {
+  sort?: string;
+  filters?: Record<string, string | number>;
+  limit?: number;
+  pages?: number;
+  since?: string;
+  fields?: string[];
+}
+
+export interface PaginationResult<T> {
+  last_modified: string | null;
+  data: T[];
+  next: (nextPage?: string | null) => Promise<PaginationResult<T>>;
+  hasNextPage: boolean;
+  totalRecords: number;
+}
+
+type BaseBatch = (client: KintoClientBase) => void;
+type BucketBatch = (client: Bucket) => void;
+type CollectionBatch = (client: Collection) => void;
+
+/**
+ * High level HTTP client for the Kinto API.
+ *
+ * @example
+ * const client = new KintoClient("https://demo.kinto-storage.org/v1");
+ * client.bucket("default")
+ *    .collection("my-blog")
+ *    .createRecord({title: "First article"})
+ *   .then(console.log.bind(console))
+ *   .catch(console.error.bind(console));
+ */
+export default class KintoClientBase {
+  private _backoffReleaseTime: number | null;
+  private _requests: KintoRequest[];
+  private _isBatch: boolean;
+  private _retry: number;
+  private _safe: boolean;
+  private _headers: Record<string, string>;
+  public serverInfo: HelloResponse | null;
+  public events?: Emitter;
+  public http: HTTP;
+  public endpoints: typeof endpoints;
+  private _remote!: string;
+  private _version!: string;
+
+  /**
+   * Constructor.
+   *
+   * @param  {String}       remote  The remote URL.
+   * @param  {Object}       [options={}]                  The options object.
+   * @param  {Boolean}      [options.safe=true]           Adds concurrency headers to every requests.
+   * @param  {EventEmitter} [options.events=EventEmitter] The events handler instance.
+   * @param  {Object}       [options.headers={}]          The key-value headers to pass to each request.
+   * @param  {Object}       [options.retry=0]             Number of retries when request fails (default: 0)
+   * @param  {String}       [options.bucket="default"]    The default bucket to use.
+   * @param  {String}       [options.requestMode="cors"]  The HTTP request mode (from ES6 fetch spec).
+   * @param  {Number}       [options.timeout=null]        The request timeout in ms, if any.
+   * @param  {Function}     [options.fetchFunc=fetch]     The function to be used to execute HTTP requests.
+   */
+  constructor(remote: string, options: KintoClientOptions) {
+    if (typeof remote !== "string" || !remote.length) {
+      throw new Error("Invalid remote URL: " + remote);
+    }
+    if (remote[remote.length - 1] === "/") {
+      remote = remote.slice(0, -1);
+    }
+    this._backoffReleaseTime = null;
+
+    this._requests = [];
+    this._isBatch = !!options.batch;
+    this._retry = options.retry || 0;
+    this._safe = !!options.safe;
+    this._headers = options.headers || {};
+
+    // public properties
+    /**
+     * The remote server base URL.
+     * @type {String}
+     */
+    this.remote = remote;
+    /**
+     * Current server information.
+     * @ignore
+     * @type {Object|null}
+     */
+    this.serverInfo = null;
+    /**
+     * The event emitter instance. Should comply with the `EventEmitter`
+     * interface.
+     * @ignore
+     * @type {Class}
+     */
+    this.events = options.events;
+
+    this.endpoints = endpoints;
+
+    const { fetchFunc, requestMode, timeout } = options;
+    /**
+     * The HTTP instance.
+     * @ignore
+     * @type {HTTP}
+     */
+    this.http = new HTTP(this.events, { fetchFunc, requestMode, timeout });
+    this._registerHTTPEvents();
+  }
+
+  /**
+   * The remote endpoint base URL. Setting the value will also extract and
+   * validate the version.
+   * @type {String}
+   */
+  get remote(): string {
+    return this._remote;
+  }
+
+  /**
+   * @ignore
+   */
+  set remote(url: string) {
+    let version;
+    try {
+      version = url.match(/\/(v\d+)\/?$/)![1];
+    } catch (err) {
+      throw new Error("The remote URL must contain the version: " + url);
+    }
+    if (version !== SUPPORTED_PROTOCOL_VERSION) {
+      throw new Error(`Unsupported protocol version: ${version}`);
+    }
+    this._remote = url;
+    this._version = version;
+  }
+
+  /**
+   * The current server protocol version, eg. `v1`.
+   * @type {String}
+   */
+  get version(): string {
+    return this._version;
+  }
+
+  /**
+   * Backoff remaining time, in milliseconds. Defaults to zero if no backoff is
+   * ongoing.
+   *
+   * @type {Number}
+   */
+  get backoff(): number {
+    const currentTime = new Date().getTime();
+    if (this._backoffReleaseTime && currentTime < this._backoffReleaseTime) {
+      return this._backoffReleaseTime - currentTime;
+    }
+    return 0;
+  }
+
+  /**
+   * Registers HTTP events.
+   * @private
+   */
+  private _registerHTTPEvents(): void {
+    // Prevent registering event from a batch client instance
+    if (!this._isBatch && this.events) {
+      this.events.on("backoff", (backoffMs) => {
+        this._backoffReleaseTime = backoffMs;
+      });
+    }
+  }
+
+  /**
+   * Retrieve a bucket object to perform operations on it.
+   *
+   * @param  {String}  name              The bucket name.
+   * @param  {Object}  [options={}]      The request options.
+   * @param  {Boolean} [options.safe]    The resulting safe option.
+   * @param  {Number}  [options.retry]   The resulting retry option.
+   * @param  {Object}  [options.headers] The extended headers object option.
+   * @return {Bucket}
+   */
+  bucket(
+    name: string,
+    options: {
+      safe?: boolean;
+      retry?: number;
+      headers?: Record<string, string>;
+    } = {}
+  ): Bucket {
+    return new Bucket(this, name, {
+      headers: this._getHeaders(options),
+      safe: this._getSafe(options),
+      retry: this._getRetry(options),
+    });
+  }
+
+  /**
+   * Set client "headers" for every request, updating previous headers (if any).
+   *
+   * @param {Object} headers The headers to merge with existing ones.
+   */
+  setHeaders(headers: Record<string, string>): void {
+    this._headers = {
+      ...this._headers,
+      ...headers,
+    };
+    this.serverInfo = null;
+  }
+
+  /**
+   * Get the value of "headers" for a given request, merging the
+   * per-request headers with our own "default" headers.
+   *
+   * Note that unlike other options, headers aren't overridden, but
+   * merged instead.
+   *
+   * @private
+   * @param {Object} options The options for a request.
+   * @returns {Object}
+   */
+  private _getHeaders(options: {
+    headers?: Record<string, string>;
+  }): Record<string, string> {
+    return {
+      ...this._headers,
+      ...options.headers,
+    };
+  }
+
+  /**
+   * Get the value of "safe" for a given request, using the
+   * per-request option if present or falling back to our default
+   * otherwise.
+   *
+   * @private
+   * @param {Object} options The options for a request.
+   * @returns {Boolean}
+   */
+  private _getSafe(options: { safe?: boolean }): boolean {
+    return { safe: this._safe, ...options }.safe;
+  }
+
+  /**
+   * As _getSafe, but for "retry".
+   *
+   * @private
+   */
+  private _getRetry(options: { retry?: number }): number {
+    return { retry: this._retry, ...options }.retry;
+  }
+
+  /**
+   * Retrieves the server's "hello" endpoint. This endpoint reveals
+   * server capabilities and settings as well as telling the client
+   * "who they are" according to their given authorization headers.
+   *
+   * @private
+   * @param  {Object}  [options={}] The request options.
+   * @param  {Object}  [options.headers={}] Headers to use when making
+   *     this request.
+   * @param  {Number}  [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  private async _getHello(
+    options: {
+      retry?: number;
+      headers?: Record<string, string>;
+    } = {}
+  ): Promise<HelloResponse> {
+    const path = this.remote + endpoints.root();
+    const { json } = await this.http.request<HelloResponse>(
+      path,
+      { headers: this._getHeaders(options) },
+      { retry: this._getRetry(options) }
+    );
+    return json;
+  }
+
+  /**
+   * Retrieves server information and persist them locally. This operation is
+   * usually performed a single time during the instance lifecycle.
+   *
+   * @param  {Object}  [options={}] The request options.
+   * @param  {Number}  [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  async fetchServerInfo(
+    options: { retry?: number } = {}
+  ): Promise<HelloResponse> {
+    if (this.serverInfo) {
+      return this.serverInfo;
+    }
+    this.serverInfo = await this._getHello({ retry: this._getRetry(options) });
+    return this.serverInfo;
+  }
+
+  /**
+   * Retrieves Kinto server settings.
+   *
+   * @param  {Object}  [options={}] The request options.
+   * @param  {Number}  [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  @nobatch("This operation is not supported within a batch operation.")
+  async fetchServerSettings(
+    options: { retry?: number } = {}
+  ): Promise<ServerSettings> {
+    const { settings } = await this.fetchServerInfo(options);
+    return settings;
+  }
+
+  /**
+   * Retrieve server capabilities information.
+   *
+   * @param  {Object}  [options={}] The request options.
+   * @param  {Number}  [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  @nobatch("This operation is not supported within a batch operation.")
+  async fetchServerCapabilities(
+    options: {
+      retry?: number;
+    } = {}
+  ): Promise<{ [key: string]: ServerCapability }> {
+    const { capabilities } = await this.fetchServerInfo(options);
+    return capabilities;
+  }
+
+  /**
+   * Retrieve authenticated user information.
+   *
+   * @param  {Object}  [options={}] The request options.
+   * @param  {Object}  [options.headers={}] Headers to use when making
+   *     this request.
+   * @param  {Number}  [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  @nobatch("This operation is not supported within a batch operation.")
+  async fetchUser(
+    options: {
+      retry?: number;
+      headers?: Record<string, string>;
+    } = {}
+  ): Promise<User | undefined> {
+    const { user } = await this._getHello(options);
+    return user;
+  }
+
+  /**
+   * Retrieve authenticated user information.
+   *
+   * @param  {Object}  [options={}] The request options.
+   * @param  {Number}  [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  @nobatch("This operation is not supported within a batch operation.")
+  async fetchHTTPApiVersion(
+    options: {
+      retry?: number;
+    } = {}
+  ): Promise<string> {
+    const { http_api_version } = await this.fetchServerInfo(options);
+    return http_api_version;
+  }
+
+  /**
+   * Process batch requests, chunking them according to the batch_max_requests
+   * server setting when needed.
+   *
+   * @param  {Array}  requests     The list of batch subrequests to perform.
+   * @param  {Object} [options={}] The options object.
+   * @return {Promise<Object, Error>}
+   */
+  private async _batchRequests(
+    requests: KintoRequest[],
+    options: {
+      retry?: number;
+      headers?: Record<string, string>;
+    } = {}
+  ): Promise<OperationResponse[]> {
+    const headers = this._getHeaders(options);
+    if (!requests.length) {
+      return [];
+    }
+    const serverSettings = await this.fetchServerSettings({
+      retry: this._getRetry(options),
+    });
+    const maxRequests = serverSettings["batch_max_requests"];
+    if (maxRequests && requests.length > maxRequests) {
+      const chunks = partition(requests, maxRequests);
+      const results = [];
+      for (const chunk of chunks) {
+        const result = await this._batchRequests(chunk, options);
+        results.push(...result);
+      }
+      return results;
+    }
+    const { responses } = (await this.execute<BatchResponse>(
+      {
+        // FIXME: is this really necessary, since it's also present in
+        // the "defaults"?
+        headers,
+        path: endpoints.batch(),
+        method: "POST",
+        body: {
+          defaults: { headers },
+          requests,
+        },
+      },
+      { retry: this._getRetry(options) }
+    )) as BatchResponse;
+    return responses;
+  }
+
+  /**
+   * Sends batch requests to the remote server.
+   *
+   * Note: Reserved for internal use only.
+   *
+   * @ignore
+   * @param  {Function} fn                        The function to use for describing batch ops.
+   * @param  {Object}   [options={}]              The options object.
+   * @param  {Boolean}  [options.safe]            The safe option.
+   * @param  {Number}   [options.retry]           The retry option.
+   * @param  {String}   [options.bucket]          The bucket name option.
+   * @param  {String}   [options.collection]      The collection name option.
+   * @param  {Object}   [options.headers]         The headers object option.
+   * @param  {Boolean}  [options.aggregate=false] Produces an aggregated result object.
+   * @return {Promise<Object, Error>}
+   */
+  @nobatch("Can't use batch within a batch!")
+  async batch(
+    fn: BaseBatch | BucketBatch | CollectionBatch,
+    options: {
+      safe?: boolean;
+      retry?: number;
+      bucket?: string;
+      collection?: string;
+      headers?: Record<string, string>;
+      aggregate?: boolean;
+    } = {}
+  ): Promise<OperationResponse<KintoObject>[] | AggregateResponse> {
+    const rootBatch = new KintoClientBase(this.remote, {
+      events: this.events,
+      batch: true,
+      safe: this._getSafe(options),
+      retry: this._getRetry(options),
+    });
+    if (options.bucket && options.collection) {
+      (fn as CollectionBatch)(
+        rootBatch.bucket(options.bucket).collection(options.collection)
+      );
+    } else if (options.bucket) {
+      (fn as BucketBatch)(rootBatch.bucket(options.bucket));
+    } else {
+      (fn as BaseBatch)(rootBatch);
+    }
+    const responses = await this._batchRequests(rootBatch._requests, options);
+    if (options.aggregate) {
+      return aggregate(responses, rootBatch._requests);
+    } else {
+      return responses;
+    }
+  }
+
+  /**
+   * Executes an atomic HTTP request.
+   *
+   * @param  {Object}  request             The request object.
+   * @param  {String}  request.path        The path to fetch, relative
+   *     to the Kinto server root.
+   * @param  {String}  [request.method="GET"] The method to use in the
+   *     request.
+   * @param  {Body}    [request.body]      The request body.
+   * @param  {Object}  [request.headers={}] The request headers.
+   * @param  {Object}  [options={}]        The options object.
+   * @param  {Boolean} [options.raw=false] If true, resolve with full response
+   * @param  {Boolean} [options.stringify=true] If true, serialize body data to
+   * @param  {Number}  [options.retry=0]   The number of times to
+   *     retry a request if the server responds with Retry-After.
+   * JSON.
+   * @return {Promise<Object, Error>}
+   */
+  async execute<T>(
+    request: KintoRequest,
+    options: {
+      raw?: boolean;
+      stringify?: boolean;
+      retry?: number;
+      query?: { [key: string]: string };
+      fields?: string[];
+    } = {}
+  ): Promise<T | HttpResponse<T>> {
+    const { raw = false, stringify = true } = options;
+    // If we're within a batch, add the request to the stack to send at once.
+    if (this._isBatch) {
+      this._requests.push(request);
+      // Resolve with a message in case people attempt at consuming the result
+      // from within a batch operation.
+      const msg = ("This result is generated from within a batch " +
+        "operation and should not be consumed.") as unknown as T;
+      return raw
+        ? ({ status: 0, json: msg, headers: new Headers() } as HttpResponse<T>)
+        : msg;
+    }
+    const uri = this.remote + addEndpointOptions(request.path, options);
+    const result = await this.http.request<T>(
+      uri,
+      cleanUndefinedProperties({
+        // Limit requests to only those parts that would be allowed in
+        // a batch request -- don't pass through other fancy fetch()
+        // options like integrity, redirect, mode because they will
+        // break on a batch request.  A batch request only allows
+        // headers, method, path (above), and body.
+        method: request.method,
+        headers: request.headers,
+        body: stringify ? JSON.stringify(request.body) : request.body,
+      }),
+      { retry: this._getRetry(options) }
+    );
+    return raw ? result : result.json;
+  }
+
+  /**
+   * Perform an operation with a given HTTP method on some pages from
+   * a paginated list, following the `next-page` header automatically
+   * until we have processed the requested number of pages. Return a
+   * response with a `.next()` method that can be called to perform
+   * the requested HTTP method on more results.
+   *
+   * @private
+   * @param  {String}  path
+   *     The path to make the request to.
+   * @param  {Object}  params
+   *     The parameters to use when making the request.
+   * @param  {String}  [params.sort="-last_modified"]
+   *     The sorting order to use when doing operation on pages.
+   * @param  {Object}  [params.filters={}]
+   *     The filters to send in the request.
+   * @param  {Number}  [params.limit=undefined]
+   *     The limit to send in the request. Undefined means no limit.
+   * @param  {Number}  [params.pages=undefined]
+   *     The number of pages to operate on. Undefined means one page. Pass
+   *     Infinity to operate on everything.
+   * @param  {String}  [params.since=undefined]
+   *     The ETag from which to start doing operation on pages.
+   * @param  {Array}   [params.fields]
+   *     Limit response to just some fields.
+   * @param  {Object}  [options={}]
+   *     Additional request-level parameters to use in all requests.
+   * @param  {Object}  [options.headers={}]
+   *     Headers to use during all requests.
+   * @param  {Number}  [options.retry=0]
+   *     Number of times to retry each request if the server responds
+   *     with Retry-After.
+   * @param  {String}  [options.method="GET"]
+   *     The method to use in the request.
+   */
+  async paginatedOperation<T>(
+    path: string,
+    params: PaginatedParams = {},
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+      method?: HttpMethod;
+    } = {}
+  ): Promise<PaginationResult<T>> {
+    // FIXME: this is called even in batch requests, which doesn't
+    // make any sense (since all batch requests get a "dummy"
+    // response; see execute() above).
+    const { sort, filters, limit, pages, since, fields } = {
+      sort: "-last_modified",
+      ...params,
+    };
+    // Safety/Consistency check on ETag value.
+    if (since && typeof since !== "string") {
+      throw new Error(
+        `Invalid value for since (${since}), should be ETag value.`
+      );
+    }
+
+    const query: { [key: string]: any } = {
+      ...filters,
+      _sort: sort,
+      _limit: limit,
+      _since: since,
+    };
+    if (fields) {
+      query._fields = fields;
+    }
+    const querystring = qsify(query);
+    let results: T[] = [],
+      current = 0;
+
+    const next = async function (
+      nextPage: string | null
+    ): Promise<PaginationResult<T>> {
+      if (!nextPage) {
+        throw new Error("Pagination exhausted.");
+      }
+
+      return processNextPage(nextPage);
+    };
+
+    const processNextPage = async (
+      nextPage: string
+    ): Promise<PaginationResult<T>> => {
+      const { headers } = options;
+      return handleResponse(await this.http.request(nextPage, { headers }));
+    };
+
+    const pageResults = (
+      results: T[],
+      nextPage: string | null,
+      etag: string | null
+    ): PaginationResult<T> => {
+      // ETag string is supposed to be opaque and stored «as-is».
+      // ETag header values are quoted (because of * and W/"foo").
+      return {
+        last_modified: etag ? etag.replace(/"/g, "") : etag,
+        data: results,
+        next: next.bind(null, nextPage),
+        hasNextPage: !!nextPage,
+        totalRecords: -1,
+      };
+    };
+
+    const handleResponse = async function ({
+      headers = new Headers(),
+      json = {} as DataResponse<T[]>,
+    }: HttpResponse<DataResponse<T[]>>): Promise<PaginationResult<T>> {
+      const nextPage = headers.get("Next-Page");
+      const etag = headers.get("ETag");
+
+      if (!pages) {
+        return pageResults(json.data, nextPage, etag);
+      }
+      // Aggregate new results with previous ones
+      results = results.concat(json.data);
+      current += 1;
+      if (current >= pages || !nextPage) {
+        // Pagination exhausted
+        return pageResults(results, nextPage, etag);
+      }
+      // Follow next page
+      return processNextPage(nextPage);
+    };
+
+    return handleResponse(
+      (await this.execute(
+        // N.B.: This doesn't use _getHeaders, because all calls to
+        // `paginatedList` are assumed to come from calls that already
+        // have headers merged at e.g. the bucket or collection level.
+        {
+          headers: options.headers ? options.headers : {},
+          path: path + "?" + querystring,
+          method: options.method,
+        },
+        // N.B. This doesn't use _getRetry, because all calls to
+        // `paginatedList` are assumed to come from calls that already
+        // used `_getRetry` at e.g. the bucket or collection level.
+        { raw: true, retry: options.retry || 0 }
+      )) as HttpResponse<DataResponse<T[]>>
+    );
+  }
+
+  /**
+   * Fetch some pages from a paginated list, following the `next-page`
+   * header automatically until we have fetched the requested number
+   * of pages. Return a response with a `.next()` method that can be
+   * called to fetch more results.
+   *
+   * @private
+   * @param  {String}  path
+   *     The path to make the request to.
+   * @param  {Object}  params
+   *     The parameters to use when making the request.
+   * @param  {String}  [params.sort="-last_modified"]
+   *     The sorting order to use when fetching.
+   * @param  {Object}  [params.filters={}]
+   *     The filters to send in the request.
+   * @param  {Number}  [params.limit=undefined]
+   *     The limit to send in the request. Undefined means no limit.
+   * @param  {Number}  [params.pages=undefined]
+   *     The number of pages to fetch. Undefined means one page. Pass
+   *     Infinity to fetch everything.
+   * @param  {String}  [params.since=undefined]
+   *     The ETag from which to start fetching.
+   * @param  {Array}   [params.fields]
+   *     Limit response to just some fields.
+   * @param  {Object}  [options={}]
+   *     Additional request-level parameters to use in all requests.
+   * @param  {Object}  [options.headers={}]
+   *     Headers to use during all requests.
+   * @param  {Number}  [options.retry=0]
+   *     Number of times to retry each request if the server responds
+   *     with Retry-After.
+   */
+  async paginatedList<T>(
+    path: string,
+    params: PaginatedParams = {},
+    options: { headers?: Record<string, string>; retry?: number } = {}
+  ): Promise<PaginationResult<T>> {
+    return this.paginatedOperation<T>(path, params, options);
+  }
+
+  /**
+   * Delete multiple objects, following the pagination if the number of
+   * objects exceeds the page limit until we have deleted the requested
+   * number of pages. Return a response with a `.next()` method that can
+   * be called to delete more results.
+   *
+   * @private
+   * @param  {String}  path
+   *     The path to make the request to.
+   * @param  {Object}  params
+   *     The parameters to use when making the request.
+   * @param  {String}  [params.sort="-last_modified"]
+   *     The sorting order to use when deleting.
+   * @param  {Object}  [params.filters={}]
+   *     The filters to send in the request.
+   * @param  {Number}  [params.limit=undefined]
+   *     The limit to send in the request. Undefined means no limit.
+   * @param  {Number}  [params.pages=undefined]
+   *     The number of pages to delete. Undefined means one page. Pass
+   *     Infinity to delete everything.
+   * @param  {String}  [params.since=undefined]
+   *     The ETag from which to start deleting.
+   * @param  {Array}   [params.fields]
+   *     Limit response to just some fields.
+   * @param  {Object}  [options={}]
+   *     Additional request-level parameters to use in all requests.
+   * @param  {Object}  [options.headers={}]
+   *     Headers to use during all requests.
+   * @param  {Number}  [options.retry=0]
+   *     Number of times to retry each request if the server responds
+   *     with Retry-After.
+   */
+  paginatedDelete<T>(
+    path: string,
+    params: PaginatedParams = {},
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+      safe?: boolean;
+      last_modified?: number;
+    } = {}
+  ): Promise<PaginationResult<T>> {
+    const { headers, safe, last_modified } = options;
+    const deleteRequest = requests.deleteRequest(path, {
+      headers,
+      safe: safe ? safe : false,
+      last_modified,
+    });
+    return this.paginatedOperation<T>(path, params, {
+      ...options,
+      headers: deleteRequest.headers as Record<string, string>,
+      method: "DELETE",
+    });
+  }
+
+  /**
+   * Lists all permissions.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers={}] Headers to use when making
+   *     this request.
+   * @param  {Number} [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object[], Error>}
+   */
+  @capable(["permissions_endpoint"])
+  async listPermissions(
+    options: PaginatedParams & {
+      retry?: number;
+      headers?: Record<string, string>;
+    } = {}
+  ): Promise<PaginationResult<PermissionData>> {
+    const path = endpoints.permissions();
+    // Ensure the default sort parameter is something that exists in permissions
+    // entries, as `last_modified` doesn't; here, we pick "id".
+    const paginationOptions = { sort: "id", ...options };
+    return this.paginatedList<PermissionData>(path, paginationOptions, {
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+    });
+  }
+
+  /**
+   * Retrieves the list of buckets.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers={}] Headers to use when making
+   *     this request.
+   * @param  {Number} [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Object} [options.filters={}] The filters object.
+   * @param  {Array}  [options.fields]     Limit response to
+   *     just some fields.
+   * @return {Promise<Object[], Error>}
+   */
+  async listBuckets(
+    options: PaginatedParams & {
+      retry?: number;
+      headers?: Record<string, string>;
+      filters?: Record<string, string | number>;
+      fields?: string[];
+      since?: string;
+    } = {}
+  ): Promise<PaginationResult<KintoObject>> {
+    const path = endpoints.bucket();
+    return this.paginatedList<KintoObject>(path, options, {
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+    });
+  }
+
+  /**
+   * Creates a new bucket on the server.
+   *
+   * @param  {String|null}  id                The bucket name (optional).
+   * @param  {Object}       [options={}]      The options object.
+   * @param  {Boolean}      [options.data]    The bucket data option.
+   * @param  {Boolean}      [options.safe]    The safe option.
+   * @param  {Object}       [options.headers] The headers object option.
+   * @param  {Number}       [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  async createBucket<T extends MappableObject>(
+    id: string | null,
+    options: {
+      data?: T & { id?: string };
+      permissions?: Partial<Record<Permission, string[]>>;
+      safe?: boolean;
+      headers?: Record<string, string>;
+      retry?: number;
+    } = {}
+  ): Promise<KintoResponse<T>> {
+    const { data, permissions } = options;
+    const _data = { ...data, id: id ? id : undefined };
+    const path = _data.id ? endpoints.bucket(_data.id) : endpoints.bucket();
+    return this.execute<KintoResponse<T>>(
+      requests.createRequest(
+        path,
+        { data: _data, permissions },
+        {
+          headers: this._getHeaders(options),
+          safe: this._getSafe(options),
+        }
+      ),
+      { retry: this._getRetry(options) }
+    ) as Promise<KintoResponse<T>>;
+  }
+
+  /**
+   * Deletes a bucket from the server.
+   *
+   * @ignore
+   * @param  {Object|String} bucket                  The bucket to delete.
+   * @param  {Object}        [options={}]            The options object.
+   * @param  {Boolean}       [options.safe]          The safe option.
+   * @param  {Object}        [options.headers]       The headers object option.
+   * @param  {Number}        [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Number}        [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async deleteBucket(
+    bucket: string | KintoIdObject,
+    options: {
+      safe?: boolean;
+      headers?: Record<string, string>;
+      retry?: number;
+      last_modified?: number;
+    } = {}
+  ): Promise<KintoResponse<{ deleted: boolean }>> {
+    const bucketObj = toDataBody(bucket);
+    if (!bucketObj.id) {
+      throw new Error("A bucket id is required.");
+    }
+    const path = endpoints.bucket(bucketObj.id);
+    const { last_modified } = { ...bucketObj, ...options };
+    return this.execute<KintoResponse<{ deleted: boolean }>>(
+      requests.deleteRequest(path, {
+        last_modified,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }),
+      { retry: this._getRetry(options) }
+    ) as Promise<KintoResponse<{ deleted: boolean }>>;
+  }
+
+  /**
+   * Deletes buckets.
+   *
+   * @param  {Object} [options={}]             The options object.
+   * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Object} [options.headers={}]     Headers to use when making
+   *     this request.
+   * @param  {Number} [options.retry=0]        Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Object} [options.filters={}]     The filters object.
+   * @param  {Array}  [options.fields]         Limit response to
+   *     just some fields.
+   * @param  {Number}  [options.last_modified] The last_modified option.
+   * @return {Promise<Object[], Error>}
+   */
+  @support("1.4", "2.0")
+  async deleteBuckets(
+    options: PaginatedParams & {
+      safe?: boolean;
+      retry?: number;
+      headers?: Record<string, string>;
+      last_modified?: number;
+    } = {}
+  ): Promise<PaginationResult<KintoObject>> {
+    const path = endpoints.bucket();
+    return this.paginatedDelete<KintoObject>(path, options, {
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+      safe: options.safe,
+      last_modified: options.last_modified,
+    });
+  }
+
+  @capable(["accounts"])
+  async createAccount(
+    username: string,
+    password: string
+  ): Promise<KintoResponse<{ password: string }>> {
+    return this.execute<KintoResponse<{ password: string }>>(
+      requests.createRequest(
+        `/accounts/${username}`,
+        { data: { password } },
+        { method: "PUT" }
+      )
+    ) as Promise<KintoResponse<{ password: string }>>;
+  }
+}

--- a/src/http/batch.ts
+++ b/src/http/batch.ts
@@ -1,0 +1,95 @@
+import { KintoRequest } from "./types";
+
+interface ConflictRecord {
+  last_modified: number;
+  id: string;
+}
+
+interface ConflictResponse {
+  existing: ConflictRecord;
+}
+
+interface ResponseBody {
+  data?: unknown;
+  details?: ConflictResponse;
+  code?: number;
+  errno?: number;
+  error?: string;
+  message?: string;
+  info?: string;
+}
+
+interface ErrorResponse {
+  path: string;
+  sent: KintoRequest;
+  error: ResponseBody;
+}
+
+export interface AggregateResponse {
+  errors: ErrorResponse[];
+  published: ResponseBody[];
+  conflicts: any[];
+  skipped: any[];
+}
+
+export interface KintoBatchResponse {
+  status: number;
+  path: string;
+  body: ResponseBody;
+  headers: { [key: string]: string };
+}
+
+/**
+ * Exports batch responses as a result object.
+ *
+ * @private
+ * @param  {Array} responses The batch subrequest responses.
+ * @param  {Array} requests  The initial issued requests.
+ * @return {Object}
+ */
+export function aggregate(
+  responses: KintoBatchResponse[] = [],
+  requests: KintoRequest[] = []
+): AggregateResponse {
+  if (responses.length !== requests.length) {
+    throw new Error("Responses length should match requests one.");
+  }
+  const results: AggregateResponse = {
+    errors: [],
+    published: [],
+    conflicts: [],
+    skipped: [],
+  };
+  return responses.reduce((acc, response, index) => {
+    const { status } = response;
+    const request = requests[index];
+    if (status >= 200 && status < 400) {
+      acc.published.push(response.body);
+    } else if (status === 404) {
+      // Extract the id manually from request path while waiting for Kinto/kinto#818
+      const regex = /(buckets|groups|collections|records)\/([^/]+)$/;
+      const extracts = request.path.match(regex);
+      const id = extracts && extracts.length === 3 ? extracts[2] : undefined;
+      acc.skipped.push({
+        id,
+        path: request.path,
+        error: response.body,
+      });
+    } else if (status === 412) {
+      acc.conflicts.push({
+        // XXX: specifying the type is probably superfluous
+        type: "outgoing",
+        local: request.body,
+        remote:
+          (response.body.details && response.body.details.existing) || null,
+      });
+    } else {
+      acc.errors.push({
+        path: request.path,
+        sent: request,
+        error: response.body,
+      });
+    }
+    return acc;
+  }, results);
+}

--- a/src/http/bucket.ts
+++ b/src/http/bucket.ts
@@ -1,0 +1,838 @@
+import { toDataBody, isObject, capable } from "./utils";
+import Collection from "./collection";
+import * as requests from "./requests";
+import KintoClientBase, { PaginatedParams, PaginationResult } from "./base";
+import {
+  KintoRequest,
+  KintoIdObject,
+  Permission,
+  KintoResponse,
+  HistoryEntry,
+  KintoObject,
+  Group,
+  OperationResponse,
+  MappableObject,
+} from "./types";
+import { HttpResponse } from "./http";
+import { AggregateResponse } from "./batch";
+
+export interface BucketOptions {
+  safe?: boolean;
+  headers?: Record<string, string>;
+  retry?: number;
+}
+/**
+ * Abstract representation of a selected bucket.
+ *
+ */
+export default class Bucket {
+  private client: KintoClientBase;
+  public name: string;
+  private _endpoints: KintoClientBase["endpoints"];
+  private _retry: number;
+  private _safe: boolean;
+  private _headers: Record<string, string>;
+
+  /**
+   * Constructor.
+   *
+   * @param  {KintoClient} client            The client instance.
+   * @param  {String}      name              The bucket name.
+   * @param  {Object}      [options={}]      The headers object option.
+   * @param  {Object}      [options.headers] The headers object option.
+   * @param  {Boolean}     [options.safe]    The safe option.
+   * @param  {Number}      [options.retry]   The retry option.
+   */
+  constructor(
+    client: KintoClientBase,
+    name: string,
+    options: BucketOptions = {}
+  ) {
+    /**
+     * @ignore
+     */
+    this.client = client;
+    /**
+     * The bucket name.
+     * @type {String}
+     */
+    this.name = name;
+
+    this._endpoints = client.endpoints;
+
+    /**
+     * @ignore
+     */
+    this._headers = options.headers || {};
+    this._retry = options.retry || 0;
+    this._safe = !!options.safe;
+  }
+
+  get execute(): KintoClientBase["execute"] {
+    return this.client.execute.bind(this.client);
+  }
+
+  get headers(): Record<string, string> {
+    return this._headers;
+  }
+
+  /**
+   * Get the value of "headers" for a given request, merging the
+   * per-request headers with our own "default" headers.
+   *
+   * @private
+   */
+  private _getHeaders(options: {
+    headers?: Record<string, string>;
+  }): Record<string, string> {
+    return {
+      ...this._headers,
+      ...options.headers,
+    };
+  }
+
+  /**
+   * Get the value of "safe" for a given request, using the
+   * per-request option if present or falling back to our default
+   * otherwise.
+   *
+   * @private
+   * @param {Object} options The options for a request.
+   * @returns {Boolean}
+   */
+  private _getSafe(options: { safe?: boolean }): boolean {
+    return { safe: this._safe, ...options }.safe;
+  }
+
+  /**
+   * As _getSafe, but for "retry".
+   *
+   * @private
+   */
+  private _getRetry(options: { retry?: number }): number {
+    return { retry: this._retry, ...options }.retry;
+  }
+
+  /**
+   * Selects a collection.
+   *
+   * @param  {String}  name              The collection name.
+   * @param  {Object}  [options={}]      The options object.
+   * @param  {Object}  [options.headers] The headers object option.
+   * @param  {Boolean} [options.safe]    The safe option.
+   * @return {Collection}
+   */
+  collection(
+    name: string,
+    options: {
+      headers?: Record<string, string>;
+      safe?: boolean;
+      retry?: number;
+    } = {}
+  ): Collection {
+    return new Collection(this.client, this, name, {
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+      safe: this._getSafe(options),
+    });
+  }
+
+  /**
+   * Retrieves the ETag of the collection list, for use with the `since` filtering option.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<String, Error>}
+   */
+  async getCollectionsTimestamp(
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+    } = {}
+  ): Promise<string | null> {
+    const path = this._endpoints.collection(this.name);
+    const request: KintoRequest = {
+      headers: this._getHeaders(options),
+      path,
+      method: "HEAD",
+    };
+    const { headers } = (await this.client.execute(request, {
+      raw: true,
+      retry: this._getRetry(options),
+    })) as HttpResponse<{}>;
+    return headers.get("ETag");
+  }
+
+  /**
+   * Retrieves the ETag of the group list, for use with the `since` filtering option.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<String, Error>}
+   */
+  async getGroupsTimestamp(
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+    } = {}
+  ): Promise<string | null> {
+    const path = this._endpoints.group(this.name);
+    const request: KintoRequest = {
+      headers: this._getHeaders(options),
+      path,
+      method: "HEAD",
+    };
+    const { headers } = (await this.client.execute(request, {
+      raw: true,
+      retry: this._getRetry(options),
+    })) as HttpResponse<{}>;
+    return headers.get("ETag");
+  }
+
+  /**
+   * Retrieves bucket data.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Object} [options.query]   Query parameters to pass in
+   *     the request. This might be useful for features that aren't
+   *     yet supported by this library.
+   * @param  {Array}  [options.fields]  Limit response to
+   *     just some fields.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  async getData<T>(
+    options: {
+      headers?: Record<string, string>;
+      query?: { [key: string]: string };
+      fields?: string[];
+      retry?: number;
+    } = {}
+  ): Promise<T> {
+    const path = this._endpoints.bucket(this.name);
+    const request = {
+      headers: this._getHeaders(options),
+      path,
+    };
+    const { data } = (await this.client.execute(request, {
+      retry: this._getRetry(options),
+      query: options.query,
+      fields: options.fields,
+    })) as { data: T };
+    return data;
+  }
+
+  /**
+   * Set bucket data.
+   * @param  {Object}  data                    The bucket data object.
+   * @param  {Object}  [options={}]            The options object.
+   * @param  {Object}  [options.headers={}]    The headers object option.
+   * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Boolean} [options.patch]         The patch option.
+   * @param  {Number}  [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async setData<T extends MappableObject>(
+    data: T & { last_modified?: number },
+    options: {
+      headers?: Record<string, string>;
+      safe?: boolean;
+      retry?: number;
+      patch?: boolean;
+      last_modified?: number;
+      permissions?: { [key in Permission]?: string[] };
+    } = {}
+  ): Promise<KintoResponse<T>> {
+    if (!isObject(data)) {
+      throw new Error("A bucket object is required.");
+    }
+
+    const bucket: T & { last_modified?: number; id?: string } = {
+      ...data,
+      id: this.name,
+    };
+
+    // For default bucket, we need to drop the id from the data object.
+    // Bug in Kinto < 3.1.1
+    const bucketId = bucket.id;
+    if (bucket.id === "default") {
+      delete bucket.id;
+    }
+
+    const path = this._endpoints.bucket(bucketId);
+    const { patch, permissions } = options;
+    const { last_modified } = { ...data, ...options };
+    const request = requests.updateRequest(
+      path,
+      { data: bucket, permissions },
+      {
+        last_modified,
+        patch,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<T>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<T>>;
+  }
+
+  /**
+   * Retrieves the list of history entries in the current bucket.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Array<Object>, Error>}
+   */
+  @capable(["history"])
+  async listHistory<T>(
+    options: PaginatedParams & {
+      headers?: Record<string, string>;
+      retry?: number;
+    } = {}
+  ): Promise<PaginationResult<HistoryEntry<T>>> {
+    const path = this._endpoints.history(this.name);
+    return this.client.paginatedList<HistoryEntry<T>>(path, options, {
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+    });
+  }
+
+  /**
+   * Retrieves the list of collections in the current bucket.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.filters={}] The filters object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Array}  [options.fields]  Limit response to
+   *     just some fields.
+   * @return {Promise<Array<Object>, Error>}
+   */
+  async listCollections(
+    options: PaginatedParams & {
+      filters?: Record<string, string | number>;
+      headers?: Record<string, string>;
+      retry?: number;
+      fields?: string[];
+    } = {}
+  ): Promise<PaginationResult<KintoObject>> {
+    const path = this._endpoints.collection(this.name);
+    return this.client.paginatedList<KintoObject>(path, options, {
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+    });
+  }
+
+  /**
+   * Creates a new collection in current bucket.
+   *
+   * @param  {String|undefined}  id          The collection id.
+   * @param  {Object}  [options={}]          The options object.
+   * @param  {Boolean} [options.safe]        The safe option.
+   * @param  {Object}  [options.headers]     The headers object option.
+   * @param  {Number}  [options.retry=0]     Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Object}  [options.permissions] The permissions object.
+   * @param  {Object}  [options.data]        The data object.
+   * @return {Promise<Object, Error>}
+   */
+  async createCollection(
+    id?: string,
+    options: {
+      safe?: boolean;
+      headers?: Record<string, string>;
+      retry?: number;
+      permissions?: { [key in Permission]?: string[] };
+      data?: any;
+    } = {}
+  ): Promise<KintoResponse<{}>> {
+    const { permissions, data = {} } = options;
+    data.id = id;
+    const path = this._endpoints.collection(this.name, id);
+    const request = requests.createRequest(
+      path,
+      { data, permissions },
+      {
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<{}>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{}>>;
+  }
+
+  /**
+   * Deletes a collection from the current bucket.
+   *
+   * @param  {Object|String} collection              The collection to delete.
+   * @param  {Object}        [options={}]            The options object.
+   * @param  {Object}        [options.headers]       The headers object option.
+   * @param  {Number}        [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Boolean}       [options.safe]          The safe option.
+   * @param  {Number}        [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async deleteCollection(
+    collection: string | KintoIdObject,
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+      safe?: boolean;
+      last_modified?: number;
+    } = {}
+  ): Promise<KintoResponse<{ deleted: boolean }>> {
+    const collectionObj = toDataBody(collection);
+    if (!collectionObj.id) {
+      throw new Error("A collection id is required.");
+    }
+    const { id } = collectionObj;
+    const { last_modified } = { ...collectionObj, ...options };
+    const path = this._endpoints.collection(this.name, id);
+    const request = requests.deleteRequest(path, {
+      last_modified,
+      headers: this._getHeaders(options),
+      safe: this._getSafe(options),
+    });
+    return this.client.execute<KintoResponse<{ deleted: boolean }>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{ deleted: boolean }>>;
+  }
+
+  /**
+   * Deletes collections from the current bucket.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.filters={}] The filters object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Array}  [options.fields]  Limit response to
+   *     just some fields.
+   * @return {Promise<Array<Object>, Error>}
+   */
+  async deleteCollections(
+    options: PaginatedParams & {
+      headers?: Record<string, string>;
+      retry?: number;
+    } = {}
+  ): Promise<PaginationResult<KintoObject>> {
+    const path = this._endpoints.collection(this.name);
+    return this.client.paginatedDelete<KintoObject>(path, options, {
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+    });
+  }
+
+  /**
+   * Retrieves the list of groups in the current bucket.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.filters={}] The filters object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Array}  [options.fields]  Limit response to
+   *     just some fields.
+   * @return {Promise<Array<Object>, Error>}
+   */
+  async listGroups(
+    options: PaginatedParams & {
+      headers?: Record<string, string>;
+      retry?: number;
+    } = {}
+  ): Promise<PaginationResult<Group>> {
+    const path = this._endpoints.group(this.name);
+    return this.client.paginatedList<Group>(path, options, {
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+    });
+  }
+
+  /**
+   * Fetches a group in current bucket.
+   *
+   * @param  {String} id                The group id.
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Object} [options.query]   Query parameters to pass in
+   *     the request. This might be useful for features that aren't
+   *     yet supported by this library.
+   * @param  {Array}  [options.fields]  Limit response to
+   *     just some fields.
+   * @return {Promise<Object, Error>}
+   */
+  async getGroup(
+    id: string,
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+      query?: { [key: string]: string };
+      fields?: string[];
+    } = {}
+  ): Promise<KintoResponse<Group>> {
+    const path = this._endpoints.group(this.name, id);
+    const request = {
+      headers: this._getHeaders(options),
+      path,
+    };
+    return this.client.execute<KintoResponse<Group>>(request, {
+      retry: this._getRetry(options),
+      query: options.query,
+      fields: options.fields,
+    }) as Promise<KintoResponse<Group>>;
+  }
+
+  /**
+   * Creates a new group in current bucket.
+   *
+   * @param  {String|undefined}  id                    The group id.
+   * @param  {Array<String>}     [members=[]]          The list of principals.
+   * @param  {Object}            [options={}]          The options object.
+   * @param  {Object}            [options.data]        The data object.
+   * @param  {Object}            [options.permissions] The permissions object.
+   * @param  {Boolean}           [options.safe]        The safe option.
+   * @param  {Object}            [options.headers]     The headers object option.
+   * @param  {Number}            [options.retry=0]     Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  async createGroup(
+    id?: string,
+    members: string[] = [],
+    options: {
+      data?: any;
+      permissions?: { [key in Permission]?: string[] };
+      safe?: boolean;
+      headers?: Record<string, string>;
+      retry?: number;
+    } = {}
+  ): Promise<KintoResponse<Group>> {
+    const data = {
+      ...options.data,
+      id,
+      members,
+    };
+    const path = this._endpoints.group(this.name, id);
+    const { permissions } = options;
+    const request = requests.createRequest(
+      path,
+      { data, permissions },
+      {
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<Group>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<Group>>;
+  }
+
+  /**
+   * Updates an existing group in current bucket.
+   *
+   * @param  {Object}  group                   The group object.
+   * @param  {Object}  [options={}]            The options object.
+   * @param  {Object}  [options.data]          The data object.
+   * @param  {Object}  [options.permissions]   The permissions object.
+   * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Number}  [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async updateGroup<T extends MappableObject>(
+    group: KintoIdObject,
+    options: {
+      data?: T & { members?: string[] };
+      permissions?: { [key in Permission]?: string[] };
+      safe?: boolean;
+      headers?: Record<string, string>;
+      retry?: number;
+      last_modified?: number;
+      patch?: boolean;
+    } = {}
+  ): Promise<KintoResponse<T & { members: string[] }>> {
+    if (!isObject(group)) {
+      throw new Error("A group object is required.");
+    }
+    if (!group.id) {
+      throw new Error("A group id is required.");
+    }
+    const data = {
+      ...options.data,
+      ...group,
+    };
+    const path = this._endpoints.group(this.name, group.id);
+    const { patch, permissions } = options;
+    const { last_modified } = { ...data, ...options };
+    const request = requests.updateRequest(
+      path,
+      { data, permissions },
+      {
+        last_modified,
+        patch,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<T & { members: string[] }>>(
+      request,
+      {
+        retry: this._getRetry(options),
+      }
+    ) as Promise<KintoResponse<T & { members: string[] }>>;
+  }
+
+  /**
+   * Deletes a group from the current bucket.
+   *
+   * @param  {Object|String} group                   The group to delete.
+   * @param  {Object}        [options={}]            The options object.
+   * @param  {Object}        [options.headers]       The headers object option.
+   * @param  {Number}        [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Boolean}       [options.safe]          The safe option.
+   * @param  {Number}        [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async deleteGroup(
+    group: string | KintoIdObject,
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+      safe?: boolean;
+      last_modified?: number;
+    } = {}
+  ): Promise<KintoResponse<{ deleted: boolean }>> {
+    const groupObj = toDataBody(group);
+    const { id } = groupObj;
+    const { last_modified } = { ...groupObj, ...options };
+    const path = this._endpoints.group(this.name, id);
+    const request = requests.deleteRequest(path, {
+      last_modified,
+      headers: this._getHeaders(options),
+      safe: this._getSafe(options),
+    });
+    return this.client.execute<KintoResponse<{ deleted: boolean }>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{ deleted: boolean }>>;
+  }
+
+  /**
+   * Deletes groups from the current bucket.
+   *
+   * @param  {Object} [options={}]          The options object.
+   * @param  {Object} [options.filters={}]  The filters object.
+   * @param  {Object} [options.headers]     The headers object option.
+   * @param  {Number} [options.retry=0]     Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Array}  [options.fields]      Limit response to
+   *     just some fields.
+   * @return {Promise<Array<Object>, Error>}
+   */
+  async deleteGroups(
+    options: PaginatedParams & {
+      headers?: Record<string, string>;
+      retry?: number;
+    } = {}
+  ): Promise<PaginationResult<KintoObject>> {
+    const path = this._endpoints.group(this.name);
+    return this.client.paginatedDelete<KintoObject>(path, options, {
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+    });
+  }
+
+  /**
+   * Retrieves the list of permissions for this bucket.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  async getPermissions(
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+    } = {}
+  ): Promise<{ [key in Permission]?: string[] }> {
+    const request = {
+      headers: this._getHeaders(options),
+      path: this._endpoints.bucket(this.name),
+    };
+    const { permissions } = (await this.client.execute<KintoResponse>(request, {
+      retry: this._getRetry(options),
+    })) as KintoResponse;
+    return permissions;
+  }
+
+  /**
+   * Replaces all existing bucket permissions with the ones provided.
+   *
+   * @param  {Object}  permissions             The permissions object.
+   * @param  {Object}  [options={}]            The options object
+   * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Object}  [options.headers={}]    The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Object}  [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async setPermissions(
+    permissions: { [key in Permission]?: string[] },
+    options: {
+      safe?: boolean;
+      headers?: Record<string, string>;
+      retry?: number;
+      last_modified?: number;
+    } = {}
+  ): Promise<KintoResponse<{}>> {
+    if (!isObject(permissions)) {
+      throw new Error("A permissions object is required.");
+    }
+    const path = this._endpoints.bucket(this.name);
+    const { last_modified } = options;
+    const data = { last_modified };
+    const request = requests.updateRequest(
+      path,
+      { data, permissions },
+      {
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<{}>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{}>>;
+  }
+
+  /**
+   * Append principals to the bucket permissions.
+   *
+   * @param  {Object}  permissions             The permissions object.
+   * @param  {Object}  [options={}]            The options object
+   * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Object}  [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async addPermissions(
+    permissions: { [key in Permission]?: string[] },
+    options: {
+      safe?: boolean;
+      headers?: Record<string, string>;
+      retry?: number;
+      last_modified?: number;
+    } = {}
+  ): Promise<KintoResponse<{}>> {
+    if (!isObject(permissions)) {
+      throw new Error("A permissions object is required.");
+    }
+    const path = this._endpoints.bucket(this.name);
+    const { last_modified } = options;
+    const request = requests.jsonPatchPermissionsRequest(
+      path,
+      permissions,
+      "add",
+      {
+        last_modified,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<{}>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{}>>;
+  }
+
+  /**
+   * Remove principals from the bucket permissions.
+   *
+   * @param  {Object}  permissions             The permissions object.
+   * @param  {Object}  [options={}]            The options object
+   * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Object}  [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async removePermissions(
+    permissions: { [key in Permission]?: string[] },
+    options: {
+      safe?: boolean;
+      headers?: Record<string, string>;
+      retry?: number;
+      last_modified?: number;
+    } = {}
+  ): Promise<KintoResponse<{}>> {
+    if (!isObject(permissions)) {
+      throw new Error("A permissions object is required.");
+    }
+    const path = this._endpoints.bucket(this.name);
+    const { last_modified } = options;
+    const request = requests.jsonPatchPermissionsRequest(
+      path,
+      permissions,
+      "remove",
+      {
+        last_modified,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<{}>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{}>>;
+  }
+
+  /**
+   * Performs batch operations at the current bucket level.
+   *
+   * @param  {Function} fn                   The batch operation function.
+   * @param  {Object}   [options={}]         The options object.
+   * @param  {Object}   [options.headers]    The headers object option.
+   * @param  {Boolean}  [options.safe]       The safe option.
+   * @param  {Number}   [options.retry=0]    The retry option.
+   * @param  {Boolean}  [options.aggregate]  Produces a grouped result object.
+   * @return {Promise<Object, Error>}
+   */
+  async batch(
+    fn: (client: Bucket) => void,
+    options: {
+      headers?: Record<string, string>;
+      safe?: boolean;
+      retry?: number;
+      aggregate?: boolean;
+    } = {}
+  ): Promise<OperationResponse<KintoObject>[] | AggregateResponse> {
+    return this.client.batch(fn, {
+      bucket: this.name,
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+      safe: this._getSafe(options),
+      aggregate: !!options.aggregate,
+    });
+  }
+}

--- a/src/http/collection.ts
+++ b/src/http/collection.ts
@@ -1,0 +1,886 @@
+import { v4 as uuid } from "uuid";
+
+import { capable, toDataBody, isObject } from "./utils";
+import * as requests from "./requests";
+import KintoClientBase, { PaginatedParams, PaginationResult } from "./base";
+import Bucket from "./bucket";
+import {
+  KintoRequest,
+  Permission,
+  KintoResponse,
+  KintoIdObject,
+  KintoObject,
+  Attachment,
+  OperationResponse,
+  MappableObject,
+} from "./types";
+import { HttpResponse } from "./http";
+import { AggregateResponse } from "./batch";
+
+export interface CollectionOptions {
+  headers?: Record<string, string>;
+  safe?: boolean;
+  retry?: number;
+}
+
+/**
+ * Abstract representation of a selected collection.
+ *
+ */
+export default class Collection {
+  public client: KintoClientBase;
+  private bucket: Bucket;
+  public name: string;
+  private _endpoints: KintoClientBase["endpoints"];
+  private _retry: number;
+  private _safe: boolean;
+  private _headers: Record<string, string>;
+
+  /**
+   * Constructor.
+   *
+   * @param  {KintoClient}  client            The client instance.
+   * @param  {Bucket}       bucket            The bucket instance.
+   * @param  {String}       name              The collection name.
+   * @param  {Object}       [options={}]      The options object.
+   * @param  {Object}       [options.headers] The headers object option.
+   * @param  {Boolean}      [options.safe]    The safe option.
+   * @param  {Number}       [options.retry]   The retry option.
+   * @param  {Boolean}      [options.batch]   (Private) Whether this
+   *     Collection is operating as part of a batch.
+   */
+  constructor(
+    client: KintoClientBase,
+    bucket: Bucket,
+    name: string,
+    options: CollectionOptions = {}
+  ) {
+    /**
+     * @ignore
+     */
+    this.client = client;
+    /**
+     * @ignore
+     */
+    this.bucket = bucket;
+    /**
+     * The collection name.
+     * @type {String}
+     */
+    this.name = name;
+
+    this._endpoints = client.endpoints;
+
+    /**
+     * @ignore
+     */
+    this._retry = options.retry || 0;
+    this._safe = !!options.safe;
+    // FIXME: This is kind of ugly; shouldn't the bucket be responsible
+    // for doing the merge?
+    this._headers = {
+      ...this.bucket.headers,
+      ...options.headers,
+    };
+  }
+
+  get execute(): KintoClientBase["execute"] {
+    return this.client.execute.bind(this.client);
+  }
+
+  /**
+   * Get the value of "headers" for a given request, merging the
+   * per-request headers with our own "default" headers.
+   *
+   * @private
+   */
+  private _getHeaders(options: {
+    headers?: Record<string, string>;
+  }): Record<string, string> {
+    return {
+      ...this._headers,
+      ...options.headers,
+    };
+  }
+
+  /**
+   * Get the value of "safe" for a given request, using the
+   * per-request option if present or falling back to our default
+   * otherwise.
+   *
+   * @private
+   * @param {Object} options The options for a request.
+   * @returns {Boolean}
+   */
+  private _getSafe(options: { safe?: boolean }): boolean {
+    return { safe: this._safe, ...options }.safe;
+  }
+
+  /**
+   * As _getSafe, but for "retry".
+   *
+   * @private
+   */
+  private _getRetry(options: { retry?: number }): number {
+    return { retry: this._retry, ...options }.retry;
+  }
+
+  /**
+   * Retrieves the total number of records in this collection.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Number, Error>}
+   */
+  async getTotalRecords(
+    options: { headers?: Record<string, string>; retry?: number } = {}
+  ): Promise<number> {
+    const path = this._endpoints.record(this.bucket.name, this.name);
+    const request: KintoRequest = {
+      headers: this._getHeaders(options),
+      path,
+      method: "HEAD",
+    };
+    const { headers } = await this.client.execute(request, {
+      raw: true,
+      retry: this._getRetry(options),
+    });
+    return parseInt(headers.get("Total-Records"), 10);
+  }
+
+  /**
+   * Retrieves the ETag of the records list, for use with the `since` filtering option.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<String, Error>}
+   */
+  async getRecordsTimestamp(
+    options: { headers?: Record<string, string>; retry?: number } = {}
+  ): Promise<string | null> {
+    const path = this._endpoints.record(this.bucket.name, this.name);
+    const request: KintoRequest = {
+      headers: this._getHeaders(options),
+      path,
+      method: "HEAD",
+    };
+    const { headers } = (await this.client.execute(request, {
+      raw: true,
+      retry: this._getRetry(options),
+    })) as HttpResponse<{}>;
+    return headers.get("ETag");
+  }
+
+  /**
+   * Retrieves collection data.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Object} [options.query]   Query parameters to pass in
+   *     the request. This might be useful for features that aren't
+   *     yet supported by this library.
+   * @param  {Array}  [options.fields]  Limit response to
+   *     just some fields.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  async getData<T>(
+    options: {
+      headers?: Record<string, string>;
+      query?: { [key: string]: string };
+      fields?: string[];
+      retry?: number;
+    } = {}
+  ): Promise<T> {
+    const path = this._endpoints.collection(this.bucket.name, this.name);
+    const request = { headers: this._getHeaders(options), path };
+    const { data } = (await this.client.execute(request, {
+      retry: this._getRetry(options),
+      query: options.query,
+      fields: options.fields,
+    })) as { data: T };
+    return data;
+  }
+
+  /**
+   * Set collection data.
+   * @param  {Object}   data                    The collection data object.
+   * @param  {Object}   [options={}]            The options object.
+   * @param  {Object}   [options.headers]       The headers object option.
+   * @param  {Number}   [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Boolean}  [options.safe]          The safe option.
+   * @param  {Boolean}  [options.patch]         The patch option.
+   * @param  {Number}   [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async setData<T extends MappableObject>(
+    data: T & { last_modified?: number },
+    options: {
+      headers?: Record<string, string>;
+      safe?: boolean;
+      retry?: number;
+      patch?: boolean;
+      last_modified?: number;
+      permissions?: { [key in Permission]?: string[] };
+    } = {}
+  ): Promise<KintoResponse<T>> {
+    if (!isObject(data)) {
+      throw new Error("A collection object is required.");
+    }
+    const { patch, permissions } = options;
+    const { last_modified } = { ...data, ...options };
+
+    const path = this._endpoints.collection(this.bucket.name, this.name);
+    const request = requests.updateRequest(
+      path,
+      { data, permissions },
+      {
+        last_modified,
+        patch,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<T>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<T>>;
+  }
+
+  /**
+   * Retrieves the list of permissions for this collection.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  async getPermissions(
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+    } = {}
+  ): Promise<{ [key in Permission]?: string[] }> {
+    const path = this._endpoints.collection(this.bucket.name, this.name);
+    const request = { headers: this._getHeaders(options), path };
+    const { permissions } = (await this.client.execute<KintoResponse>(request, {
+      retry: this._getRetry(options),
+    })) as KintoResponse;
+    return permissions;
+  }
+
+  /**
+   * Replaces all existing collection permissions with the ones provided.
+   *
+   * @param  {Object}   permissions             The permissions object.
+   * @param  {Object}   [options={}]            The options object
+   * @param  {Object}   [options.headers]       The headers object option.
+   * @param  {Number}   [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Boolean}  [options.safe]          The safe option.
+   * @param  {Number}   [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async setPermissions(
+    permissions: { [key in Permission]?: string[] },
+    options: {
+      safe?: boolean;
+      headers?: Record<string, string>;
+      retry?: number;
+      last_modified?: number;
+    } = {}
+  ): Promise<KintoResponse<{}>> {
+    if (!isObject(permissions)) {
+      throw new Error("A permissions object is required.");
+    }
+    const path = this._endpoints.collection(this.bucket.name, this.name);
+    const data = { last_modified: options.last_modified };
+    const request = requests.updateRequest(
+      path,
+      { data, permissions },
+      {
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<{}>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{}>>;
+  }
+
+  /**
+   * Append principals to the collection permissions.
+   *
+   * @param  {Object}  permissions             The permissions object.
+   * @param  {Object}  [options={}]            The options object
+   * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Object}  [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async addPermissions(
+    permissions: { [key in Permission]?: string[] },
+    options: {
+      safe?: boolean;
+      headers?: Record<string, string>;
+      retry?: number;
+      last_modified?: number;
+    } = {}
+  ): Promise<KintoResponse<{}>> {
+    if (!isObject(permissions)) {
+      throw new Error("A permissions object is required.");
+    }
+    const path = this._endpoints.collection(this.bucket.name, this.name);
+    const { last_modified } = options;
+    const request = requests.jsonPatchPermissionsRequest(
+      path,
+      permissions,
+      "add",
+      {
+        last_modified,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<{}>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{}>>;
+  }
+
+  /**
+   * Remove principals from the collection permissions.
+   *
+   * @param  {Object}  permissions             The permissions object.
+   * @param  {Object}  [options={}]            The options object
+   * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Object}  [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async removePermissions(
+    permissions: { [key in Permission]?: string[] },
+    options: {
+      safe?: boolean;
+      headers?: Record<string, string>;
+      retry?: number;
+      last_modified?: number;
+    } = {}
+  ): Promise<KintoResponse<{}>> {
+    if (!isObject(permissions)) {
+      throw new Error("A permissions object is required.");
+    }
+    const path = this._endpoints.collection(this.bucket.name, this.name);
+    const { last_modified } = options;
+    const request = requests.jsonPatchPermissionsRequest(
+      path,
+      permissions,
+      "remove",
+      {
+        last_modified,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<{}>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{}>>;
+  }
+
+  /**
+   * Creates a record in current collection.
+   *
+   * @param  {Object}  record                The record to create.
+   * @param  {Object}  [options={}]          The options object.
+   * @param  {Object}  [options.headers]     The headers object option.
+   * @param  {Number}  [options.retry=0]     Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Boolean} [options.safe]        The safe option.
+   * @param  {Object}  [options.permissions] The permissions option.
+   * @return {Promise<Object, Error>}
+   */
+  async createRecord<T extends MappableObject>(
+    record: T & { id?: string },
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+      safe?: boolean;
+      permissions?: { [key in Permission]?: string[] };
+    } = {}
+  ): Promise<KintoResponse<T>> {
+    const { permissions } = options;
+    const path = this._endpoints.record(this.bucket.name, this.name, record.id);
+    const request = requests.createRequest(
+      path,
+      { data: record, permissions },
+      {
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    return this.client.execute<KintoResponse<T>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<T>>;
+  }
+
+  /**
+   * Adds an attachment to a record, creating the record when it doesn't exist.
+   *
+   * @param  {String}  dataURL                 The data url.
+   * @param  {Object}  [record={}]             The record data.
+   * @param  {Object}  [options={}]            The options object.
+   * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Number}  [options.last_modified] The last_modified option.
+   * @param  {Object}  [options.permissions]   The permissions option.
+   * @param  {String}  [options.filename]      Force the attachment filename.
+   * @param  {String}  [options.gzipped]       Force the attachment to be gzipped or not.
+   * @return {Promise<Object, Error>}
+   */
+  @capable(["attachments"])
+  async addAttachment(
+    dataURI: string,
+    record: { [key: string]: string } = {},
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+      safe?: boolean;
+      last_modified?: number;
+      permissions?: { [key in Permission]?: string[] };
+      filename?: string;
+      gzipped?: boolean;
+    } = {}
+  ): Promise<
+    KintoResponse<{
+      attachment: Attachment;
+    }>
+  > {
+    const { permissions } = options;
+    const id = record.id || uuid();
+    const path = this._endpoints.attachment(this.bucket.name, this.name, id);
+    const { last_modified } = { ...record, ...options };
+    const addAttachmentRequest = requests.addAttachmentRequest(
+      path,
+      dataURI,
+      { data: record, permissions },
+      {
+        last_modified,
+        filename: options.filename,
+        gzipped: options.gzipped,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
+    );
+    await this.client.execute(addAttachmentRequest, {
+      stringify: false,
+      retry: this._getRetry(options),
+    });
+    return this.getRecord<{ attachment: Attachment }>(id);
+  }
+
+  /**
+   * Removes an attachment from a given record.
+   *
+   * @param  {Object}  recordId                The record id.
+   * @param  {Object}  [options={}]            The options object.
+   * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Number}  [options.last_modified] The last_modified option.
+   */
+  @capable(["attachments"])
+  async removeAttachment(
+    recordId: string,
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+      safe?: boolean;
+      last_modified?: number;
+    } = {}
+  ): Promise<{}> {
+    const { last_modified } = options;
+    const path = this._endpoints.attachment(
+      this.bucket.name,
+      this.name,
+      recordId
+    );
+    const request = requests.deleteRequest(path, {
+      last_modified,
+      headers: this._getHeaders(options),
+      safe: this._getSafe(options),
+    });
+    return this.client.execute<{}>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<{}>;
+  }
+
+  /**
+   * Updates a record in current collection.
+   *
+   * @param  {Object}  record                  The record to update.
+   * @param  {Object}  [options={}]            The options object.
+   * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Number}  [options.last_modified] The last_modified option.
+   * @param  {Object}  [options.permissions]   The permissions option.
+   * @return {Promise<Object, Error>}
+   */
+  async updateRecord<T>(
+    record: T & { id: string },
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+      safe?: boolean;
+      last_modified?: number;
+      permissions?: { [key in Permission]?: string[] };
+      patch?: boolean;
+    } = {}
+  ): Promise<KintoResponse<T>> {
+    if (!isObject(record)) {
+      throw new Error("A record object is required.");
+    }
+    if (!record.id) {
+      throw new Error("A record id is required.");
+    }
+    const { permissions } = options;
+    const { last_modified } = { ...record, ...options };
+    const path = this._endpoints.record(this.bucket.name, this.name, record.id);
+    const request = requests.updateRequest(
+      path,
+      { data: record, permissions },
+      {
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+        last_modified,
+        patch: !!options.patch,
+      }
+    );
+    return this.client.execute<KintoResponse<T>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<T>>;
+  }
+
+  /**
+   * Deletes a record from the current collection.
+   *
+   * @param  {Object|String} record                  The record to delete.
+   * @param  {Object}        [options={}]            The options object.
+   * @param  {Object}        [options.headers]       The headers object option.
+   * @param  {Number}        [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Boolean}       [options.safe]          The safe option.
+   * @param  {Number}        [options.last_modified] The last_modified option.
+   * @return {Promise<Object, Error>}
+   */
+  async deleteRecord(
+    record: string | KintoIdObject,
+    options: {
+      headers?: Record<string, string>;
+      retry?: number;
+      safe?: boolean;
+      last_modified?: number;
+    } = {}
+  ): Promise<KintoResponse<{ deleted: boolean }>> {
+    const recordObj = toDataBody(record);
+    if (!recordObj.id) {
+      throw new Error("A record id is required.");
+    }
+    const { id } = recordObj;
+    const { last_modified } = { ...recordObj, ...options };
+    const path = this._endpoints.record(this.bucket.name, this.name, id);
+    const request = requests.deleteRequest(path, {
+      last_modified,
+      headers: this._getHeaders(options),
+      safe: this._getSafe(options),
+    });
+    return this.client.execute<KintoResponse<{ deleted: boolean }>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{ deleted: boolean }>>;
+  }
+
+  /**
+   * Deletes records from the current collection.
+   *
+   * Sorting is done by passing a `sort` string option:
+   *
+   * - The field to order the results by, prefixed with `-` for descending.
+   * Default: `-last_modified`.
+   *
+   * @see http://kinto.readthedocs.io/en/stable/api/1.x/sorting.html
+   *
+   * Filtering is done by passing a `filters` option object:
+   *
+   * - `{fieldname: "value"}`
+   * - `{min_fieldname: 4000}`
+   * - `{in_fieldname: "1,2,3"}`
+   * - `{not_fieldname: 0}`
+   * - `{exclude_fieldname: "0,1"}`
+   *
+   * @see http://kinto.readthedocs.io/en/stable/api/1.x/filtering.html
+   *
+   * @param  {Object}   [options={}]                    The options object.
+   * @param  {Object}   [options.headers]               The headers object option.
+   * @param  {Number}   [options.retry=0]               Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Object}   [options.filters={}]            The filters object.
+   * @param  {String}   [options.sort="-last_modified"] The sort field.
+   * @param  {String}   [options.at]                    The timestamp to get a snapshot at.
+   * @param  {String}   [options.limit=null]            The limit field.
+   * @param  {String}   [options.pages=1]               The number of result pages to aggregate.
+   * @param  {Number}   [options.since=null]            Only retrieve records modified since the provided timestamp.
+   * @param  {Array}    [options.fields]                Limit response to just some fields.
+   * @return {Promise<Object, Error>}
+   */
+  async deleteRecords<T extends KintoObject>(
+    options: PaginatedParams & {
+      headers?: Record<string, string>;
+      retry?: number;
+    } = {}
+  ): Promise<PaginationResult<T>> {
+    const path = this._endpoints.record(this.bucket.name, this.name);
+    return this.client.paginatedDelete<T>(path, options, {
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+    });
+  }
+
+  /**
+   * Retrieves a record from the current collection.
+   *
+   * @param  {String} id                The record id to retrieve.
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Object} [options.query]   Query parameters to pass in
+   *     the request. This might be useful for features that aren't
+   *     yet supported by this library.
+   * @param  {Array}  [options.fields]  Limit response to
+   *     just some fields.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<Object, Error>}
+   */
+  async getRecord<T>(
+    id: string,
+    options: {
+      headers?: Record<string, string>;
+      query?: { [key: string]: string };
+      fields?: string[];
+      retry?: number;
+    } = {}
+  ): Promise<KintoResponse<T>> {
+    const path = this._endpoints.record(this.bucket.name, this.name, id);
+    const request = { headers: this._getHeaders(options), path };
+    return this.client.execute<KintoResponse<T>>(request, {
+      retry: this._getRetry(options),
+      query: options.query,
+      fields: options.fields,
+    }) as Promise<KintoResponse<T>>;
+  }
+
+  /**
+   * Lists records from the current collection.
+   *
+   * Sorting is done by passing a `sort` string option:
+   *
+   * - The field to order the results by, prefixed with `-` for descending.
+   * Default: `-last_modified`.
+   *
+   * @see http://kinto.readthedocs.io/en/stable/api/1.x/sorting.html
+   *
+   * Filtering is done by passing a `filters` option object:
+   *
+   * - `{fieldname: "value"}`
+   * - `{min_fieldname: 4000}`
+   * - `{in_fieldname: "1,2,3"}`
+   * - `{not_fieldname: 0}`
+   * - `{exclude_fieldname: "0,1"}`
+   *
+   * @see http://kinto.readthedocs.io/en/stable/api/1.x/filtering.html
+   *
+   * Paginating is done by passing a `limit` option, then calling the `next()`
+   * method from the resolved result object to fetch the next page, if any.
+   *
+   * @param  {Object}   [options={}]                    The options object.
+   * @param  {Object}   [options.headers]               The headers object option.
+   * @param  {Number}   [options.retry=0]               Number of retries to make
+   *     when faced with transient errors.
+   * @param  {Object}   [options.filters={}]            The filters object.
+   * @param  {String}   [options.sort="-last_modified"] The sort field.
+   * @param  {String}   [options.at]                    The timestamp to get a snapshot at.
+   * @param  {String}   [options.limit=null]            The limit field.
+   * @param  {String}   [options.pages=1]               The number of result pages to aggregate.
+   * @param  {Number}   [options.since=null]            Only retrieve records modified since the provided timestamp.
+   * @param  {Array}    [options.fields]                Limit response to just some fields.
+   * @return {Promise<Object, Error>}
+   */
+  async listRecords<T extends KintoObject>(
+    options: PaginatedParams & {
+      headers?: Record<string, string>;
+      retry?: number;
+      at?: number;
+    } = {}
+  ): Promise<PaginationResult<T>> {
+    const path = this._endpoints.record(this.bucket.name, this.name);
+    if (options.at) {
+      return this.getSnapshot<T>(options.at);
+    } else {
+      return this.client.paginatedList<T>(path, options, {
+        headers: this._getHeaders(options),
+        retry: this._getRetry(options),
+      });
+    }
+  }
+
+  /**
+   * @private
+   */
+  async isHistoryComplete(): Promise<boolean> {
+    // We consider that if we have the collection creation event part of the
+    // history, then all records change events have been tracked.
+    const {
+      data: [oldestHistoryEntry],
+    } = await this.bucket.listHistory({
+      limit: 1,
+      filters: {
+        action: "create",
+        resource_name: "collection",
+        collection_id: this.name,
+      },
+    });
+    return !!oldestHistoryEntry;
+  }
+
+  /**
+   * @private
+   */
+  @capable(["history"])
+  async getSnapshot<T extends KintoObject>(
+    at: number
+  ): Promise<PaginationResult<T>> {
+    if (!at || !Number.isInteger(at) || at <= 0) {
+      throw new Error("Invalid argument, expected a positive integer.");
+    }
+    // Retrieve history and check it covers the required time range.
+    // Ensure we have enough history data to retrieve the complete list of
+    // changes.
+    if (!(await this.isHistoryComplete())) {
+      throw new Error(
+        "Computing a snapshot is only possible when the full history for a " +
+          "collection is available. Here, the history plugin seems to have " +
+          "been enabled after the creation of the collection."
+      );
+    }
+
+    // Because of https://github.com/Kinto/kinto-http.js/issues/963
+    // we cannot simply rely on the history endpoint.
+    // Our strategy here is to clean-up the history entries from the
+    // records that were deleted via the plural endpoint.
+    // We will detect them by comparing the current state of the collection
+    // and the full history of the collection since its genesis.
+
+    // List full history of collection.
+    const { data: fullHistory } = await this.bucket.listHistory<T>({
+      pages: Infinity, // all pages up to target timestamp are required
+      sort: "last_modified", // chronological order
+      filters: {
+        resource_name: "record",
+        collection_id: this.name,
+      },
+    });
+
+    // Keep latest entry ever, and latest within snapshot window.
+    // (history is sorted chronologically)
+    const latestEver = new Map();
+    const latestInSnapshot = new Map();
+    for (const entry of fullHistory) {
+      if (entry.target.data.last_modified <= at) {
+        // Snapshot includes changes right on timestamp.
+        latestInSnapshot.set(entry.record_id, entry);
+      }
+      latestEver.set(entry.record_id, entry);
+    }
+
+    // Current records ids in the collection.
+    const { data: current } = await this.listRecords({
+      pages: Infinity,
+      fields: ["id"], // we don't need attributes.
+    });
+    const currentIds = new Set(current.map((record) => record.id));
+
+    // If a record is not in the current collection, and its
+    // latest history entry isn't a delete then this means that
+    // it was deleted via the plural endpoint (and that we lost track
+    // of this deletion because of bug #963)
+    const deletedViaPlural = new Set();
+    for (const entry of latestEver.values()) {
+      if (entry.action != "delete" && !currentIds.has(entry.record_id)) {
+        deletedViaPlural.add(entry.record_id);
+      }
+    }
+
+    // Now reconstruct the collection based on latest version in snapshot
+    // filtering all deleted records.
+    const reconstructed = [];
+    for (const entry of latestInSnapshot.values()) {
+      if (entry.action != "delete" && !deletedViaPlural.has(entry.record_id)) {
+        reconstructed.push(entry.target.data);
+      }
+    }
+
+    return {
+      last_modified: String(at),
+      data: Array.from(reconstructed).sort(
+        (a, b) => b.last_modified - a.last_modified
+      ),
+      next: () => {
+        throw new Error("Snapshots don't support pagination");
+      },
+      hasNextPage: false,
+      totalRecords: reconstructed.length,
+    } as PaginationResult<T>;
+  }
+
+  /**
+   * Performs batch operations at the current collection level.
+   *
+   * @param  {Function} fn                   The batch operation function.
+   * @param  {Object}   [options={}]         The options object.
+   * @param  {Object}   [options.headers]    The headers object option.
+   * @param  {Boolean}  [options.safe]       The safe option.
+   * @param  {Number}   [options.retry]      The retry option.
+   * @param  {Boolean}  [options.aggregate]  Produces a grouped result object.
+   * @return {Promise<Object, Error>}
+   */
+  async batch(
+    fn: (client: Collection) => void,
+    options: {
+      headers?: Record<string, string>;
+      safe?: boolean;
+      retry?: number;
+      aggregate?: boolean;
+    } = {}
+  ): Promise<OperationResponse<KintoObject>[] | AggregateResponse> {
+    return this.client.batch(fn, {
+      bucket: this.bucket.name,
+      collection: this.name,
+      headers: this._getHeaders(options),
+      retry: this._getRetry(options),
+      safe: this._getSafe(options),
+      aggregate: !!options.aggregate,
+    });
+  }
+}

--- a/src/http/endpoints.ts
+++ b/src/http/endpoints.ts
@@ -1,0 +1,21 @@
+/**
+ * Endpoints templates.
+ * @type {Object}
+ */
+const ENDPOINTS = {
+  root: () => "/",
+  batch: () => "/batch",
+  permissions: () => "/permissions",
+  bucket: (bucket?: string) => "/buckets" + (bucket ? `/${bucket}` : ""),
+  history: (bucket: string) => `${ENDPOINTS.bucket(bucket)}/history`,
+  collection: (bucket: string, coll?: string) =>
+    `${ENDPOINTS.bucket(bucket)}/collections` + (coll ? `/${coll}` : ""),
+  group: (bucket: string, group?: string) =>
+    `${ENDPOINTS.bucket(bucket)}/groups` + (group ? `/${group}` : ""),
+  record: (bucket: string, coll: string, id?: string) =>
+    `${ENDPOINTS.collection(bucket, coll)}/records` + (id ? `/${id}` : ""),
+  attachment: (bucket: string, coll: string, id: string) =>
+    `${ENDPOINTS.record(bucket, coll, id)}/attachment`,
+};
+
+export default ENDPOINTS;

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -1,0 +1,136 @@
+import { FetchResponse } from "./types";
+
+/**
+ * Kinto server error code descriptors.
+ */
+const ERROR_CODES = {
+  104: "Missing Authorization Token",
+  105: "Invalid Authorization Token",
+  106: "Request body was not valid JSON",
+  107: "Invalid request parameter",
+  108: "Missing request parameter",
+  109: "Invalid posted data",
+  110: "Invalid Token / id",
+  111: "Missing Token / id",
+  112: "Content-Length header was not provided",
+  113: "Request body too large",
+  114: "Resource was created, updated or deleted meanwhile",
+  115: "Method not allowed on this end point (hint: server may be readonly)",
+  116: "Requested version not available on this server",
+  117: "Client has sent too many requests",
+  121: "Resource access is forbidden for this user",
+  122: "Another resource violates constraint",
+  201: "Service Temporary unavailable due to high load",
+  202: "Service deprecated",
+  999: "Internal Server Error",
+};
+
+export default ERROR_CODES;
+
+class NetworkTimeoutError extends Error {
+  public url: string;
+  public options: Object;
+
+  constructor(url: string, options: Object) {
+    super(
+      `Timeout while trying to access ${url} with ${JSON.stringify(options)}`
+    );
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, NetworkTimeoutError);
+    }
+
+    this.url = url;
+    this.options = options;
+  }
+}
+
+class UnparseableResponseError extends Error {
+  public status: number;
+  public response: FetchResponse;
+  public stack?: string;
+  public error: Error;
+
+  constructor(response: FetchResponse, body: string, error: Error) {
+    const { status } = response;
+
+    super(
+      `Response from server unparseable (HTTP ${
+        status || 0
+      }; ${error}): ${body}`
+    );
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, UnparseableResponseError);
+    }
+
+    this.status = status;
+    this.response = response;
+    this.stack = error.stack;
+    this.error = error;
+  }
+}
+
+export interface ServerResponseObject {
+  code: number;
+  errno: keyof typeof ERROR_CODES;
+  error: string;
+  message: string;
+  info: string;
+  details: unknown;
+}
+
+/**
+ * "Error" subclass representing a >=400 response from the server.
+ *
+ * Whether or not this is an error depends on your application.
+ *
+ * The `json` field can be undefined if the server responded with an
+ * empty response body. This shouldn't generally happen. Most "bad"
+ * responses come with a JSON error description, or (if they're
+ * fronted by a CDN or nginx or something) occasionally non-JSON
+ * responses (which become UnparseableResponseErrors, above).
+ */
+class ServerResponse extends Error {
+  public response: FetchResponse;
+  public data?: ServerResponseObject;
+
+  constructor(response: FetchResponse, json?: ServerResponseObject) {
+    const { status } = response;
+    let { statusText } = response;
+    let errnoMsg;
+
+    if (json) {
+      // Try to fill in information from the JSON error.
+      statusText = json.error || statusText;
+
+      // Take errnoMsg from either ERROR_CODES or json.message.
+      if (json.errno && json.errno in ERROR_CODES) {
+        errnoMsg = ERROR_CODES[json.errno];
+      } else if (json.message) {
+        errnoMsg = json.message;
+      }
+
+      // If we had both ERROR_CODES and json.message, and they differ,
+      // combine them.
+      if (errnoMsg && json.message && json.message !== errnoMsg) {
+        errnoMsg += ` (${json.message})`;
+      }
+    }
+
+    let message = `HTTP ${status} ${statusText}`;
+    if (errnoMsg) {
+      message += `: ${errnoMsg}`;
+    }
+
+    super(message.trim());
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ServerResponse);
+    }
+
+    this.response = response;
+    this.data = json;
+  }
+}
+
+export { NetworkTimeoutError, ServerResponse, UnparseableResponseError };

--- a/src/http/http.ts
+++ b/src/http/http.ts
@@ -1,0 +1,261 @@
+import { delay, obscureAuthorizationHeader } from "./utils";
+import {
+  NetworkTimeoutError,
+  ServerResponse,
+  UnparseableResponseError,
+  ServerResponseObject,
+} from "./errors";
+import { Emitter, FetchFunction, FetchHeaders, FetchResponse } from "./types";
+
+interface HttpOptions {
+  timeout?: number | null;
+  requestMode?: RequestMode;
+  fetchFunc?: FetchFunction;
+}
+
+interface RequestOptions {
+  retry: number;
+}
+
+export interface HttpResponse<T> {
+  status: number;
+  json: T;
+  headers: FetchHeaders;
+}
+
+/**
+ * Enhanced HTTP client for the Kinto protocol.
+ * @private
+ */
+export default class HTTP {
+  /**
+   * Default HTTP request headers applied to each outgoing request.
+   *
+   * @type {Object}
+   */
+  static get DEFAULT_REQUEST_HEADERS(): Record<string, string> {
+    return {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+  }
+
+  /**
+   * Default options.
+   *
+   * @type {Object}
+   */
+  static get defaultOptions(): HttpOptions {
+    return { timeout: null, requestMode: "cors" };
+  }
+
+  public events?: Emitter;
+  public requestMode: RequestMode;
+  public timeout: number;
+  public fetchFunc: FetchFunction;
+
+  /**
+   * Constructor.
+   *
+   * @param {EventEmitter} events                       The event handler.
+   * @param {Object}       [options={}}                 The options object.
+   * @param {Number}       [options.timeout=null]       The request timeout in ms, if any (default: `null`).
+   * @param {String}       [options.requestMode="cors"] The HTTP request mode (default: `"cors"`).
+   */
+  constructor(events?: Emitter, options: HttpOptions = {}) {
+    // public properties
+    /**
+     * The event emitter instance.
+     * @type {EventEmitter}
+     */
+    this.events = events;
+
+    /**
+     * The request mode.
+     * @see  https://fetch.spec.whatwg.org/#requestmode
+     * @type {String}
+     */
+    this.requestMode = options.requestMode || HTTP.defaultOptions.requestMode!;
+
+    /**
+     * The request timeout.
+     * @type {Number}
+     */
+    this.timeout = options.timeout || HTTP.defaultOptions.timeout!;
+
+    /**
+     * The fetch() function.
+     * @type {Function}
+     */
+    this.fetchFunc = options.fetchFunc || globalThis.fetch.bind(globalThis);
+  }
+
+  /**
+   * @private
+   */
+  timedFetch(url: string, options: RequestInit): Promise<FetchResponse> {
+    let hasTimedout = false;
+    return new Promise((resolve, reject) => {
+      // Detect if a request has timed out.
+      let _timeoutId: ReturnType<typeof setTimeout>;
+      if (this.timeout) {
+        _timeoutId = setTimeout(() => {
+          hasTimedout = true;
+          if (options && options.headers) {
+            options = {
+              ...options,
+              headers: obscureAuthorizationHeader(options.headers),
+            };
+          }
+          reject(new NetworkTimeoutError(url, options));
+        }, this.timeout);
+      }
+      function proceedWithHandler(fn: (arg: any) => void): (arg: any) => void {
+        return (arg: any) => {
+          if (!hasTimedout) {
+            if (_timeoutId) {
+              clearTimeout(_timeoutId);
+            }
+            fn(arg);
+          }
+        };
+      }
+      this.fetchFunc(url, options)
+        .then(proceedWithHandler(resolve))
+        .catch(proceedWithHandler(reject));
+    });
+  }
+
+  /**
+   * @private
+   */
+  async processResponse<T>(response: FetchResponse): Promise<HttpResponse<T>> {
+    const { status, headers } = response;
+    const text = await response.text();
+    // Check if we have a body; if so parse it as JSON.
+    let json: unknown;
+    if (text.length !== 0) {
+      try {
+        json = JSON.parse(text);
+      } catch (err) {
+        throw new UnparseableResponseError(response, text, err as Error);
+      }
+    }
+    if (status >= 400) {
+      throw new ServerResponse(response, json as ServerResponseObject);
+    }
+    return { status, json: json as T, headers };
+  }
+
+  /**
+   * @private
+   */
+  async retry<T>(
+    url: string,
+    retryAfter: number,
+    request: RequestInit,
+    options: RequestOptions
+  ): Promise<HttpResponse<T>> {
+    await delay(retryAfter);
+    return this.request<T>(url, request, {
+      ...options,
+      retry: options.retry - 1,
+    });
+  }
+
+  /**
+   * Performs an HTTP request to the Kinto server.
+   *
+   * Resolves with an objet containing the following HTTP response properties:
+   * - `{Number}  status`  The HTTP status code.
+   * - `{Object}  json`    The JSON response body.
+   * - `{Headers} headers` The response headers object; see the ES6 fetch() spec.
+   *
+   * @param  {String} url               The URL.
+   * @param  {Object} [request={}]      The request object, passed to
+   *     fetch() as its options object.
+   * @param  {Object} [request.headers] The request headers object (default: {})
+   * @param  {Object} [options={}]      Options for making the
+   *     request
+   * @param  {Number} [options.retry]   Number of retries (default: 0)
+   * @return {Promise}
+   */
+  async request<T>(
+    url: string,
+    request: RequestInit = { headers: {} },
+    options: RequestOptions = { retry: 0 }
+  ): Promise<HttpResponse<T>> {
+    // Ensure default request headers are always set
+    request.headers = { ...HTTP.DEFAULT_REQUEST_HEADERS, ...request.headers };
+    // If a multipart body is provided, remove any custom Content-Type header as
+    // the fetch() implementation will add the correct one for us.
+    if (request.body && request.body instanceof FormData) {
+      if (request.headers instanceof Headers) {
+        request.headers.delete("Content-Type");
+      } else if (!Array.isArray(request.headers)) {
+        delete request.headers["Content-Type"];
+      }
+    }
+    request.mode = this.requestMode;
+
+    const response = await this.timedFetch(url, request);
+    const { headers } = response;
+
+    this._checkForDeprecationHeader(headers);
+    this._checkForBackoffHeader(headers);
+
+    // Check if the server summons the client to retry after a while.
+    const retryAfter = this._checkForRetryAfterHeader(headers);
+    // If number of allowed of retries is not exhausted, retry the same request.
+    if (retryAfter && options.retry > 0) {
+      return this.retry<T>(url, retryAfter, request, options);
+    } else {
+      return this.processResponse<T>(response);
+    }
+  }
+
+  _checkForDeprecationHeader(headers: FetchHeaders): void {
+    const alertHeader = headers.get("Alert");
+    if (!alertHeader) {
+      return;
+    }
+    let alert;
+    try {
+      alert = JSON.parse(alertHeader);
+    } catch (err) {
+      console.warn("Unable to parse Alert header message", alertHeader);
+      return;
+    }
+    console.warn(alert.message, alert.url);
+    if (this.events) {
+      this.events.emit("deprecated", alert);
+    }
+  }
+
+  _checkForBackoffHeader(headers: FetchHeaders): void {
+    let backoffMs;
+    const backoffHeader = headers.get("Backoff");
+    const backoffSeconds = backoffHeader ? parseInt(backoffHeader, 10) : 0;
+    if (backoffSeconds > 0) {
+      backoffMs = new Date().getTime() + backoffSeconds * 1000;
+    } else {
+      backoffMs = 0;
+    }
+    if (this.events) {
+      this.events.emit("backoff", backoffMs);
+    }
+  }
+
+  _checkForRetryAfterHeader(headers: FetchHeaders): number | undefined {
+    const retryAfter = headers.get("Retry-After");
+    if (!retryAfter) {
+      return;
+    }
+    const delay = parseInt(retryAfter, 10) * 1000;
+    const tryAgainAfter = new Date().getTime() + delay;
+    if (this.events) {
+      this.events.emit("retry-after", tryAgainAfter);
+    }
+    return delay;
+  }
+}

--- a/src/http/index.browser.ts
+++ b/src/http/index.browser.ts
@@ -1,0 +1,2 @@
+import KintoClient from "./index";
+export default KintoClient;

--- a/src/http/index.fx.ts
+++ b/src/http/index.fx.ts
@@ -1,0 +1,33 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import KintoClientBase, { KintoClientOptions } from "./base";
+import * as errors from "./errors";
+import { EventEmitter as ee } from "events";
+
+declare const ChromeUtils: any;
+const { EventEmitter } = ChromeUtils.import(
+  "resource://gre/modules/EventEmitter.jsm"
+) as { EventEmitter: any };
+
+export default class KintoHttpClient extends KintoClientBase {
+  constructor(remote: string, options: Partial<KintoClientOptions> = {}) {
+    const events = {};
+    EventEmitter.decorate(events);
+    super(remote, { events: events as ee, ...options });
+  }
+}
+
+(KintoHttpClient as any).errors = errors;

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,0 +1,32 @@
+import KintoClientBase, {
+  KintoClientOptions,
+  SUPPORTED_PROTOCOL_VERSION,
+} from "./base";
+import type { AggregateResponse } from "./batch";
+import Collection from "./collection";
+import type {
+  KintoObject,
+  KintoIdObject,
+  KintoResponse,
+  Permission,
+  PermissionData,
+} from "./types";
+
+export default class KintoClient extends KintoClientBase {
+  constructor(remote: string, options: Partial<KintoClientOptions> = {}) {
+    const events = options.events;
+
+    super(remote, Object.assign({ events }, options));
+  }
+}
+
+export {
+  KintoObject,
+  KintoIdObject,
+  Collection,
+  AggregateResponse,
+  KintoResponse,
+  Permission,
+  PermissionData,
+  SUPPORTED_PROTOCOL_VERSION,
+};

--- a/src/http/requests.ts
+++ b/src/http/requests.ts
@@ -1,0 +1,178 @@
+import { KintoRequest, HttpMethod, Permission } from "./types";
+import { createFormData } from "./utils";
+
+interface RequestOptions {
+  safe?: boolean;
+  headers?: Headers | Record<string, string> | string[][];
+  method?: HttpMethod;
+  gzipped?: boolean | null;
+  last_modified?: number;
+  patch?: boolean;
+}
+type AddAttachmentRequestOptions = RequestOptions & {
+  last_modified?: number;
+  filename?: string;
+};
+
+type RequestBody = {
+  data?: any;
+  permissions?: Partial<Record<Permission, string[]>>;
+};
+interface RecordRequestBody extends RequestBody {
+  data?: { id?: string; last_modified?: number; [key: string]: any };
+}
+
+const requestDefaults: RequestOptions = {
+  safe: false,
+  // check if we should set default content type here
+  headers: {},
+  patch: false,
+};
+
+/**
+ * @private
+ */
+function safeHeader(
+  safe?: boolean,
+  last_modified?: number
+): Record<string, string> {
+  if (!safe) {
+    return {};
+  }
+  if (last_modified) {
+    return { "If-Match": `"${last_modified}"` };
+  }
+  return { "If-None-Match": "*" };
+}
+
+/**
+ * @private
+ */
+export function createRequest(
+  path: string,
+  { data, permissions }: RequestBody,
+  options: RequestOptions = {}
+): KintoRequest {
+  const { headers, safe } = {
+    ...requestDefaults,
+    ...options,
+  };
+  const method = options.method || (data && data.id) ? "PUT" : "POST";
+  return {
+    method,
+    path,
+    headers: { ...headers, ...safeHeader(safe) },
+    body: { data, permissions },
+  };
+}
+
+/**
+ * @private
+ */
+export function updateRequest(
+  path: string,
+  { data, permissions }: RecordRequestBody,
+  options: RequestOptions = {}
+): KintoRequest {
+  const { headers, safe, patch } = { ...requestDefaults, ...options };
+  const { last_modified } = { ...data, ...options };
+
+  const hasNoData =
+    data &&
+    Object.keys(data).filter((k) => k !== "id" && k !== "last_modified")
+      .length === 0;
+  if (hasNoData) {
+    data = undefined;
+  }
+
+  return {
+    method: patch ? "PATCH" : "PUT",
+    path,
+    headers: { ...headers, ...safeHeader(safe, last_modified) },
+    body: { data, permissions },
+  };
+}
+
+/**
+ * @private
+ */
+export function jsonPatchPermissionsRequest(
+  path: string,
+  permissions: { [key in Permission]?: string[] },
+  opType: string,
+  options: RequestOptions = {}
+): KintoRequest {
+  const { headers, safe, last_modified } = { ...requestDefaults, ...options };
+
+  const ops = [];
+
+  for (const [type, principals] of Object.entries(permissions)) {
+    if (principals) {
+      for (const principal of principals) {
+        ops.push({
+          op: opType,
+          path: `/permissions/${type}/${principal}`,
+        });
+      }
+    }
+  }
+
+  return {
+    method: "PATCH",
+    path,
+    headers: {
+      ...headers,
+      ...safeHeader(safe, last_modified),
+      "Content-Type": "application/json-patch+json",
+    },
+    body: ops,
+  };
+}
+
+/**
+ * @private
+ */
+export function deleteRequest(
+  path: string,
+  options: RequestOptions = {}
+): KintoRequest {
+  const { headers, safe, last_modified } = {
+    ...requestDefaults,
+    ...options,
+  };
+  if (safe && !last_modified) {
+    throw new Error("Safe concurrency check requires a last_modified value.");
+  }
+  return {
+    method: "DELETE",
+    path,
+    headers: { ...headers, ...safeHeader(safe, last_modified) },
+  };
+}
+
+/**
+ * @private
+ */
+export function addAttachmentRequest(
+  path: string,
+  dataURI: string,
+  { data, permissions }: RecordRequestBody = {},
+  options: AddAttachmentRequestOptions = {}
+): KintoRequest {
+  const { headers, safe, gzipped } = { ...requestDefaults, ...options };
+  const { last_modified } = { ...data, ...options };
+
+  const body = { data, permissions };
+  const formData = createFormData(dataURI, body, options);
+
+  const customPath = `${path}${
+    gzipped !== null ? "?gzipped=" + (gzipped ? "true" : "false") : ""
+  }`;
+
+  return {
+    method: "POST",
+    path: customPath,
+    headers: { ...headers, ...safeHeader(safe, last_modified) },
+    body: formData,
+  };
+}

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -1,0 +1,136 @@
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD";
+
+export interface KintoRequest {
+  method?: HttpMethod;
+  path: string;
+  headers: HeadersInit;
+  body?: any;
+}
+
+export interface KintoIdObject {
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface KintoObject extends KintoIdObject {
+  last_modified: number;
+}
+
+export type Permission =
+  | "bucket:create"
+  | "read"
+  | "write"
+  | "collection:create"
+  | "group:create"
+  | "record:create";
+
+export interface User {
+  id: string;
+  principals: string[];
+  bucket: string;
+}
+
+export interface ServerCapability {
+  description: string;
+  url: string;
+  version?: string;
+  [key: string]: unknown;
+}
+
+export interface ServerSettings {
+  readonly: boolean;
+  batch_max_requests: number;
+}
+
+export interface HelloResponse {
+  project_name: string;
+  project_version: string;
+  http_api_version: string;
+  project_docs: string;
+  url: string;
+  settings: ServerSettings;
+  user?: User;
+  capabilities: { [key: string]: ServerCapability };
+}
+
+export interface OperationResponse<T = KintoObject> {
+  status: number;
+  path: string;
+  body: { data: T };
+  headers: Record<string, string>;
+}
+
+export interface BatchResponse {
+  responses: OperationResponse[];
+}
+
+export interface DataResponse<T> {
+  data: T;
+}
+
+export type MappableObject = { [key in string | number]: unknown };
+
+export interface KintoResponse<T = unknown> {
+  data: KintoObject & T;
+  permissions: { [key in Permission]?: string[] };
+}
+
+export interface HistoryEntry<T> {
+  action: "create" | "update" | "delete";
+  collection_id: string;
+  date: string;
+  id: string;
+  last_modified: number;
+  record_id: string;
+  resource_name: string;
+  target: KintoResponse<T>;
+  timestamp: number;
+  uri: string;
+  user_id: string;
+}
+
+export interface PermissionData {
+  bucket_id: string;
+  collection_id?: string;
+  id: string;
+  permissions: Permission[];
+  resource_name: string;
+  uri: string;
+}
+
+export interface Attachment {
+  filename: string;
+  hash: string;
+  location: string;
+  mimetype: string;
+  size: number;
+}
+
+export interface Group extends KintoObject {
+  members: string[];
+}
+
+export interface Emitter {
+  emit(type: string, event?: any): void;
+  on(type: string, handler: (event?: any) => void): void;
+  off(type: string, handler: (event?: any) => void): void;
+}
+
+export interface FetchHeaders {
+  keys(): IterableIterator<string> | string[];
+  entries(): IterableIterator<[string, string]> | [string, string][];
+  get(name: string): string | null;
+  has(name: string): boolean;
+}
+
+export interface FetchResponse {
+  status: number;
+  statusText: string;
+  text(): Promise<string>;
+  headers: FetchHeaders;
+}
+
+export type FetchFunction = (
+  input: RequestInfo,
+  init?: RequestInit | undefined
+) => Promise<FetchResponse>;

--- a/src/http/utils.ts
+++ b/src/http/utils.ts
@@ -1,0 +1,373 @@
+/**
+ * Chunks an array into n pieces.
+ *
+ * @private
+ * @param  {Array}  array
+ * @param  {Number} n
+ * @return {Array}
+ */
+export function partition<T>(array: T[], n: number): T[][] {
+  if (n <= 0) {
+    return [array];
+  }
+  return array.reduce<T[][]>((acc, x, i) => {
+    if (i === 0 || i % n === 0) {
+      acc.push([x]);
+    } else {
+      acc[acc.length - 1].push(x);
+    }
+    return acc;
+  }, []);
+}
+
+/**
+ * Returns a Promise always resolving after the specified amount in milliseconds.
+ *
+ * @return Promise<void>
+ */
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface Entity {
+  id: string;
+}
+
+/**
+ * Always returns a resource data object from the provided argument.
+ *
+ * @private
+ * @param  {Object|String} resource
+ * @return {Object}
+ */
+export function toDataBody<T extends Entity>(resource: T | string): Entity {
+  if (isObject(resource)) {
+    return resource as T;
+  }
+  if (typeof resource === "string") {
+    return { id: resource };
+  }
+  throw new Error("Invalid argument.");
+}
+
+/**
+ * Transforms an object into an URL query string, stripping out any undefined
+ * values.
+ *
+ * @param  {Object} obj
+ * @return {String}
+ */
+export function qsify(obj: { [key: string]: any }): string {
+  const encode = (v: any): string =>
+    encodeURIComponent(typeof v === "boolean" ? String(v) : v);
+  const stripped = cleanUndefinedProperties(obj);
+  return Object.keys(stripped)
+    .map((k) => {
+      const ks = encode(k) + "=";
+      if (Array.isArray(stripped[k])) {
+        return ks + stripped[k].map((v: any) => encode(v)).join(",");
+      } else {
+        return ks + encode(stripped[k]);
+      }
+    })
+    .join("&");
+}
+
+/**
+ * Checks if a version is within the provided range.
+ *
+ * @param  {String} version    The version to check.
+ * @param  {String} minVersion The minimum supported version (inclusive).
+ * @param  {String} maxVersion The minimum supported version (exclusive).
+ * @throws {Error} If the version is outside of the provided range.
+ */
+export function checkVersion(
+  version: string,
+  minVersion: string,
+  maxVersion: string
+): void {
+  const extract = (str: string): number[] =>
+    str.split(".").map((x) => parseInt(x, 10));
+  const [verMajor, verMinor] = extract(version);
+  const [minMajor, minMinor] = extract(minVersion);
+  const [maxMajor, maxMinor] = extract(maxVersion);
+  const checks = [
+    verMajor < minMajor,
+    verMajor === minMajor && verMinor < minMinor,
+    verMajor > maxMajor,
+    verMajor === maxMajor && verMinor >= maxMinor,
+  ];
+  if (checks.some((x) => x)) {
+    throw new Error(
+      `Version ${version} doesn't satisfy ${minVersion} <= x < ${maxVersion}`
+    );
+  }
+}
+
+type DecoratorReturn = (
+  target: any,
+  key: string,
+  descriptor: TypedPropertyDescriptor<(...args: any[]) => any>
+) => {
+  configurable: boolean;
+  get(): (...args: any) => Promise<any>;
+};
+
+/**
+ * Generates a decorator function ensuring a version check is performed against
+ * the provided requirements before executing it.
+ *
+ * @param  {String} min The required min version (inclusive).
+ * @param  {String} max The required max version (inclusive).
+ * @return {Function}
+ */
+export function support(min: string, max: string): DecoratorReturn {
+  return function (
+    // @ts-ignore
+    target: any,
+    key: string,
+    descriptor: TypedPropertyDescriptor<(...args: any[]) => any>
+  ) {
+    const fn = descriptor.value;
+    return {
+      configurable: true,
+      get() {
+        const wrappedMethod = (...args: any): Promise<any> => {
+          // "this" is the current instance which its method is decorated.
+          const client = (this as any).client ? (this as any).client : this;
+          return client
+            .fetchHTTPApiVersion()
+            .then((version: string) => checkVersion(version, min, max))
+            .then(() => fn!.apply(this, args));
+        };
+        Object.defineProperty(this, key, {
+          value: wrappedMethod,
+          configurable: true,
+          writable: true,
+        });
+        return wrappedMethod;
+      },
+    };
+  };
+}
+
+/**
+ * Generates a decorator function ensuring that the specified capabilities are
+ * available on the server before executing it.
+ *
+ * @param  {Array<String>} capabilities The required capabilities.
+ * @return {Function}
+ */
+export function capable(capabilities: string[]): DecoratorReturn {
+  return function (
+    // @ts-ignore
+    target: any,
+    key: string,
+    descriptor: TypedPropertyDescriptor<(...args: any[]) => any>
+  ) {
+    const fn = descriptor.value;
+    return {
+      configurable: true,
+      get() {
+        const wrappedMethod = (...args: any): Promise<any> => {
+          // "this" is the current instance which its method is decorated.
+          const client = (this as any).client ? (this as any).client : this;
+          return client
+            .fetchServerCapabilities()
+            .then((available: string[]) => {
+              const missing = capabilities.filter((c) => !(c in available));
+              if (missing.length > 0) {
+                const missingStr = missing.join(", ");
+                throw new Error(
+                  `Required capabilities ${missingStr} not present on server`
+                );
+              }
+            })
+            .then(() => fn!.apply(this, args));
+        };
+        Object.defineProperty(this, key, {
+          value: wrappedMethod,
+          configurable: true,
+          writable: true,
+        });
+        return wrappedMethod;
+      },
+    };
+  };
+}
+
+/**
+ * Generates a decorator function ensuring an operation is not performed from
+ * within a batch request.
+ *
+ * @param  {String} message The error message to throw.
+ * @return {Function}
+ */
+export function nobatch(message: string): DecoratorReturn {
+  return function (
+    // @ts-ignore
+    target: any,
+    key: string,
+    descriptor: TypedPropertyDescriptor<(...args: any[]) => any>
+  ) {
+    const fn = descriptor.value;
+    return {
+      configurable: true,
+      get() {
+        const wrappedMethod = (...args: any): any => {
+          // "this" is the current instance which its method is decorated.
+          if ((this as any)._isBatch) {
+            throw new Error(message);
+          }
+          return fn!.apply(this, args);
+        };
+        Object.defineProperty(this, key, {
+          value: wrappedMethod,
+          configurable: true,
+          writable: true,
+        });
+        return wrappedMethod;
+      },
+    };
+  };
+}
+
+/**
+ * Returns true if the specified value is an object (i.e. not an array nor null).
+ * @param  {Object} thing The value to inspect.
+ * @return {bool}
+ */
+export function isObject(thing: unknown): boolean {
+  return typeof thing === "object" && thing !== null && !Array.isArray(thing);
+}
+
+interface TypedDataURL {
+  type: string;
+  base64: string;
+  [key: string]: string;
+}
+
+/**
+ * Parses a data url.
+ * @param  {String} dataURL The data url.
+ * @return {Object}
+ */
+export function parseDataURL(dataURL: string): TypedDataURL {
+  const regex = /^data:(.*);base64,(.*)/;
+  const match = dataURL.match(regex);
+  if (!match) {
+    throw new Error(`Invalid data-url: ${String(dataURL).substr(0, 32)}...`);
+  }
+  const props = match[1];
+  const base64 = match[2];
+  const [type, ...rawParams] = props.split(";");
+  const params = rawParams.reduce<{ [key: string]: string }>((acc, param) => {
+    const [key, value] = param.split("=");
+    return { ...acc, [key]: value };
+  }, {});
+  return { ...params, type, base64 };
+}
+
+/**
+ * Extracts file information from a data url.
+ * @param  {String} dataURL The data url.
+ * @return {Object}
+ */
+export function extractFileInfo(dataURL: string): {
+  blob: Blob;
+  name: string;
+} {
+  const { name, type, base64 } = parseDataURL(dataURL);
+  const binary = atob(base64);
+  const array = [];
+  for (let i = 0; i < binary.length; i++) {
+    array.push(binary.charCodeAt(i));
+  }
+  const blob = new Blob([new Uint8Array(array)], { type });
+
+  return { blob, name };
+}
+
+/**
+ * Creates a FormData instance from a data url and an existing JSON response
+ * body.
+ * @param  {String} dataURL            The data url.
+ * @param  {Object} body               The response body.
+ * @param  {Object} [options={}]       The options object.
+ * @param  {Object} [options.filename] Force attachment file name.
+ * @return {FormData}
+ */
+export function createFormData(
+  dataURL: string,
+  body: { [key: string]: any },
+  options: { filename?: string } = {}
+): FormData {
+  const { filename = "untitled" } = options;
+  const { blob, name } = extractFileInfo(dataURL);
+  const formData = new FormData();
+  formData.append("attachment", blob, name || filename);
+  for (const property in body) {
+    if (typeof body[property] !== "undefined") {
+      formData.append(property, JSON.stringify(body[property]));
+    }
+  }
+  return formData;
+}
+
+/**
+ * Clones an object with all its undefined keys removed.
+ * @private
+ */
+export function cleanUndefinedProperties(obj: { [key: string]: any }): {
+  [key: string]: any;
+} {
+  const result: { [key: string]: any } = {};
+  for (const key in obj) {
+    if (typeof obj[key] !== "undefined") {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+}
+
+/**
+ * Handle common query parameters for Kinto requests.
+ *
+ * @param  {String}  [path]  The endpoint base path.
+ * @param  {Array}   [options.fields]    Fields to limit the
+ *   request to.
+ * @param  {Object}  [options.query={}]  Additional query arguments.
+ */
+export function addEndpointOptions(
+  path: string,
+  options: { fields?: string[]; query?: { [key: string]: string } } = {}
+): string {
+  const query: { [key: string]: any } = { ...options.query };
+  if (options.fields) {
+    query._fields = options.fields;
+  }
+  const queryString = qsify(query);
+  if (queryString) {
+    return path + "?" + queryString;
+  }
+  return path;
+}
+
+/**
+ * Replace authorization header with an obscured version
+ */
+export function obscureAuthorizationHeader(headers: HeadersInit): {
+  [key: string]: string;
+} {
+  const h = new Headers(headers);
+  if (h.has("authorization")) {
+    h.set("authorization", "**** (suppressed)");
+  }
+
+  const obscuredHeaders: { [key: string]: string } = {};
+  for (const [header, value] of h.entries()) {
+    obscuredHeaders[header] = value;
+  }
+
+  return obscuredHeaders;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Api from "kinto-http";
+import KintoClient from "./http";
 import BaseAdapter, { AbstractBaseAdapter } from "./adapters/base";
 import IDB from "./adapters/IDB";
 import KintoBase from "./KintoBase";
@@ -26,7 +26,7 @@ export default class Kinto<
   }
 
   get ApiClass() {
-    return Api;
+    return KintoClient;
   }
 
   constructor(options: KintoBaseOptions = {}) {
@@ -51,4 +51,4 @@ export type {
   CollectionSyncOptions,
   Conflict,
 };
-export { KintoBase, BaseAdapter, AbstractBaseAdapter, getDeepKey };
+export { KintoClient, KintoBase, BaseAdapter, AbstractBaseAdapter, getDeepKey };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { KintoIdObject, Permission } from "kinto-http";
+import { KintoIdObject, Permission } from "./http";
 import Collection from "./collection";
 
 export type $TSFixMe = any;

--- a/test/adapters/IDB_test.ts
+++ b/test/adapters/IDB_test.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import IDB, { open, execute } from "../../src/adapters/IDB";
 import { v4 as uuid4 } from "uuid";
 import { StorageProxy } from "../../src/adapters/base";
-import { KintoIdObject } from "kinto-http";
+import { KintoIdObject } from "../../src/http";
 import { expectAsyncError } from "../test_utils";
 
 const { expect } = intern.getPlugin("chai");

--- a/test/collection_test.ts
+++ b/test/collection_test.ts
@@ -3045,7 +3045,7 @@ describe("Collection", () => {
           let fetch;
 
           beforeEach(() => {
-            // Disable stubbing of kinto-http of upper tests.
+            // Disable stubbing of HTTP client of upper tests.
             sandbox.restore();
             // Stub low-level fetch instead.
             fetch = sandbox.stub(articles.api.http, "timedFetch");

--- a/test/collection_test.ts
+++ b/test/collection_test.ts
@@ -7,9 +7,11 @@ import Memory from "../src/adapters/memory";
 import BaseAdapter from "../src/adapters/base";
 import Collection, { SyncResultObject } from "../src/collection";
 import { Hooks, IdSchema, RemoteTransformer, KintoError } from "../src/types";
-import Api, { KintoIdObject } from "kinto-http";
-import KintoClient from "kinto-http";
-import { KintoObject, Collection as KintoClientCollection } from "kinto-http";
+import Api, {
+  KintoObject,
+  KintoIdObject,
+  Collection as KintoClientCollection,
+} from "../src/http";
 import { recordsEqual } from "../src/collection";
 import {
   updateTitleWithDelay,
@@ -1804,7 +1806,7 @@ describe("Collection", () => {
                   totalRecords: 0,
                 })
               ) as any;
-            client = new KintoClient("http://server.com/v1")
+            client = new Api("http://server.com/v1")
               .bucket("bucket")
               .collection("collection");
             await Promise.all(
@@ -2450,7 +2452,7 @@ describe("Collection", () => {
         const records = [{ id: uuid4(), title: "foo", _status: "created" }];
 
         beforeEach(() => {
-          client = new KintoClient("http://server.com/v1")
+          client = new Api("http://server.com/v1")
             .bucket("bucket")
             .collection("collection");
           articles = testCollection();
@@ -2459,7 +2461,7 @@ describe("Collection", () => {
 
         it("should publish local changes to the server", async () => {
           const batchRequests = sandbox
-            .stub(KintoClient.prototype, "_batchRequests" as any)
+            .stub(Api.prototype, "_batchRequests" as any)
             .returns(Promise.resolve([{}]));
 
           await articles.pushChanges(client, records, result);
@@ -2472,7 +2474,7 @@ describe("Collection", () => {
 
         it("should not publish local fields to the server", async () => {
           const batchRequests = sandbox
-            .stub(KintoClient.prototype, "_batchRequests" as any)
+            .stub(Api.prototype, "_batchRequests" as any)
             .returns(Promise.resolve([{}]));
 
           articles = testCollection({ localFields: ["size"] });
@@ -2504,7 +2506,7 @@ describe("Collection", () => {
 
         it("should not publish records created and deleted locally and never synced", async () => {
           const batchRequests = sandbox
-            .stub(KintoClient.prototype, "_batchRequests" as any)
+            .stub(Api.prototype, "_batchRequests" as any)
             .returns(Promise.resolve([]));
 
           const toDelete = [{ id: records[0].id, _status: "deleted" }]; // no timestamp.

--- a/test/http/.eslintrc
+++ b/test/http/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "@typescript-eslint/explicit-function-return-type": 0
+  }
+}

--- a/test/http/api_test.ts
+++ b/test/http/api_test.ts
@@ -1,0 +1,1382 @@
+import sinon from "sinon";
+import { EventEmitter } from "events";
+import { fakeServerResponse, Stub, expectAsyncError } from "./test_utils";
+import KintoClient from "../../src/http";
+import KintoClientBase, {
+  SUPPORTED_PROTOCOL_VERSION as SPV,
+  PaginationResult,
+} from "../../src/http/base";
+import Bucket from "../../src/http/bucket";
+import { HelloResponse, OperationResponse } from "../../src/http/types";
+import { KintoBatchResponse, AggregateResponse } from "../../src/http/batch";
+
+const { expect } = intern.getPlugin("chai");
+intern.getPlugin("chai").should();
+const { describe, it, beforeEach, afterEach } =
+  intern.getPlugin("interface.bdd");
+
+const FAKE_SERVER_URL = "http://fake-server/v1";
+
+/** @test {KintoClient} */
+describe("KintoClient", () => {
+  let sandbox: sinon.SinonSandbox, api: KintoClient, events: EventEmitter;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    events = new EventEmitter();
+    api = new KintoClient(FAKE_SERVER_URL, { events });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  /** @test {KintoClient#constructor} */
+  describe("#constructor", () => {
+    const sampleRemote = `http://test/${SPV}`;
+
+    it("should check that `remote` is a string", () => {
+      expect(
+        () =>
+          new KintoClient(42 as any, {
+            events,
+          })
+      ).to.Throw(Error, /Invalid remote URL/);
+    });
+
+    it("should validate `remote` arg value", () => {
+      expect(() => new KintoClient("http://nope")).to.Throw(
+        Error,
+        /The remote URL must contain the version/
+      );
+    });
+
+    it("should strip any trailing slash", () => {
+      expect(new KintoClient(sampleRemote).remote).eql(sampleRemote);
+    });
+
+    it("should expose a passed events instance option", () => {
+      expect(new KintoClient(sampleRemote, { events }).events).to.eql(events);
+    });
+
+    it("should propagate its events property to child dependencies", () => {
+      const api = new KintoClient(sampleRemote, { events });
+      expect(api.http.events).eql(api.events);
+    });
+
+    it("should assign version value", () => {
+      expect(new KintoClient(sampleRemote).version).eql(SPV);
+      expect(new KintoClient(sampleRemote).version).eql(SPV);
+    });
+
+    it("should accept a headers option", () => {
+      expect(
+        new KintoClient(sampleRemote, {
+          headers: { Foo: "Bar" },
+        })["_headers"]
+      ).eql({ Foo: "Bar" });
+    });
+
+    it("should validate protocol version", () => {
+      expect(() => new KintoClient("http://test/v999")).to.Throw(
+        Error,
+        /^Unsupported protocol version/
+      );
+    });
+
+    it("should propagate the requestMode option to the child HTTP instance", () => {
+      const requestMode = "no-cors";
+      expect(
+        new KintoClient(sampleRemote, {
+          requestMode,
+        }).http.requestMode
+      ).eql(requestMode);
+    });
+
+    it("should keep the default timeout in the child HTTP instance", () => {
+      expect(new KintoClient(sampleRemote).http.timeout).eql(null);
+    });
+
+    it("should propagate the timeout option to the child HTTP instance", () => {
+      const timeout = 1000;
+      expect(
+        new KintoClient(sampleRemote, {
+          timeout,
+        }).http.timeout
+      ).eql(timeout);
+    });
+
+    it("should not create an event emitter if none is provided", () => {
+      expect(new KintoClient(sampleRemote).events).to.be.undefined;
+    });
+
+    it("should expose provided event emitter as a property", () => {
+      const events = new EventEmitter();
+      expect(new KintoClient(sampleRemote, { events }).events).eql(events);
+    });
+
+    it("should accept a safe option", () => {
+      const api = new KintoClient(sampleRemote, { safe: true });
+      expect(api["_safe"]).eql(true);
+    });
+
+    it("should use fetchFunc option", async () => {
+      let called = false;
+      async function fetchFunc() {
+        called = true;
+        return fakeServerResponse(200, {}, {});
+      }
+      const api = new KintoClient(sampleRemote, { fetchFunc });
+
+      await api.fetchServerInfo();
+
+      expect(called).eql(true);
+    });
+  });
+
+  /** @test {KintoClient#setHeaders} */
+  describe("#setHeaders", () => {
+    let client: KintoClient;
+
+    beforeEach(() => {
+      client = new KintoClient(FAKE_SERVER_URL, {
+        headers: { Foo: "Bar", Authorization: "Biz" },
+      });
+    });
+
+    it("should override constructor headers", () => {
+      client.setHeaders({
+        Authorization: "Baz",
+      });
+      expect(client["_headers"]).eql({ Foo: "Bar", Authorization: "Baz" });
+    });
+  });
+
+  /** @test {KintoClient#backoff} */
+  describe("get backoff()", () => {
+    it("should provide the remaining backoff time in ms if any", async () => {
+      // Make Date#getTime always returning 1000000, for predictability
+      sandbox.stub(Date.prototype, "getTime").returns(1000 * 1000);
+      sandbox
+        .stub(api.http as any, "fetchFunc")
+        .returns(fakeServerResponse(200, {}, { Backoff: "1000" }));
+
+      await api.listBuckets();
+      return expect(api.backoff).eql(1000000);
+    });
+
+    it("should provide no remaining backoff time when none is set", async () => {
+      sandbox
+        .stub(api.http as any, "fetchFunc")
+        .returns(fakeServerResponse(200, {}, {}));
+
+      await api.listBuckets();
+      return expect(api.backoff).eql(0);
+    });
+  });
+
+  /** @test {KintoClient#bucket} */
+  describe("#bucket()", () => {
+    it("should return a Bucket instance", () => {
+      expect(api.bucket("foo")).to.be.an.instanceOf(Bucket);
+    });
+
+    it("should propagate default req options to bucket instance", () => {
+      const options = {
+        safe: true,
+        retry: 0,
+        headers: { Foo: "Bar" },
+        batch: false,
+      };
+
+      const bucket = api.bucket("foo", options);
+      expect(bucket).property("_safe", options.safe);
+      expect(bucket).property("_retry", options.retry);
+      expect(bucket).property("_headers").eql(options.headers);
+    });
+  });
+
+  /** @test {KintoClient#fetchServerInfo} */
+  describe("#fetchServerInfo", () => {
+    const fakeServerInfo: HelloResponse = {
+      project_name: "",
+      project_version: "",
+      http_api_version: "",
+      project_docs: "",
+      url: "",
+      settings: { readonly: false, batch_max_requests: 25 },
+      capabilities: {},
+    };
+
+    it("should retrieve server settings on first request made", async () => {
+      sandbox
+        .stub(api.http as any, "fetchFunc")
+        .returns(fakeServerResponse(200, fakeServerInfo));
+
+      (await api.fetchServerInfo()).should.deep.equal(fakeServerInfo);
+    });
+
+    it("should store server settings into the serverSettings property", async () => {
+      // api.serverSettings = { a: 1 };
+      sandbox
+        .stub(api.http as any, "fetchFunc")
+        .returns(fakeServerResponse(200, fakeServerInfo));
+
+      await api.fetchServerInfo();
+      expect(api).property("serverInfo").deep.equal(fakeServerInfo);
+    });
+
+    it("should not fetch server settings if they're cached already", () => {
+      api.serverInfo = fakeServerInfo;
+      const fetchStub = sandbox.stub(api.http as any, "fetchFunc");
+
+      api.fetchServerInfo();
+      sinon.assert.notCalled(fetchStub);
+    });
+
+    it("should refresh server info if headers were changed", () => {
+      api.serverInfo = fakeServerInfo;
+      api.setHeaders({
+        Authorization: "Baz",
+      });
+      expect(api.serverInfo).eql(null);
+    });
+  });
+
+  /** @test {KintoClient#fetchServerSettings} */
+  describe("#fetchServerSettings()", () => {
+    const fakeServerInfo = { settings: { fake: true } };
+
+    it("should retrieve server settings", async () => {
+      sandbox
+        .stub(api.http as any, "fetchFunc")
+        .returns(fakeServerResponse(200, fakeServerInfo));
+
+      (await api.fetchServerSettings()).should.have.property("fake").eql(true);
+    });
+  });
+
+  /** @test {KintoClient#fetchServerCapabilities} */
+  describe("#fetchServerCapabilities()", () => {
+    const fakeServerInfo = { capabilities: { fake: true } };
+
+    it("should retrieve server capabilities", async () => {
+      sandbox
+        .stub(api.http as any, "fetchFunc")
+        .returns(fakeServerResponse(200, fakeServerInfo));
+
+      (await api.fetchServerCapabilities()).should.have
+        .property("fake")
+        .eql(true);
+    });
+  });
+
+  /** @test {KintoClient#fetchUser} */
+  describe("#fetchUser()", () => {
+    const fakeServerInfo = { user: { fake: true } };
+
+    it("should retrieve user information", async () => {
+      sandbox
+        .stub(api.http as any, "fetchFunc")
+        .returns(fakeServerResponse(200, fakeServerInfo));
+
+      (await api.fetchUser())!.should.have.property("fake").eql(true);
+    });
+  });
+
+  /** @test {KintoClient#fetchHTTPApiVersion} */
+  describe("#fetchHTTPApiVersion()", () => {
+    const fakeServerInfo = { http_api_version: { fake: true } };
+
+    it("should retrieve current API version", async () => {
+      sandbox
+        .stub(api.http as any, "fetchFunc")
+        .returns(fakeServerResponse(200, fakeServerInfo));
+
+      (await api.fetchHTTPApiVersion()).should.have.property("fake").eql(true);
+    });
+  });
+
+  /** @test {KintoClient#batch} */
+  describe("#batch", () => {
+    beforeEach(() => {
+      const fetchServerSettings = sandbox.stub().returns(
+        Promise.resolve({
+          batch_max_requests: 3,
+        })
+      );
+      sandbox.stub(api, "fetchServerSettings").get(() => fetchServerSettings);
+    });
+
+    function executeBatch(fixtures: { [key: string]: any }[], options = {}) {
+      return api
+        .bucket("default")
+        .collection("blog")
+        .batch((batch) => {
+          for (const article of fixtures) {
+            batch.createRecord(article);
+          }
+        }, options);
+    }
+
+    describe("Batch client setup", () => {
+      it("should skip registering HTTP events", async () => {
+        const on = sandbox.spy();
+        const api = new KintoClient(FAKE_SERVER_URL, { events: { on } as any });
+
+        await api.batch(() => {});
+        return sinon.assert.calledOnce(on);
+      });
+    });
+
+    describe("server request", () => {
+      let requestBody: any, requestHeaders: any, fetch: sinon.SinonStub;
+
+      beforeEach(() => {
+        fetch = sandbox.stub(api.http as any, "fetchFunc");
+        fetch.returns(fakeServerResponse(200, { responses: [] }));
+      });
+
+      it("should ensure server settings are fetched", async () => {
+        await api.batch((batch: KintoClientBase) => batch.createBucket("blog"));
+        return sinon.assert.called(api.fetchServerSettings as any);
+      });
+
+      describe("empty request list", () => {
+        it("should not perform request on empty operation list", () => {
+          // @ts-ignore
+          api.batch((batch) => {});
+
+          sinon.assert.notCalled(fetch);
+        });
+      });
+
+      describe("non-empty request list", () => {
+        const fixtures = [
+          { title: "art1" },
+          { title: "art2" },
+          { title: "art3" },
+        ];
+
+        beforeEach(async () => {
+          api["_headers"] = { Authorization: "Basic plop" };
+          await api
+            .bucket("default")
+            .collection("blog")
+            .batch(
+              (batch) => {
+                for (const article of fixtures) {
+                  batch.createRecord(article);
+                }
+              },
+              { headers: { Foo: "Bar" } }
+            );
+          const request = fetch.firstCall.args[1];
+          requestHeaders = request.headers;
+          requestBody = JSON.parse(request.body);
+        });
+
+        it("should call the batch endpoint", () => {
+          sinon.assert.calledWithMatch(fetch, `/${SPV}/batch`);
+        });
+
+        it("should define main batch request default headers", () => {
+          expect(requestBody.defaults.headers).eql({
+            Authorization: "Basic plop",
+            Foo: "Bar",
+          });
+        });
+
+        it("should attach all batch request headers", () => {
+          expect(requestHeaders.Authorization).eql("Basic plop");
+        });
+
+        it("should batch the expected number of requests", () => {
+          expect(requestBody.requests.length).eql(3);
+        });
+      });
+
+      describe("Safe mode", () => {
+        const fixtures = [{ title: "art1" }, { title: "art2" }];
+
+        it("should forward the safe option to resulting requests", async () => {
+          await api
+            .bucket("default")
+            .collection("blog")
+            .batch(
+              (batch) => {
+                for (const article of fixtures) {
+                  batch.createRecord(article);
+                }
+              },
+              { safe: true }
+            );
+          const { requests } = JSON.parse(fetch.firstCall.args[1].body);
+          expect(
+            requests.map(
+              (r: {
+                headers: {
+                  [key: string]: string;
+                }[];
+              }) => r.headers
+            )
+          ).eql([{ "If-None-Match": "*" }, { "If-None-Match": "*" }]);
+        });
+      });
+
+      describe("Retry", (__test) => {
+        const response = {
+          status: 201,
+          path: `/${SPV}/buckets/blog/collections/articles/records`,
+          body: { data: { id: 1, title: "art" } },
+        };
+
+        beforeEach(() => {
+          fetch
+            .onCall(0)
+            .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
+          fetch.onCall(1).returns(
+            fakeServerResponse(200, {
+              responses: [response],
+            })
+          );
+        });
+
+        it("should retry the request if option is specified", async () => {
+          const r = await api
+            .bucket("default")
+            .collection("blog")
+            .batch((batch) => batch.createRecord({}), {
+              retry: 1,
+            });
+          return expect((r as OperationResponse[])[0]).eql(response);
+        });
+      });
+    });
+
+    describe("server response", () => {
+      const fixtures = [
+        { id: "1", title: "art1" },
+        { id: "2", title: "art2" },
+      ];
+
+      it("should reject on HTTP 400", async () => {
+        sandbox.stub(api.http as any, "fetchFunc").returns(
+          fakeServerResponse(400, {
+            error: true,
+            errno: 117,
+            message: "http 400",
+          })
+        );
+
+        await expectAsyncError(() => executeBatch(fixtures), /HTTP 400/);
+      });
+
+      it("should reject on HTTP error status code", async () => {
+        sandbox.stub(api.http as any, "fetchFunc").returns(
+          fakeServerResponse(500, {
+            error: true,
+            message: "http 500",
+          })
+        );
+
+        await expectAsyncError(() => executeBatch(fixtures), /HTTP 500/);
+      });
+
+      it("should expose succesful subrequest responses", async () => {
+        const responses = [
+          {
+            status: 201,
+            path: `/${SPV}/buckets/blog/collections/articles/records`,
+            body: { data: fixtures[0] },
+          },
+          {
+            status: 201,
+            path: `/${SPV}/buckets/blog/collections/articles/records`,
+            body: { data: fixtures[1] },
+          },
+        ];
+        sandbox
+          .stub(api.http as any, "fetchFunc")
+          .returns(fakeServerResponse(200, { responses }));
+
+        (await executeBatch(fixtures)).should.deep.equal(responses);
+      });
+
+      it("should expose failing subrequest responses", async () => {
+        const missingRemotely = fixtures[0];
+        const responses = [
+          {
+            status: 404,
+            path: `/${SPV}/buckets/blog/collections/articles/records/1`,
+            body: missingRemotely,
+          },
+        ];
+        sandbox
+          .stub(api.http as any, "fetchFunc")
+          .returns(fakeServerResponse(200, { responses }));
+
+        (await executeBatch(fixtures)).should.deep.equal(responses);
+      });
+
+      it("should resolve with encountered HTTP 500", async () => {
+        const responses = [
+          {
+            status: 500,
+            path: `/${SPV}/buckets/blog/collections/articles/records/1`,
+            body: { 500: true },
+          },
+        ];
+        sandbox
+          .stub(api.http as any, "fetchFunc")
+          .returns(fakeServerResponse(200, { responses }));
+
+        (await executeBatch(fixtures)).should.deep.equal(responses);
+      });
+
+      it("should expose encountered HTTP 412", async () => {
+        const responses = [
+          {
+            status: 412,
+            path: `/${SPV}/buckets/blog/collections/articles/records/1`,
+            body: { details: { existing: { title: "foo" } } },
+          },
+        ];
+        sandbox
+          .stub(api.http as any, "fetchFunc")
+          .returns(fakeServerResponse(200, { responses }));
+
+        (await executeBatch(fixtures)).should.deep.equal(responses);
+      });
+    });
+
+    describe("Chunked requests", () => {
+      // 4 operations, one more than the test limit which is 3
+      const fixtures = [
+        { id: "1", title: "foo" },
+        { id: "2", title: "bar" },
+        { id: "3", title: "baz" },
+        { id: "4", title: "qux" },
+      ];
+
+      it("should chunk batch requests", async () => {
+        sandbox
+          .stub(api.http as any, "fetchFunc")
+          .onFirstCall()
+          .returns(
+            fakeServerResponse(200, {
+              responses: [
+                { status: 200, body: { data: 1 } },
+                { status: 200, body: { data: 2 } },
+                { status: 200, body: { data: 3 } },
+              ],
+            })
+          )
+          .onSecondCall()
+          .returns(
+            fakeServerResponse(200, {
+              responses: [{ status: 200, body: { data: 4 } }],
+            })
+          );
+        const responses = (await executeBatch(fixtures)) as OperationResponse[];
+        responses
+          .map((response) => response.body.data)
+          .should.deep.equal([1, 2, 3, 4]);
+      });
+
+      it("should not chunk batch requests if setting is falsy", async () => {
+        const fetchServerSettings = sandbox.stub().returns(
+          Promise.resolve({
+            batch_max_requests: 0,
+          })
+        );
+        sandbox.stub(api, "fetchServerSettings").get(() => fetchServerSettings);
+        const fetchStub = sandbox.stub(api.http as any, "fetchFunc").returns(
+          fakeServerResponse(200, {
+            responses: [],
+          })
+        );
+        await executeBatch(fixtures);
+        return sinon.assert.calledOnce(fetchStub);
+      });
+
+      it("should map initial records to conflict objects", async () => {
+        sandbox
+          .stub(api.http as any, "fetchFunc")
+          .onFirstCall()
+          .returns(
+            fakeServerResponse(200, {
+              responses: [
+                { status: 412, body: { details: { existing: { id: 1 } } } },
+                { status: 412, body: { details: { existing: { id: 2 } } } },
+                { status: 412, body: {} },
+              ],
+            })
+          )
+          .onSecondCall()
+          .returns(
+            fakeServerResponse(200, {
+              responses: [
+                { status: 412, body: { details: { existing: { id: 4 } } } },
+              ],
+            })
+          );
+
+        const responses = (await executeBatch(fixtures)) as OperationResponse[];
+        responses
+          .map((response) => response.status)
+          .should.deep.equal([412, 412, 412, 412]);
+      });
+
+      it("should chunk batch requests concurrently", async () => {
+        sandbox
+          .stub(api.http as any, "fetchFunc")
+          .onFirstCall()
+          .returns(
+            new Promise((resolve) => {
+              function onTimeout() {
+                resolve(
+                  fakeServerResponse(200, {
+                    responses: [
+                      { status: 200, body: { data: 1 } },
+                      { status: 200, body: { data: 2 } },
+                      { status: 200, body: { data: 3 } },
+                    ],
+                  })
+                );
+              }
+              setTimeout(onTimeout, 100);
+            })
+          )
+          .onSecondCall()
+          .returns(
+            new Promise((resolve) => {
+              function onTimeout() {
+                resolve(
+                  fakeServerResponse(200, {
+                    responses: [{ status: 200, body: { data: 4 } }],
+                  })
+                );
+              }
+              setTimeout(onTimeout, 5);
+            })
+          );
+        const responses = (await executeBatch(fixtures)) as OperationResponse[];
+        responses
+          .map((response) => response.body.data)
+          .should.deep.equal([1, 2, 3, 4]);
+      });
+    });
+
+    describe("Aggregate mode", () => {
+      const fixtures = [
+        { title: "art1" },
+        { title: "art2" },
+        { title: "art3" },
+        { title: "art4" },
+      ];
+
+      it("should resolve with an aggregated result object", async () => {
+        const responses: KintoBatchResponse[] = [
+          {
+            status: 200,
+            path: "",
+            body: {},
+            headers: {},
+          },
+          {
+            status: 200,
+            path: "",
+            body: {},
+            headers: {},
+          },
+        ];
+        sandbox
+          .stub(api.http as any, "fetchFunc")
+          .returns(fakeServerResponse(200, { responses }));
+
+        const aggregateResponse = (await executeBatch(fixtures, {
+          aggregate: true,
+        })) as AggregateResponse;
+        aggregateResponse.should.deep.equal({
+          errors: [],
+          published: [{}, {}, {}, {}],
+          conflicts: [],
+          skipped: [],
+        });
+      });
+    });
+  });
+
+  /** @test {KintoClient#execute} */
+  describe("#execute()", () => {
+    it("should ensure passing defined allowed defined request options", async () => {
+      sinon.stub(api, "fetchServerInfo").returns(Promise.resolve({} as any));
+      const request = sinon
+        .stub(api.http, "request")
+        .returns(Promise.resolve({} as any));
+
+      await api.execute({ path: "/foo", garbage: true } as any);
+      sinon.assert.calledWith(
+        request,
+        "http://fake-server/v1/foo",
+        {},
+        { retry: 0 }
+      );
+    });
+  });
+
+  /** @test {KintoClient#paginatedList} */
+  describe("#paginatedList()", () => {
+    const ETag = '"42"';
+    const path = "/some/path";
+    let executeStub: Stub<typeof api.execute>;
+
+    describe("No pagination", () => {
+      beforeEach(() => {
+        // Since listRecords use `raw: true`, stub with full response:
+        executeStub = sandbox.stub(api, "execute").returns(
+          Promise.resolve({
+            json: { data: [{ a: 1 }] },
+            headers: {
+              get: (name: string) => {
+                if (name === "ETag") {
+                  return ETag;
+                }
+              },
+            },
+          })
+        );
+      });
+
+      it("should execute expected request", () => {
+        api.paginatedList(path);
+
+        sinon.assert.calledWithMatch(
+          executeStub,
+          { path: `${path}?_sort=-last_modified`, headers: {} },
+          { raw: true }
+        );
+      });
+
+      it("should sort records", () => {
+        api.paginatedList(path, { sort: "title" });
+
+        sinon.assert.calledWithMatch(
+          executeStub,
+          { path: `${path}?_sort=title`, headers: {} },
+          { raw: true }
+        );
+      });
+
+      it("should resolve with records list", async () => {
+        (await api.paginatedList(path)).should.have
+          .property("data")
+          .eql([{ a: 1 }]);
+      });
+
+      it("should resolve with a next() function", async () => {
+        (await api.paginatedList(path)).should.have
+          .property("next")
+          .to.be.a("function");
+      });
+
+      it("should support the since option", () => {
+        api.paginatedList(path, { since: ETag });
+
+        const qs = "_sort=-last_modified&_since=%2242%22";
+        sinon.assert.calledWithMatch(executeStub, {
+          path: `${path}?${qs}`,
+          headers: {},
+        });
+      });
+
+      it("should throw if the since option is invalid", async () => {
+        await expectAsyncError(
+          () => api.paginatedList(path, { since: 123 } as any),
+          /Invalid value for since \(123\), should be ETag value/
+        );
+      });
+
+      it("should resolve with the collection last_modified without quotes", async () => {
+        (await api.paginatedList(path)).should.have
+          .property("last_modified")
+          .eql("42");
+      });
+
+      it("should resolve with the hasNextPage being set to false", async () => {
+        (await api.paginatedList(path)).should.have
+          .property("hasNextPage")
+          .eql(false);
+      });
+
+      it("should pass fields through", () => {
+        api.paginatedList(path, { fields: ["c", "d"] });
+
+        sinon.assert.calledWithMatch(executeStub, {
+          path: `${path}?_sort=-last_modified&_fields=c,d`,
+          headers: {},
+        });
+      });
+    });
+
+    describe("Filtering", () => {
+      let executeStub: Stub<typeof api.execute>;
+
+      beforeEach(() => {
+        executeStub = sandbox.stub(api, "execute").returns(
+          Promise.resolve({
+            json: { data: [] },
+            headers: { get: () => {} },
+          })
+        );
+      });
+
+      it("should generate the expected filtering query string", () => {
+        api.paginatedList(path, { sort: "x", filters: { min_y: 2, not_z: 3 } });
+
+        const expectedQS = "min_y=2&not_z=3&_sort=x";
+        sinon.assert.calledWithMatch(
+          executeStub,
+          { path: `${path}?${expectedQS}`, headers: {} },
+          { raw: true }
+        );
+      });
+
+      it("shouldn't need an explicit sort parameter", () => {
+        api.paginatedList(path, { filters: { min_y: 2, not_z: 3 } });
+
+        const expectedQS = "min_y=2&not_z=3&_sort=-last_modified";
+        sinon.assert.calledWithMatch(
+          executeStub,
+          { path: `${path}?${expectedQS}`, headers: {} },
+          { raw: true }
+        );
+      });
+    });
+
+    describe("Pagination", () => {
+      let headersgetSpy: sinon.SinonStub;
+      let executeStub: Stub<typeof api.execute>;
+
+      it("should issue a request with the specified limit applied", () => {
+        headersgetSpy = sandbox.stub().returns("");
+        executeStub = sandbox.stub(api, "execute").returns(
+          Promise.resolve({
+            json: { data: [] },
+            headers: { get: headersgetSpy },
+          })
+        );
+
+        api.paginatedList(path, { limit: 2 });
+
+        const expectedQS = "_sort=-last_modified&_limit=2";
+        sinon.assert.calledWithMatch(
+          executeStub,
+          { path: `${path}?${expectedQS}`, headers: {} },
+          { raw: true }
+        );
+      });
+
+      it("should query for next page", async () => {
+        const { http } = api;
+        headersgetSpy = sandbox.stub().returns("http://next-page/");
+        sandbox.stub(api, "execute").returns(
+          Promise.resolve({
+            json: { data: [] },
+            headers: { get: headersgetSpy },
+          })
+        );
+        const requestStub = sandbox.stub(http, "request").returns(
+          Promise.resolve({
+            status: 200,
+            headers: new Headers(),
+            json: { data: [] },
+          })
+        );
+
+        await api.paginatedList(path, { limit: 2, pages: 2 });
+        sinon.assert.calledWith(requestStub, "http://next-page/");
+      });
+
+      it("should aggregate paginated results", async () => {
+        const { http } = api;
+        sandbox
+          .stub(http, "request")
+          // first page
+          .onFirstCall()
+          .returns(
+            Promise.resolve({
+              status: 200,
+              headers: new Headers({ "Next-Page": "http://next-page/" }),
+              json: { data: [1, 2] },
+            })
+          )
+          // second page
+          .onSecondCall()
+          .returns(
+            Promise.resolve({
+              status: 200,
+              headers: new Headers(),
+              json: { data: [3] },
+            })
+          );
+
+        (await api.paginatedList(path, { limit: 2, pages: 2 })).should.have
+          .property("data")
+          .eql([1, 2, 3]);
+      });
+
+      it("should resolve with the hasNextPage being set to true", async () => {
+        const { http } = api;
+        sandbox
+          .stub(http, "request")
+          // first page
+          .onFirstCall()
+          .returns(
+            Promise.resolve({
+              status: 200,
+              headers: new Headers({ "Next-Page": "http://next-page/" }),
+              json: { data: [1, 2] },
+            })
+          );
+
+        (await api.paginatedList(path)).should.have
+          .property("hasNextPage")
+          .eql(true);
+      });
+    });
+
+    describe("Batch mode", () => {
+      it("should not attempt at consumming response headers ", () => {
+        // Emulate an ongoing batch operation
+        (api as any)._isBatch = true;
+
+        return api.paginatedList(path);
+      });
+    });
+  });
+
+  /** @test {KintoClient#listPermissions} */
+  describe("#listPermissions()", () => {
+    const data: PaginationResult<{ id: string }> = {
+      last_modified: "",
+      data: [{ id: "a" }, { id: "b" }],
+      next: () => {
+        return Promise.resolve(
+          {} as unknown as PaginationResult<{
+            id: string;
+          }>
+        );
+      },
+      hasNextPage: false,
+      totalRecords: 2,
+    };
+    let executeStub: Stub<typeof api.execute>;
+
+    describe("Capability available", () => {
+      beforeEach(() => {
+        api.serverInfo = {
+          project_name: "",
+          project_version: "",
+          http_api_version: "",
+          project_docs: "",
+          url: "",
+          settings: { readonly: false, batch_max_requests: 25 },
+          capabilities: {
+            permissions_endpoint: {
+              description: "",
+              url: "",
+            },
+          },
+        };
+        executeStub = sandbox
+          .stub(api, "execute")
+          .returns(
+            Promise.resolve({ json: { data: [] }, headers: { get: () => "" } })
+          );
+      });
+
+      it("should execute expected request", async () => {
+        await api.listPermissions();
+        sinon.assert.calledWithMatch(executeStub, {
+          path: "/permissions?_sort=id",
+          headers: {},
+        });
+      });
+
+      it("should support passing custom headers", async () => {
+        api["_headers"] = { Foo: "Bar" };
+        await api.listPermissions({ headers: { Baz: "Qux" } });
+        sinon.assert.calledWithMatch(executeStub, {
+          path: "/permissions?_sort=id",
+          headers: { Foo: "Bar", Baz: "Qux" },
+        });
+      });
+
+      it("should resolve with a result object", async () => {
+        sandbox.stub(api, "paginatedList").returns(Promise.resolve(data));
+        (await api.listPermissions()).should.have
+          .property("data")
+          .eql(data.data);
+      });
+    });
+
+    describe("Capability unavailable", () => {
+      it("should reject with an error when the capability is not available", async () => {
+        api.serverInfo = {
+          project_name: "",
+          project_version: "",
+          http_api_version: "",
+          project_docs: "",
+          url: "",
+          settings: { readonly: false, batch_max_requests: 25 },
+          capabilities: {},
+        };
+
+        await expectAsyncError(
+          () => api.listPermissions(),
+          /permissions_endpoint/
+        );
+      });
+    });
+  });
+
+  /** @test {KintoClient#listBuckets} */
+  describe("#listBuckets()", () => {
+    const data: PaginationResult<{ id: string }> = {
+      last_modified: "",
+      data: [{ id: "a" }, { id: "b" }],
+      next: () => {
+        return Promise.resolve(
+          {} as unknown as PaginationResult<{
+            id: string;
+          }>
+        );
+      },
+      hasNextPage: false,
+      totalRecords: 2,
+    };
+    let paginatedListStub: Stub<typeof api.paginatedList>;
+
+    beforeEach(() => {
+      paginatedListStub = sandbox
+        .stub(api, "paginatedList")
+        .returns(Promise.resolve(data));
+    });
+
+    it("should execute expected request", () => {
+      api.listBuckets({ since: "42" });
+
+      sinon.assert.calledWithMatch(
+        paginatedListStub,
+        "/buckets",
+        { since: "42" },
+        { headers: {}, retry: 0 }
+      );
+    });
+
+    it("should support passing custom headers", () => {
+      api["_headers"] = { Foo: "Bar" };
+      api.listBuckets({ headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        paginatedListStub,
+        "/buckets",
+        {},
+        { headers: { Foo: "Bar", Baz: "Qux" } }
+      );
+    });
+
+    it("should resolve with a result object", async () => {
+      (await api.listBuckets()).should.have.property("data").eql(data.data);
+    });
+
+    it("should support filters and fields", () => {
+      api.listBuckets({ filters: { a: "b" }, fields: ["c", "d"] });
+
+      sinon.assert.calledWithMatch(paginatedListStub, "/buckets", {
+        filters: { a: "b" },
+        fields: ["c", "d"],
+      });
+    });
+  });
+
+  /** @test {KintoClient#createBucket} */
+  describe("#createBucket", () => {
+    let executeStub: Stub<typeof api.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox.stub(api, "execute").returns(Promise.resolve());
+    });
+
+    it("should execute expected request", () => {
+      api.createBucket("foo");
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/foo",
+          headers: {},
+          body: {
+            data: { id: "foo" },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should accept a data option", () => {
+      api.createBucket("foo", { data: { a: 1 } });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/foo",
+          headers: {},
+          body: {
+            data: { a: 1 },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should accept a safe option", () => {
+      api.createBucket("foo", { safe: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/foo",
+          headers: { "If-None-Match": "*" },
+          body: {
+            data: { id: "foo" },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should extend request headers with optional ones", () => {
+      api["_headers"] = { Foo: "Bar" };
+
+      api.createBucket("foo", { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/foo",
+          headers: { Foo: "Bar", Baz: "Qux" },
+          body: {
+            data: { id: "foo" },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+  });
+
+  /** @test {KintoClient#deleteBucket} */
+  describe("#deleteBucket()", () => {
+    let executeStub: Stub<typeof api.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox.stub(api, "execute").returns(Promise.resolve());
+    });
+
+    it("should execute expected request", () => {
+      api.deleteBucket("plop");
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/plop",
+          headers: {},
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should accept a bucket object", () => {
+      api.deleteBucket({ id: "plop" });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/plop",
+          headers: {},
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should throw if safe is true and last_modified isn't provided", async () => {
+      await expectAsyncError(
+        () => api.deleteBucket("plop", { safe: true }),
+        /Safe concurrency check requires a last_modified value./
+      );
+    });
+
+    it("should rely on the provided last_modified for the safe option", () => {
+      api.deleteBucket("plop", { last_modified: 42, safe: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/plop",
+          headers: {
+            "If-Match": `"42"`,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should extend request headers with optional ones", () => {
+      api["_headers"] = { Foo: "Bar" };
+
+      api.deleteBucket("plop", { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/plop",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+          },
+        },
+        { retry: 0 }
+      );
+    });
+  });
+
+  /** @test {KintoClient#deleteBuckets} */
+  describe("#deleteBuckets()", () => {
+    let executeStub: Stub<typeof api.execute>;
+
+    beforeEach(() => {
+      api.serverInfo = {
+        project_name: "",
+        project_version: "",
+        http_api_version: "1.4",
+        project_docs: "",
+        url: "",
+        settings: { readonly: false, batch_max_requests: 25 },
+        capabilities: {},
+      };
+      executeStub = sandbox.stub(api, "execute").returns(Promise.resolve({}));
+    });
+
+    it("should execute expected request", async () => {
+      await api.deleteBuckets();
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets?_sort=-last_modified",
+          headers: {},
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should throw if safe is true and last_modified isn't provided", async () => {
+      await expectAsyncError(
+        () => api.deleteBuckets({ safe: true }),
+        /Safe concurrency check requires a last_modified value./
+      );
+    });
+
+    it("should rely on the provided last_modified for the safe option", async () => {
+      await api.deleteBuckets({ last_modified: 42, safe: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets?_sort=-last_modified",
+          headers: {
+            "If-Match": `"42"`,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should extend request headers with optional ones", async () => {
+      api["_headers"] = { Foo: "Bar" };
+
+      await api.deleteBuckets({ headers: { Baz: "Qux" } });
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets?_sort=-last_modified",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should accept a timestamp option", async () => {
+      await api.deleteBuckets({ filters: { since: 42 } });
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets?since=42&_sort=-last_modified",
+          headers: {},
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should support filters and fields", async () => {
+      await api.deleteBuckets({
+        filters: { a: "b" },
+        fields: ["c", "d"],
+      });
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets?a=b&_sort=-last_modified&_fields=c,d",
+          headers: {},
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should reject if http_api_version mismatches", async () => {
+      api.serverInfo = {
+        project_name: "",
+        project_version: "",
+        http_api_version: "1.3",
+        project_docs: "",
+        url: "",
+        settings: { readonly: false, batch_max_requests: 25 },
+        capabilities: {},
+      };
+
+      await expectAsyncError(() => api.deleteBuckets(), /Version/);
+    });
+  });
+});

--- a/test/http/batch_test.ts
+++ b/test/http/batch_test.ts
@@ -1,0 +1,235 @@
+import * as requests from "../../src/http/requests";
+import {
+  aggregate,
+  AggregateResponse,
+  KintoBatchResponse,
+} from "../../src/http/batch";
+import { KintoRequest } from "../../src/http/types";
+
+const { expect } = intern.getPlugin("chai");
+intern.getPlugin("chai").should();
+const { describe, it, beforeEach } = intern.getPlugin("interface.bdd");
+
+describe("batch module", () => {
+  describe("aggregate()", () => {
+    it("should throw if responses length doesn't match requests one", () => {
+      const resp = {
+        status: 200,
+        path: "/sample",
+        body: { data: {} },
+        headers: {},
+      };
+      const req = requests.createRequest("foo1", {
+        data: { id: 1 },
+      });
+      expect(() => aggregate([resp], [req, req])).to.Throw(Error, /match/);
+    });
+
+    it("should return an object", () => {
+      expect(aggregate([], [])).to.be.an("object");
+    });
+
+    it("should return an object with the expected keys", () => {
+      expect(aggregate([], [])).to.include.keys([
+        "published",
+        "conflicts",
+        "skipped",
+        "errors",
+      ]);
+    });
+
+    it("should expose HTTP 500 errors in the errors list", () => {
+      const _requests = [
+        requests.createRequest("foo1", {
+          data: { id: 1 },
+        }),
+        requests.createRequest("foo2", { data: { id: 2 } }),
+      ];
+      const responses = [
+        { status: 500, body: { data: { err: 1 } }, path: "/foo1", headers: {} },
+        { status: 503, body: { data: { err: 2 } }, path: "/foo2", headers: {} },
+      ];
+
+      expect(aggregate(responses, _requests))
+        .to.have.property("errors")
+        .eql([
+          {
+            error: { data: { err: 1 } },
+            path: "foo1",
+            sent: _requests[0],
+          },
+          {
+            error: { data: { err: 2 } },
+            path: "foo2",
+            sent: _requests[1],
+          },
+        ]);
+    });
+
+    it("should expose HTTP 200<=x<400 responses in the published list", () => {
+      const _requests = [
+        requests.createRequest("foo", {
+          data: { id: 1 },
+        }),
+        requests.createRequest("foo", { data: { id: 2 } }),
+      ];
+      const responses = [
+        { status: 200, body: { data: { id: 1 } }, path: "/foo", headers: {} },
+        { status: 201, body: { data: { id: 2 } }, path: "/foo", headers: {} },
+      ];
+
+      expect(aggregate(responses, _requests))
+        .to.have.property("published")
+        .eql(responses.map((r) => r.body));
+    });
+
+    it("should expose HTTP 404 responses in the skipped list", () => {
+      const _requests = [
+        requests.createRequest("records/123", {
+          data: { id: 1 },
+        }),
+        requests.createRequest("records/123", { data: { id: 2 } }),
+      ];
+      const responses = [
+        {
+          status: 404,
+          body: { errno: 110, code: 404, error: "Not found" },
+          path: "records/123",
+          headers: {},
+        },
+        {
+          status: 404,
+          body: { errno: 110, code: 404, error: "Not found" },
+          path: "records/123",
+          headers: {},
+        },
+      ];
+
+      expect(aggregate(responses, _requests))
+        .to.have.property("skipped")
+        .eql(
+          responses.map((r) => ({
+            id: "123",
+            path: "records/123",
+            error: r.body,
+          }))
+        );
+    });
+
+    it("should expose HTTP 412 responses in the conflicts list", () => {
+      const _requests = [
+        requests.createRequest("records/123", {
+          data: { id: 1 },
+        }),
+        requests.createRequest("records/123", { data: { id: 2 } }),
+      ];
+      const responses = [
+        {
+          status: 412,
+          body: { details: { existing: { last_modified: 0, id: "1" } } },
+          path: "records/123",
+          headers: {},
+        },
+        { status: 412, body: {}, path: "records/123", headers: {} },
+      ];
+
+      expect(aggregate(responses, _requests))
+        .to.have.property("conflicts")
+        .eql([
+          {
+            type: "outgoing",
+            local: _requests[0].body,
+            remote: { last_modified: 0, id: "1" },
+          },
+          {
+            type: "outgoing",
+            local: _requests[1].body,
+            remote: null,
+          },
+        ]);
+    });
+
+    describe("Heterogeneous combinations", () => {
+      let _requests: KintoRequest[],
+        responses: KintoBatchResponse[],
+        results: AggregateResponse;
+
+      beforeEach(() => {
+        _requests = [
+          requests.createRequest("collections/abc/records/123", {
+            data: { id: 1 },
+          }),
+          requests.createRequest("collections/abc/records/123", {
+            data: { id: 2 },
+          }),
+          requests.createRequest("collections/abc/records/123", {
+            data: { id: 3 },
+          }),
+          requests.createRequest("collections/abc/records/123", {
+            data: { id: 4, a: 1 },
+          }),
+        ];
+        responses = [
+          { status: 500, path: "path1", body: { errno: 1 }, headers: {} },
+          {
+            status: 200,
+            body: { data: { foo: "bar" } },
+            path: "/",
+            headers: {},
+          },
+          {
+            status: 404,
+            body: { errno: 110, code: 404, error: "Not found" },
+            path: "/",
+            headers: {},
+          },
+          {
+            status: 412,
+            body: { details: { existing: { last_modified: 1, id: "1" } } },
+            path: "/",
+            headers: {},
+          },
+        ];
+
+        results = aggregate(responses, _requests);
+      });
+
+      it("should list errors", () => {
+        expect(results.errors).eql([
+          {
+            error: { errno: 1 },
+            path: "collections/abc/records/123",
+            sent: _requests[0],
+          },
+        ]);
+      });
+
+      it("should list published data", () => {
+        expect(results.published).eql([{ data: { foo: "bar" } }]);
+      });
+
+      it("should list conflicts", () => {
+        expect(results.conflicts).eql([
+          {
+            type: "outgoing",
+            local: {
+              data: { id: 4, a: 1 },
+              permissions: undefined,
+            },
+            remote: { last_modified: 1, id: "1" },
+          },
+        ]);
+      });
+
+      it("should list skips", () => {
+        expect(results.skipped).eql([
+          {
+            id: "123",
+            path: "collections/abc/records/123",
+            error: responses[2].body,
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/test/http/bucket_test.ts
+++ b/test/http/bucket_test.ts
@@ -1,0 +1,1285 @@
+import sinon from "sinon";
+import KintoClient from "../../src/http";
+import Bucket, { BucketOptions } from "../../src/http/bucket";
+import Collection from "../../src/http/collection";
+import { PaginationResult } from "../../src/http/base";
+import { Stub, expectAsyncError, fakeHeaders } from "./test_utils";
+
+const { expect } = intern.getPlugin("chai");
+intern.getPlugin("chai").should();
+const { describe, it, beforeEach, afterEach } =
+  intern.getPlugin("interface.bdd");
+
+const FAKE_SERVER_URL = "http://fake-server/v1";
+
+/** @test {Bucket} */
+describe("Bucket", () => {
+  let sandbox: sinon.SinonSandbox, client: KintoClient;
+
+  function getBlogBucket(options?: BucketOptions) {
+    return new Bucket(client, "blog", options);
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    client = new KintoClient(FAKE_SERVER_URL);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("Options handling", () => {
+    it("should accept options", () => {
+      const options = { headers: { Foo: "Bar" }, safe: true };
+      const bucket = getBlogBucket(options);
+      expect(bucket).property("_headers", options.headers);
+      expect(bucket).property("_safe", options.safe);
+    });
+  });
+
+  /** @test {Bucket#getData} */
+  describe("#getData()", () => {
+    it("should execute expected request", async () => {
+      const executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ headers: fakeHeaders() }));
+
+      await getBlogBucket().getData();
+
+      sinon.assert.calledWithMatch(executeStub, {
+        path: "/buckets/blog",
+        headers: {},
+      });
+    });
+
+    it("should resolve with response data", async () => {
+      const response = { data: { foo: "bar" }, permissions: {} };
+      sandbox.stub(client, "execute").returns(Promise.resolve(response));
+
+      const data = (await getBlogBucket().getData()) as { foo: string };
+      data.should.deep.equal({
+        foo: "bar",
+      });
+    });
+
+    it("should support query and fields", () => {
+      const response = { data: { foo: "bar" }, permissions: {} };
+      const requestStub = sandbox.stub(client.http, "request").returns(
+        Promise.resolve({
+          headers: fakeHeaders(),
+          json: response,
+          status: 200,
+        })
+      );
+
+      getBlogBucket().getData({ query: { a: "b" }, fields: ["c", "d"] });
+
+      sinon.assert.calledWithMatch(
+        requestStub,
+        "http://fake-server/v1/buckets/blog?a=b&_fields=c,d",
+        {
+          headers: {},
+        }
+      );
+    });
+  });
+
+  describe("#setData()", () => {
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: 1 }));
+    });
+
+    it("should set the bucket data", () => {
+      getBlogBucket().setData({ a: 1 });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog",
+          headers: {},
+          body: {
+            data: { id: "blog", a: 1 },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should handle the patch option", () => {
+      getBlogBucket().setData({ a: 1 }, { patch: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PATCH",
+          path: "/buckets/blog",
+          headers: {},
+          body: {
+            data: { id: "blog", a: 1 },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should handle the safe option", () => {
+      getBlogBucket().setData({ a: 1 }, { safe: true, last_modified: 42 });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog",
+          headers: { "If-Match": `"42"` },
+          body: {
+            data: { id: "blog", a: 1 },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should resolve with json result", async () => {
+      (await getBlogBucket().setData({ a: 1 })).should.deep.equal({ data: 1 });
+    });
+  });
+
+  /** @test {Bucket#collection} */
+  describe("#collection()", () => {
+    it("should return a Collection instance", () => {
+      expect(getBlogBucket().collection("posts")).to.be.an.instanceOf(
+        Collection
+      );
+    });
+
+    it("should return a named collection", () => {
+      expect(getBlogBucket().collection("posts").name).eql("posts");
+    });
+
+    it("should propagate bucket options", () => {
+      const collection = getBlogBucket({
+        headers: { Foo: "Bar" },
+        safe: true,
+      }).collection("posts", { headers: { Baz: "Qux" }, safe: false });
+      expect(collection["_headers"]).eql({ Foo: "Bar", Baz: "Qux" });
+      expect(collection["_retry"]).eql(0);
+      expect(collection["_safe"]).eql(false);
+    });
+  });
+
+  /** @test {Bucket#getCollectionsTimestamp} */
+  describe("#getCollectionsTimestamp()", () => {
+    it("should execute expected request", async () => {
+      const executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ headers: fakeHeaders() }));
+
+      await getBlogBucket().getCollectionsTimestamp();
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        { method: "HEAD", path: "/buckets/blog/collections", headers: {} },
+        { raw: true }
+      );
+    });
+
+    it("should resolve with the ETag header value", async () => {
+      const etag = '"42"';
+      sandbox.stub(client, "execute").returns(
+        Promise.resolve({
+          headers: {
+            get(value: string) {
+              return value == "ETag" ? etag : null;
+            },
+          },
+        })
+      );
+
+      (await getBlogBucket().getCollectionsTimestamp())!.should.deep.equal(
+        etag
+      );
+    });
+  });
+
+  /** @test {Bucket#listCollections} */
+  describe("#listCollections()", () => {
+    const data: PaginationResult<{ id: string }> = {
+      last_modified: "",
+      data: [{ id: "a" }, { id: "b" }],
+      next: () => {
+        return Promise.resolve(
+          {} as unknown as PaginationResult<{
+            id: string;
+          }>
+        );
+      },
+      hasNextPage: false,
+      totalRecords: 2,
+    };
+    let paginatedListStub: Stub<typeof client.paginatedList>;
+
+    beforeEach(() => {
+      paginatedListStub = sandbox
+        .stub(client, "paginatedList")
+        .returns(Promise.resolve(data));
+    });
+
+    it("should list bucket collections", () => {
+      getBlogBucket().listCollections({ since: "42" });
+
+      sinon.assert.calledWithMatch(
+        paginatedListStub,
+        "/buckets/blog/collections",
+        { since: "42" },
+        { headers: {} }
+      );
+    });
+
+    it("should merge default options", () => {
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+      }).listCollections({ headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        paginatedListStub,
+        "/buckets/blog/collections",
+        {},
+        { headers: { Foo: "Bar", Baz: "Qux" } }
+      );
+    });
+
+    it("should support filters and fields", () => {
+      getBlogBucket().listCollections({
+        filters: { a: "b" },
+        fields: ["c", "d"],
+      });
+
+      sinon.assert.calledWithMatch(
+        paginatedListStub,
+        "/buckets/blog/collections",
+        { filters: { a: "b" }, fields: ["c", "d"] }
+      );
+    });
+
+    it("should return the list of collections", async () => {
+      (await getBlogBucket().listCollections()).should.deep.equal(data);
+    });
+  });
+
+  /** @test {Bucket#createCollection} */
+  describe("#createCollection()", () => {
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: {} }));
+    });
+
+    it("should accept a safe option", () => {
+      getBlogBucket().createCollection("foo", { safe: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/collections/foo",
+          headers: { "If-None-Match": `*` },
+          body: {
+            data: { id: "foo" },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should extend request headers with optional ones", () => {
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+      }).createCollection("foo", { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/collections/foo",
+          headers: { Baz: "Qux" },
+          body: {
+            data: { id: "foo" },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    describe("Named collection", () => {
+      it("should create a named collection", () => {
+        getBlogBucket().createCollection("foo");
+
+        sinon.assert.calledWithMatch(
+          executeStub,
+          {
+            method: "PUT",
+            path: "/buckets/blog/collections/foo",
+            headers: {},
+            body: {
+              data: { id: "foo" },
+              permissions: undefined,
+            },
+          },
+          { retry: 0 }
+        );
+      });
+
+      it("should merge default options", () => {
+        getBlogBucket({
+          headers: { Foo: "Bar" },
+          safe: true,
+        }).createCollection("foo", { headers: { Baz: "Qux" } });
+
+        sinon.assert.calledWithMatch(
+          executeStub,
+          {
+            method: "PUT",
+            path: "/buckets/blog/collections/foo",
+            headers: { Foo: "Bar", Baz: "Qux", "If-None-Match": "*" },
+            body: {
+              data: { id: "foo" },
+              permissions: undefined,
+            },
+          },
+          { retry: 0 }
+        );
+      });
+    });
+
+    describe("Unnamed collection", () => {
+      it("should create an unnamed collection", () => {
+        getBlogBucket().createCollection();
+
+        sinon.assert.calledWithMatch(
+          executeStub,
+          {
+            method: "POST",
+            path: "/buckets/blog/collections",
+            headers: {},
+            body: {
+              data: {},
+              permissions: undefined,
+            },
+          },
+          { retry: 0 }
+        );
+      });
+
+      it("should merge default options", () => {
+        getBlogBucket({
+          headers: { Foo: "Bar" },
+          safe: true,
+        }).createCollection("", { headers: { Baz: "Qux" } });
+
+        sinon.assert.calledWithMatch(
+          executeStub,
+          {
+            method: "POST",
+            path: "/buckets/blog/collections",
+            headers: { Foo: "Bar", Baz: "Qux", "If-None-Match": "*" },
+            body: {
+              data: {},
+              permissions: undefined,
+            },
+          },
+          { retry: 0 }
+        );
+      });
+    });
+  });
+
+  /** @test {Bucket#deleteCollection} */
+  describe("#deleteCollection", () => {
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: {} }));
+    });
+
+    it("should delete a collection", () => {
+      getBlogBucket().deleteCollection("todelete");
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/blog/collections/todelete",
+          headers: {},
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should merge default options", () => {
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+        safe: true,
+      }).deleteCollection("todelete", {
+        headers: { Baz: "Qux" },
+        last_modified: 42,
+      });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/blog/collections/todelete",
+          headers: { Baz: "Qux", "If-Match": `"42"` },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should throw if safe is true and last_modified isn't provided", async () => {
+      await expectAsyncError(
+        () => getBlogBucket().deleteCollection("todelete", { safe: true }),
+        /Safe concurrency check requires a last_modified value./
+      );
+    });
+
+    it("should rely on the provided last_modified for the safe option", () => {
+      getBlogBucket().deleteCollection(
+        { id: "todelete", last_modified: 42 },
+        { safe: true }
+      );
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/blog/collections/todelete",
+          headers: { "If-Match": `"42"` },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should extend request headers with optional ones", () => {
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+      }).deleteCollection("todelete", { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/blog/collections/todelete",
+          headers: { Foo: "Bar", Baz: "Qux" },
+        },
+        { retry: 0 }
+      );
+    });
+  });
+
+  /** @test {Bucket#deleteCollections} */
+  describe("#deleteCollections", () => {
+    let executeStub: sinon.SinonStub;
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: {} }));
+    });
+
+    it("should delete all collections", () => {
+      getBlogBucket().deleteCollections();
+
+      sinon.assert.calledWithMatch(executeStub, {
+        method: "DELETE",
+        path: "/buckets/blog/collections?_sort=-last_modified",
+        headers: {},
+      });
+    });
+
+    it("should accept a timestamp option", () => {
+      getBlogBucket().deleteCollections({
+        filters: { since: 42 },
+      });
+
+      sinon.assert.calledWithMatch(executeStub, {
+        method: "DELETE",
+        path: "/buckets/blog/collections?since=42&_sort=-last_modified",
+        headers: {},
+      });
+    });
+
+    it("should merge default options", () => {
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+      }).deleteCollections({ headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(executeStub, {
+        path: "/buckets/blog/collections?_sort=-last_modified",
+        headers: { Foo: "Bar", Baz: "Qux" },
+      });
+    });
+
+    it("should support filters and fields", () => {
+      getBlogBucket().deleteCollections({
+        filters: { a: "b" },
+        fields: ["c", "d"],
+      });
+
+      sinon.assert.calledWithMatch(executeStub, {
+        path: "/buckets/blog/collections?a=b&_sort=-last_modified&_fields=c,d",
+        headers: {},
+      });
+    });
+  });
+
+  /** @test {Bucket#getGroupsTimestamp} */
+  describe("#getGroupsTimestamp()", () => {
+    it("should execute expected request", async () => {
+      const executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ headers: fakeHeaders() }));
+
+      await getBlogBucket().getGroupsTimestamp();
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        { method: "HEAD", path: "/buckets/blog/groups", headers: {} },
+        { raw: true }
+      );
+    });
+
+    it("should resolve with the ETag header value", async () => {
+      const etag = '"42"';
+      sandbox.stub(client, "execute").returns(
+        Promise.resolve({
+          headers: {
+            get(value: string) {
+              return value == "ETag" ? etag : null;
+            },
+          },
+        })
+      );
+
+      (await getBlogBucket().getGroupsTimestamp())!.should.deep.equal(etag);
+    });
+  });
+
+  /** @test {Bucket#listGroups} */
+  describe("#listGroups()", () => {
+    const data: PaginationResult<{ id: string }> = {
+      last_modified: "",
+      data: [{ id: "a" }, { id: "b" }],
+      next: () => {
+        return Promise.resolve(
+          {} as unknown as PaginationResult<{
+            id: string;
+          }>
+        );
+      },
+      hasNextPage: false,
+      totalRecords: 2,
+    };
+    let paginatedListStub: Stub<typeof client.paginatedList>;
+
+    beforeEach(() => {
+      paginatedListStub = sandbox
+        .stub(client, "paginatedList")
+        .returns(Promise.resolve(data));
+    });
+
+    it("should list bucket groups", () => {
+      getBlogBucket().listGroups({ since: "42" });
+
+      sinon.assert.calledWithMatch(
+        paginatedListStub,
+        "/buckets/blog/groups",
+        { since: "42" },
+        { headers: {} }
+      );
+    });
+
+    it("should merge default options", () => {
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+      }).listGroups({ headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        paginatedListStub,
+        "/buckets/blog/groups",
+        {},
+        { headers: { Foo: "Bar", Baz: "Qux" } }
+      );
+    });
+
+    it("should support filters and fields", () => {
+      getBlogBucket().listGroups({ filters: { a: "b" }, fields: ["c", "d"] });
+
+      sinon.assert.calledWithMatch(paginatedListStub, "/buckets/blog/groups", {
+        filters: { a: "b" },
+        fields: ["c", "d"],
+      });
+    });
+
+    it("should return the list of groups", async () => {
+      (await getBlogBucket().listGroups()).should.deep.equal(data);
+    });
+  });
+
+  /** @test {Bucket#getGroup} */
+  describe("#getGroup", () => {
+    const fakeGroup = { data: {}, permissions: {} };
+    let executeStub: Stub<typeof client.execute>;
+
+    it("should extend request headers with optional ones", () => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve(fakeGroup));
+
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+      }).getGroup("foo", { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(executeStub, {
+        path: "/buckets/blog/groups/foo",
+        headers: { Foo: "Bar", Baz: "Qux" },
+      });
+    });
+
+    it("should return the group", async () => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve(fakeGroup));
+
+      (await getBlogBucket().getGroup("foo")).should.deep.equal(fakeGroup);
+    });
+
+    it("should support query and fields", () => {
+      const requestStub = sandbox.stub(client.http, "request").returns(
+        Promise.resolve({
+          headers: fakeHeaders(),
+          json: {},
+          status: 200,
+        })
+      );
+
+      getBlogBucket().getGroup("foo", {
+        query: { a: "b" },
+        fields: ["c", "d"],
+      });
+
+      sinon.assert.calledWithMatch(
+        requestStub,
+        "http://fake-server/v1/buckets/blog/groups/foo?a=b&_fields=c,d",
+        {
+          headers: {},
+        }
+      );
+    });
+  });
+
+  /** @test {Bucket#createGroup} */
+  describe("#createGroup", () => {
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: {} }));
+    });
+
+    it("should accept a safe option", () => {
+      getBlogBucket().createGroup("foo", [], { safe: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/groups/foo",
+          headers: { "If-None-Match": `*` },
+          body: { data: { id: "foo", members: [] }, permissions: undefined },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should extend request headers with optional ones", () => {
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+      }).createGroup("foo", [], { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/groups/foo",
+          headers: { Foo: "Bar", Baz: "Qux" },
+          body: { data: { id: "foo", members: [] }, permissions: undefined },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should create a group with empty list of members", () => {
+      getBlogBucket().createGroup("foo");
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/groups/foo",
+          headers: {},
+          body: { data: { id: "foo", members: [] }, permissions: undefined },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should create a group with optional data and permissions", () => {
+      const group = {
+        data: { age: 21 },
+        permissions: { write: ["github:leplatrem"] },
+      };
+      getBlogBucket().createGroup("foo", [], group);
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/groups/foo",
+          headers: {},
+          body: {
+            data: { id: "foo", members: [], age: 21 },
+            permissions: group.permissions,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+  });
+
+  /** @test {Bucket#updateGroup} */
+  describe("#updateGroup", () => {
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: {} }));
+    });
+
+    it("should throw if record is not an object", async () => {
+      await expectAsyncError(
+        () => getBlogBucket().updateGroup(undefined as any),
+        /group object is required/
+      );
+    });
+
+    it("should throw if id is missing", async () => {
+      expectAsyncError(
+        () => getBlogBucket().updateGroup({} as any),
+        /group id is required/
+      );
+    });
+
+    it("should accept a patch option", () => {
+      getBlogBucket().updateGroup({ id: "foo", members: [] }, { patch: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PATCH",
+          path: "/buckets/blog/groups/foo",
+          headers: {},
+          body: {
+            data: { id: "foo", members: [] },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should extend request headers with optional ones", () => {
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+      }).updateGroup({ id: "foo", members: [] }, { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/groups/foo",
+          headers: { Foo: "Bar", Baz: "Qux" },
+          body: {
+            data: { id: "foo", members: [] },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should update the group from first argument", () => {
+      getBlogBucket().updateGroup({ id: "foo", members: [] });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/groups/foo",
+          headers: {},
+          body: {
+            data: { id: "foo", members: [] },
+            permissions: undefined,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should update the group with optional data and permissions", () => {
+      const group = {
+        data: { age: 21 },
+        permissions: { write: ["github:leplatrem"] },
+      };
+      getBlogBucket().updateGroup({ id: "foo", members: [] }, group);
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/groups/foo",
+          headers: {},
+          body: {
+            data: { id: "foo", members: [], age: 21 },
+            permissions: group.permissions,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+  });
+
+  /** @test {Bucket#updateGroup} */
+  describe("#deleteGroup", () => {
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: {} }));
+    });
+
+    it("should delete a group", () => {
+      getBlogBucket().deleteGroup("todelete");
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/blog/groups/todelete",
+          headers: {},
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should merge default options", () => {
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+        safe: true,
+      }).deleteGroup("todelete", {
+        headers: { Baz: "Qux" },
+        last_modified: 42,
+      });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/blog/groups/todelete",
+          headers: { Foo: "Bar", Baz: "Qux", "If-Match": `"42"` },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should throw if safe is true and last_modified isn't provided", async () => {
+      await expectAsyncError(
+        () => getBlogBucket().deleteGroup("todelete", { safe: true }),
+        /Safe concurrency check requires a last_modified value./
+      );
+    });
+
+    it("should rely on the provided last_modified for the safe option", () => {
+      getBlogBucket().deleteGroup(
+        { id: "todelete", last_modified: 42 },
+        { safe: true }
+      );
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/blog/groups/todelete",
+          headers: { "If-Match": `"42"` },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should extend request headers with optional ones", () => {
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+      }).deleteGroup("todelete", { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/blog/groups/todelete",
+          headers: { Foo: "Bar", Baz: "Qux" },
+        },
+        { retry: 0 }
+      );
+    });
+  });
+
+  /** @test {Bucket#deleteGroups} */
+  describe("#deleteGroups", () => {
+    let executeStub: sinon.SinonStub;
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: {} }));
+    });
+
+    it("should delete all Groups", () => {
+      getBlogBucket().deleteGroups();
+
+      sinon.assert.calledWithMatch(executeStub, {
+        method: "DELETE",
+        path: "/buckets/blog/groups?_sort=-last_modified",
+        headers: {},
+      });
+    });
+
+    it("should accept a timestamp option", () => {
+      getBlogBucket().deleteGroups({
+        filters: { since: 42 },
+      });
+
+      sinon.assert.calledWithMatch(executeStub, {
+        method: "DELETE",
+        path: "/buckets/blog/groups?since=42&_sort=-last_modified",
+        headers: {},
+      });
+    });
+
+    it("should merge default options", () => {
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+      }).deleteGroups({ headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(executeStub, {
+        method: "DELETE",
+        path: "/buckets/blog/groups?_sort=-last_modified",
+        headers: { Foo: "Bar", Baz: "Qux" },
+      });
+    });
+
+    it("should support filters and fields", () => {
+      getBlogBucket().deleteGroups({
+        filters: { a: "b" },
+        fields: ["c", "d"],
+      });
+
+      sinon.assert.calledWithMatch(executeStub, {
+        method: "DELETE",
+        path: "/buckets/blog/groups?a=b&_sort=-last_modified&_fields=c,d",
+        headers: {},
+      });
+    });
+  });
+
+  /** @test {Bucket#getPermissions} */
+  describe("#getPermissions()", () => {
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox.stub(client, "execute").returns(
+        Promise.resolve({
+          data: {},
+          permissions: { write: ["fakeperms"] },
+        })
+      );
+    });
+
+    it("should retrieve permissions", async () => {
+      const bucket = getBlogBucket();
+      (await bucket.getPermissions()).should.deep.equal({
+        write: ["fakeperms"],
+      });
+    });
+
+    it("should merge default options", () => {
+      const bucket = getBlogBucket({ headers: { Foo: "Bar" }, safe: true });
+
+      return bucket.getPermissions({ headers: { Baz: "Qux" } }).then((_) => {
+        sinon.assert.calledWithMatch(executeStub, {
+          path: "/buckets/blog",
+          headers: { Baz: "Qux", Foo: "Bar" },
+        });
+      });
+    });
+  });
+
+  /** @test {Bucket#setPermissions} */
+  describe("#setPermissions()", () => {
+    const fakePermissions = { read: [] as string[], write: [] as string[] };
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox.stub(client, "execute").returns(
+        Promise.resolve({
+          data: {},
+          permissions: fakePermissions,
+        })
+      );
+    });
+
+    it("should set permissions", () => {
+      getBlogBucket().setPermissions(fakePermissions);
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog",
+          headers: {},
+          body: { permissions: fakePermissions },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should merge default options", () => {
+      const bucket = getBlogBucket({ headers: { Foo: "Bar" }, safe: true });
+
+      bucket.setPermissions(fakePermissions, { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog",
+          headers: { Foo: "Bar", Baz: "Qux", "If-None-Match": "*" },
+          body: { permissions: fakePermissions },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should accept a last_modified option", () => {
+      const bucket = getBlogBucket({ headers: { Foo: "Bar" }, safe: true });
+
+      bucket.setPermissions(fakePermissions, { last_modified: 42 });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog",
+          headers: { Foo: "Bar", "If-Match": `"42"` },
+          body: { permissions: fakePermissions },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should resolve with response data", async () => {
+      (await getBlogBucket().setPermissions(fakePermissions)).should.have
+        .property("permissions")
+        .eql(fakePermissions);
+    });
+  });
+
+  /** @test {Bucket#addPermissions} */
+  describe("#addPermissions()", () => {
+    const fakePermissions = { read: [] as string[], write: [] as string[] };
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox.stub(client, "execute").returns(
+        Promise.resolve({
+          data: {},
+          permissions: fakePermissions,
+        })
+      );
+    });
+
+    it("should append permissions", () => {
+      getBlogBucket().addPermissions(fakePermissions);
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PATCH",
+          path: "/buckets/blog",
+          headers: {
+            "Content-Type": "application/json-patch+json",
+          },
+          body: [],
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should merge default options", () => {
+      const bucket = getBlogBucket({ headers: { Foo: "Bar" }, safe: true });
+
+      bucket.addPermissions(fakePermissions, { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PATCH",
+          path: "/buckets/blog",
+          headers: {
+            "Content-Type": "application/json-patch+json",
+            Foo: "Bar",
+            Baz: "Qux",
+            "If-None-Match": "*",
+          },
+          body: [],
+        },
+        { retry: 0 }
+      );
+    });
+  });
+
+  /** @test {Bucket#removePermissions} */
+  describe("#removePermissions()", () => {
+    const fakePermissions = { read: [] as string[], write: [] as string[] };
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox.stub(client, "execute").returns(
+        Promise.resolve({
+          data: {},
+          permissions: fakePermissions,
+        })
+      );
+    });
+
+    it("should pop permissions", () => {
+      getBlogBucket().removePermissions(fakePermissions);
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PATCH",
+          path: "/buckets/blog",
+          headers: {
+            "Content-Type": "application/json-patch+json",
+          },
+          body: [],
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should merge default options", () => {
+      const bucket = getBlogBucket({ headers: { Foo: "Bar" }, safe: true });
+
+      bucket.removePermissions(fakePermissions, { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PATCH",
+          path: "/buckets/blog",
+          headers: {
+            "Content-Type": "application/json-patch+json",
+            Foo: "Bar",
+            Baz: "Qux",
+            "If-None-Match": "*",
+          },
+          body: [],
+        },
+        { retry: 0 }
+      );
+    });
+  });
+
+  /** @test {Bucket#batch} */
+  describe("#batch()", () => {
+    let batchStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      batchStub = sandbox.stub();
+      sandbox.stub(client, "batch").get(() => batchStub);
+    });
+
+    it("should batch operations for this bucket", () => {
+      // @ts-ignore
+      const fn = (batch: any) => {};
+
+      getBlogBucket().batch(fn);
+
+      sinon.assert.calledWith(batchStub, fn, {
+        bucket: "blog",
+        headers: {},
+        retry: 0,
+        safe: false,
+        aggregate: false,
+      });
+    });
+
+    it("should merge default options", () => {
+      // @ts-ignore
+      const fn = (batch: any) => {};
+
+      getBlogBucket({
+        headers: { Foo: "Bar" },
+        safe: true,
+      }).batch(fn, { headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWith(batchStub, fn, {
+        bucket: "blog",
+        headers: { Foo: "Bar", Baz: "Qux" },
+        retry: 0,
+        safe: true,
+        aggregate: false,
+      });
+    });
+  });
+
+  /** @test {Bucket#execute} */
+  describe("#execute()", () => {
+    it("should rely on client execute", () => {
+      const bucket = getBlogBucket();
+      const executeStub = sandbox.stub();
+      sandbox.stub(client, "execute").get(() => executeStub);
+      const req = { path: "/", headers: {} };
+
+      bucket.execute(req);
+
+      sinon.assert.calledWith(executeStub, req);
+    });
+  });
+});

--- a/test/http/collection_test.ts
+++ b/test/http/collection_test.ts
@@ -1,0 +1,841 @@
+import sinon from "sinon";
+import KintoClient from "../../src/http";
+import Bucket from "../../src/http/bucket";
+import Collection, { CollectionOptions } from "../../src/http/collection";
+import {
+  fakeServerResponse,
+  Stub,
+  expectAsyncError,
+  fakeHeaders,
+} from "./test_utils";
+import { PaginationResult } from "../../src/http/base";
+
+intern.getPlugin("chai").should();
+const { describe, it, beforeEach, afterEach } =
+  intern.getPlugin("interface.bdd");
+
+const FAKE_SERVER_URL = "http://fake-server/v1";
+
+/** @test {Collection} */
+describe("HTTP Collection", () => {
+  let sandbox: sinon.SinonSandbox, client: KintoClient, coll: Collection;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    client = new KintoClient(FAKE_SERVER_URL);
+    const bucket = new Bucket(client, "blog", { headers: { Foo: "Bar" } });
+    coll = new Collection(client, bucket, "posts", { headers: { Baz: "Qux" } });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function getBlogPostsCollection(options?: CollectionOptions) {
+    return new Bucket(client, "blog").collection("posts", options);
+  }
+
+  /** @test {Collection#getTotalRecords} */
+  describe("#getTotalRecords()", () => {
+    it("should execute expected request", async () => {
+      const executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ headers: fakeHeaders() }));
+
+      await getBlogPostsCollection().getTotalRecords();
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "HEAD",
+          path: "/buckets/blog/collections/posts/records",
+          headers: {},
+        },
+        { raw: true }
+      );
+    });
+
+    it("should resolve with the Total-Records header value", async () => {
+      sandbox.stub(client, "execute").returns(
+        Promise.resolve({
+          headers: {
+            get() {
+              return 42;
+            },
+          },
+        })
+      );
+
+      (await getBlogPostsCollection().getTotalRecords()).should.equal(42);
+    });
+  });
+
+  /** @test {Collection#getData} */
+  describe("#getData()", () => {
+    it("should execute expected request", async () => {
+      const executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ headers: fakeHeaders() }));
+
+      await getBlogPostsCollection().getData();
+
+      sinon.assert.calledWithMatch(executeStub, {
+        path: "/buckets/blog/collections/posts",
+        headers: {},
+      });
+    });
+
+    it("should resolve with response data", async () => {
+      const response = { data: { foo: "bar" } };
+      sandbox.stub(client, "execute").returns(Promise.resolve(response));
+
+      const data = (await getBlogPostsCollection().getData()) as {
+        foo: string;
+      };
+      data.should.deep.equal({
+        foo: "bar",
+      });
+    });
+
+    it("should pass query through", async () => {
+      const requestStub = sandbox.stub(client.http, "request").returns(
+        Promise.resolve({
+          headers: fakeHeaders(),
+          json: {},
+          status: 200,
+        })
+      );
+
+      await getBlogPostsCollection().getData({ query: { _expected: '"123"' } });
+
+      sinon.assert.calledWithMatch(
+        requestStub,
+        "http://fake-server/v1/buckets/blog/collections/posts?_expected=%22123%22",
+        {
+          headers: {},
+        }
+      );
+    });
+
+    it("supports _fields", async () => {
+      const requestStub = sandbox.stub(client.http, "request").returns(
+        Promise.resolve({
+          headers: fakeHeaders(),
+          json: {},
+          status: 200,
+        })
+      );
+
+      await getBlogPostsCollection().getData({ fields: ["a", "b"] });
+
+      sinon.assert.calledWithMatch(
+        requestStub,
+        "http://fake-server/v1/buckets/blog/collections/posts?_fields=a,b",
+        {
+          headers: {},
+        }
+      );
+    });
+  });
+
+  /** @test {Collection#getPermissions} */
+  describe("#getPermissions()", () => {
+    beforeEach(() => {
+      sandbox.stub(client, "execute").returns(
+        Promise.resolve({
+          data: {},
+          permissions: { write: ["fakeperms"] },
+        })
+      );
+    });
+
+    it("should retrieve permissions", async () => {
+      (await coll.getPermissions()).should.deep.equal({ write: ["fakeperms"] });
+    });
+  });
+
+  /** @test {Collection#setPermissions} */
+  describe("#setPermissions()", () => {
+    const fakePermissions = { read: [] as string[], write: [] as string[] };
+    let executeStub: Stub<typeof coll.client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({}));
+    });
+
+    it("should set permissions", () => {
+      coll.setPermissions(fakePermissions);
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/collections/posts",
+          headers: { Foo: "Bar", Baz: "Qux" },
+          body: {
+            data: undefined,
+            permissions: fakePermissions,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should handle the safe option", () => {
+      coll.setPermissions(fakePermissions, { safe: true, last_modified: 42 });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/collections/posts",
+          headers: { Foo: "Bar", Baz: "Qux", "If-Match": '"42"' },
+          body: {
+            data: undefined,
+            permissions: fakePermissions,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should resolve with json result", async () => {
+      (await coll.setPermissions(fakePermissions)).should.deep.equal({});
+    });
+  });
+
+  /** @test {Collection#addPermissions} */
+  describe("#addPermissions()", () => {
+    const fakePermissions = { read: [] as string[], write: [] as string[] };
+    let executeStub: Stub<typeof coll.client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({}));
+    });
+
+    it("should append permissions", () => {
+      coll.addPermissions(fakePermissions);
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PATCH",
+          path: "/buckets/blog/collections/posts",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+            "Content-Type": "application/json-patch+json",
+          },
+          body: [],
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should handle the safe option", () => {
+      coll.addPermissions(fakePermissions, { safe: true, last_modified: 42 });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PATCH",
+          path: "/buckets/blog/collections/posts",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+            "Content-Type": "application/json-patch+json",
+            "If-Match": `"42"`,
+          },
+          body: [],
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should resolve with json result", async () => {
+      (await coll.setPermissions(fakePermissions)).should.deep.equal({});
+    });
+  });
+
+  /** @test {Collection#removePermissions} */
+  describe("#removePermissions()", () => {
+    const fakePermissions = { read: [] as string[], write: [] as string[] };
+    let executeStub: Stub<typeof coll.client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({}));
+    });
+
+    it("should pop permissions", () => {
+      coll.setPermissions(fakePermissions);
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/collections/posts",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+          },
+          body: { data: undefined, permissions: fakePermissions },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should handle the safe option", () => {
+      coll.setPermissions(fakePermissions, { safe: true, last_modified: 42 });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/collections/posts",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+            "If-Match": `"42"`,
+          },
+          body: { data: undefined, permissions: fakePermissions },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should resolve with json result", async () => {
+      (await coll.setPermissions(fakePermissions)).should.deep.equal({});
+    });
+  });
+
+  /** @test {Collection#setData} */
+  describe("#setData()", () => {
+    let executeStub: Stub<typeof coll.client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: { foo: "bar" } }));
+    });
+
+    it("should set the data", () => {
+      coll.setData({ a: 1 });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/collections/posts",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+          },
+          body: { data: { a: 1 } },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should handle the safe option", () => {
+      coll.setData({ a: 1 }, { safe: true, last_modified: 42 });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/collections/posts",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+            "If-Match": `"42"`,
+          },
+          body: { data: { a: 1 } },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should handle the patch option", () => {
+      coll.setData({ a: 1 }, { patch: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PATCH",
+          path: "/buckets/blog/collections/posts",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+          },
+          body: { data: { a: 1 } },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should resolve with json result", async () => {
+      (await coll.setData({ a: 1 })).should.deep.equal({
+        data: { foo: "bar" },
+      });
+    });
+  });
+
+  /** @test {Collection#createRecord} */
+  describe("#createRecord()", () => {
+    const record = { title: "foo" };
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: 1 }));
+    });
+
+    it("should create the expected request", () => {
+      coll.createRecord(record);
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "POST",
+          path: "/buckets/blog/collections/posts/records",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+          },
+          body: { data: record },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should accept a safe option", () => {
+      coll.createRecord(record, { safe: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "POST",
+          path: "/buckets/blog/collections/posts/records",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+            "If-None-Match": "*",
+          },
+          body: { data: record },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should execute the expected request", () => {
+      return coll.createRecord(record).then(() => {
+        sinon.assert.calledWithMatch(executeStub, {
+          path: "/buckets/blog/collections/posts/records",
+          headers: {},
+        });
+      });
+    });
+
+    it("should resolve with response body", async () => {
+      (await coll.createRecord(record)).should.deep.equal({ data: 1 });
+    });
+  });
+
+  /** @test {Collection#updateRecord} */
+  describe("#updateRecord()", () => {
+    const record = { id: "2", title: "foo" };
+    let executeStub: Stub<typeof coll.client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: 1 }));
+    });
+
+    it("should throw if record is not an object", async () => {
+      await expectAsyncError(
+        () => coll.updateRecord(2 as any),
+        /record object is required/
+      );
+    });
+
+    it("should throw if id is missing", async () => {
+      await expectAsyncError(
+        () => coll.updateRecord({} as any),
+        /record id is required/
+      );
+    });
+
+    it("should create the expected request", () => {
+      coll.updateRecord(record);
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/collections/posts/records/2",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+          },
+          body: { data: record },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should accept a safe option", () => {
+      coll.updateRecord({ ...record, last_modified: 42 }, { safe: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PUT",
+          path: "/buckets/blog/collections/posts/records/2",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+            "If-Match": `"42"`,
+          },
+          body: { data: record },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should accept a patch option", () => {
+      coll.updateRecord(record, { patch: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "PATCH",
+          path: "/buckets/blog/collections/posts/records/2",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+          },
+          body: { data: record, permissions: undefined },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should resolve with response body", async () => {
+      (await coll.updateRecord(record)).should.deep.equal({ data: 1 });
+    });
+  });
+
+  /** @test {Collection#deleteRecord} */
+  describe("#deleteRecord()", () => {
+    // let deleteRequestStub: Stub<typeof requests.deleteRequest>;
+    let executeStub: Stub<typeof coll.client.execute>;
+
+    beforeEach(() => {
+      // deleteRequestStub = sandbox.stub(requests, "deleteRequest");
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: 1 }));
+    });
+
+    it("should throw if id is missing", async () => {
+      await expectAsyncError(
+        () => coll.deleteRecord({} as any),
+        /record id is required/
+      );
+    });
+
+    it("should delete a record", () => {
+      coll.deleteRecord("1");
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/blog/collections/posts/records/1",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+          },
+        },
+        { retry: 0 }
+      );
+    });
+
+    it("should throw if safe is true and last_modified isn't provided", async () => {
+      await expectAsyncError(
+        () => coll.deleteRecord("1", { safe: true }),
+        /Safe concurrency check requires a last_modified value./
+      );
+    });
+
+    it("should rely on the provided last_modified for the safe option", () => {
+      coll.deleteRecord({ id: "1", last_modified: 42 }, { safe: true });
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "DELETE",
+          path: "/buckets/blog/collections/posts/records/1",
+          headers: {
+            Foo: "Bar",
+            Baz: "Qux",
+            "If-Match": `"42"`,
+          },
+        },
+        { retry: 0 }
+      );
+    });
+  });
+
+  /** @test {Collection#deleteRecords} */
+  describe("#deleteRecords()", () => {
+    let executeStub: Stub<typeof coll.client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: {} }));
+    });
+
+    it("should delete all records", () => {
+      coll.deleteRecords();
+
+      sinon.assert.calledWithMatch(executeStub, {
+        method: "DELETE",
+        path: "/buckets/blog/collections/posts/records?_sort=-last_modified",
+        headers: {},
+      });
+    });
+
+    it("should accept a timestamp option", () => {
+      coll.deleteRecords({
+        filters: { since: 42 },
+      });
+
+      sinon.assert.calledWithMatch(executeStub, {
+        method: "DELETE",
+        path: "/buckets/blog/collections/posts/records?since=42&_sort=-last_modified",
+        headers: {},
+      });
+    });
+
+    it("should extend request headers with optional ones", () => {
+      coll["_headers"] = { Foo: "Bar" };
+      coll.deleteRecords({ headers: { Baz: "Qux" } });
+
+      sinon.assert.calledWithMatch(executeStub, {
+        method: "DELETE",
+        path: "/buckets/blog/collections/posts/records?_sort=-last_modified",
+        headers: { Foo: "Bar", Baz: "Qux" },
+      });
+    });
+
+    it("should support filters and fields", () => {
+      coll.deleteRecords({
+        filters: { a: "b" },
+        fields: ["c", "d"],
+      });
+
+      sinon.assert.calledWithMatch(executeStub, {
+        method: "DELETE",
+        path: "/buckets/blog/collections/posts/records?a=b&_sort=-last_modified&_fields=c,d",
+        headers: {},
+      });
+    });
+  });
+
+  /** @test {Collection#getRecord} */
+  describe("#getRecord()", () => {
+    let executeStub: Stub<typeof client.execute>;
+
+    beforeEach(() => {
+      executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ data: 1 }));
+    });
+
+    it("should execute expected request", () => {
+      coll.getRecord("1");
+
+      sinon.assert.calledWith(executeStub, {
+        path: "/buckets/blog/collections/posts/records/1",
+        headers: { Foo: "Bar", Baz: "Qux" },
+      });
+    });
+
+    it("should retrieve a record", async () => {
+      (await coll.getRecord("1")).should.deep.equal({ data: 1 });
+    });
+
+    it("should support query and fields", () => {
+      coll.getRecord("1", { query: { a: "b" }, fields: ["c", "d"] });
+
+      sinon.assert.calledWith(
+        executeStub,
+        {
+          headers: { Baz: "Qux", Foo: "Bar" },
+          path: "/buckets/blog/collections/posts/records/1",
+        },
+        { fields: ["c", "d"], query: { a: "b" }, retry: 0 }
+      );
+    });
+  });
+
+  /** @test {Collection#getRecordsTimestamp} */
+  describe("#getRecordsTimestamp()", () => {
+    it("should execute expected request", async () => {
+      const executeStub = sandbox
+        .stub(client, "execute")
+        .returns(Promise.resolve({ headers: fakeHeaders() }));
+
+      await getBlogPostsCollection().getRecordsTimestamp();
+
+      sinon.assert.calledWithMatch(
+        executeStub,
+        {
+          method: "HEAD",
+          path: "/buckets/blog/collections/posts/records",
+          headers: {},
+        },
+        { raw: true }
+      );
+    });
+
+    it("should resolve with the ETag header value", async () => {
+      const etag = '"42"';
+      sandbox.stub(client, "execute").returns(
+        Promise.resolve({
+          headers: {
+            get(value: string) {
+              return value == "ETag" ? etag : null;
+            },
+          },
+        })
+      );
+
+      (await getBlogPostsCollection().getRecordsTimestamp())!.should.deep.equal(
+        etag
+      );
+    });
+  });
+
+  /** @test {Collection#listRecords} */
+  describe("#listRecords()", () => {
+    const data: PaginationResult<{ id: string }> = {
+      last_modified: "",
+      data: [{ id: "a" }, { id: "b" }],
+      next: () => {
+        return Promise.resolve(
+          {} as unknown as PaginationResult<{
+            id: string;
+          }>
+        );
+      },
+      hasNextPage: false,
+      totalRecords: 2,
+    };
+    let paginatedListStub: Stub<typeof coll.client.paginatedList>;
+
+    beforeEach(() => {
+      paginatedListStub = sandbox
+        .stub(coll.client, "paginatedList")
+        .returns(Promise.resolve(data));
+    });
+
+    it("should execute expected request", () => {
+      coll.listRecords({ since: "42" });
+
+      sinon.assert.calledWithMatch(
+        paginatedListStub,
+        "/buckets/blog/collections/posts/records",
+        { since: "42" },
+        { headers: { Baz: "Qux", Foo: "Bar" }, retry: 0 }
+      );
+    });
+
+    it("should support passing custom headers", () => {
+      coll.listRecords({ headers: { "Another-Header": "Hello" } });
+
+      sinon.assert.calledWithMatch(
+        paginatedListStub,
+        "/buckets",
+        {},
+        { headers: { Foo: "Bar", Baz: "Qux", "Another-Header": "Hello" } }
+      );
+    });
+
+    it("should resolve with a result object", async () => {
+      (await coll.listRecords()).should.have.property("data").eql(data.data);
+    });
+
+    it("should support filters and fields", () => {
+      coll.listRecords({ filters: { a: "b" }, fields: ["c", "d"] });
+
+      sinon.assert.calledWithMatch(
+        paginatedListStub,
+        "/buckets/blog/collections/posts/records",
+        { filters: { a: "b" }, fields: ["c", "d"] }
+      );
+    });
+
+    describe("Retry", () => {
+      const response = { data: [{ id: 1, title: "art" }] };
+
+      beforeEach(() => {
+        sandbox.restore();
+        const fetchStub = sandbox.stub(client.http as any, "fetchFunc");
+        fetchStub
+          .onCall(0)
+          .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
+        fetchStub.onCall(1).returns(fakeServerResponse(200, response));
+      });
+
+      it("should retry the request if option is specified", async () => {
+        const { data } = await coll.listRecords({ retry: 1 });
+        data[0].should.have.property("title").eql("art");
+      });
+    });
+  });
+
+  /** @test {Collection#batch} */
+  describe("#batch()", () => {
+    it("should batch operations", () => {
+      const batchStub = sandbox.stub();
+      sandbox.stub(client, "batch").get(() => batchStub);
+      // @ts-ignore
+      const fn = (batch: any) => {};
+
+      coll.batch(fn);
+
+      sinon.assert.calledWith(batchStub, fn, {
+        bucket: "blog",
+        collection: "posts",
+        headers: { Foo: "Bar", Baz: "Qux" },
+        retry: 0,
+        safe: false,
+        aggregate: false,
+      });
+    });
+  });
+
+  /** @test {Collection#execute} */
+  describe("#execute()", () => {
+    it("should rely on client execute", () => {
+      const executeStub = sandbox.stub();
+      sandbox.stub(client, "execute").get(() => executeStub);
+      const req = { path: "/", headers: {} };
+
+      coll.execute(req);
+
+      sinon.assert.calledWith(executeStub, req);
+    });
+  });
+});

--- a/test/http/endpoint_test.ts
+++ b/test/http/endpoint_test.ts
@@ -1,0 +1,42 @@
+import endpoints from "../../src/http/endpoints";
+
+const { expect } = intern.getPlugin("chai");
+intern.getPlugin("chai").should();
+const { describe, it } = intern.getPlugin("interface.bdd");
+
+/** @test {endpoint} */
+describe("endpoint()", () => {
+  it("should provide a root endpoint", () => {
+    expect(endpoints.root()).eql("/");
+  });
+
+  it("should provide a batch endpoint", () => {
+    expect(endpoints.batch()).eql("/batch");
+  });
+
+  it("should provide a bucket endpoint", () => {
+    expect(endpoints.bucket("foo")).eql("/buckets/foo");
+  });
+
+  it("should provide a collection endpoint", () => {
+    expect(endpoints.collection("foo", "bar")).eql(
+      "/buckets/foo/collections/bar"
+    );
+  });
+
+  it("should provide a records endpoint", () => {
+    expect(endpoints.record("foo", "bar")).eql(
+      "/buckets/foo/collections/bar/records"
+    );
+  });
+
+  it("should provide a record endpoint", () => {
+    expect(endpoints.record("foo", "bar", "42")).eql(
+      "/buckets/foo/collections/bar/records/42"
+    );
+  });
+
+  it("should provide a permissions endpoint", () => {
+    expect(endpoints.permissions()).eql("/permissions");
+  });
+});

--- a/test/http/http_test.ts
+++ b/test/http/http_test.ts
@@ -1,0 +1,475 @@
+import sinon from "sinon";
+import { EventEmitter } from "events";
+import mitt from "mitt";
+import { fakeServerResponse, Stub, expectAsyncError } from "./test_utils";
+import HTTP from "../../src/http/http";
+import {
+  NetworkTimeoutError,
+  ServerResponse,
+  UnparseableResponseError,
+} from "../../src/http/errors";
+import { Emitter } from "../../src/http/types";
+
+const { expect } = intern.getPlugin("chai");
+intern.getPlugin("chai").should();
+const { describe, it, beforeEach, afterEach } =
+  intern.getPlugin("interface.bdd");
+
+/** @test {HTTP} */
+describe("HTTP class", () => {
+  function runSuite(label: string, emitter?: () => Emitter) {
+    describe(label, () => {
+      let sandbox: sinon.SinonSandbox, events: Emitter | undefined, http: HTTP;
+
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        events = emitter ? emitter() : undefined;
+        http = new HTTP(events, { timeout: 100 });
+      });
+
+      afterEach(() => sandbox.restore());
+
+      /** @test {HTTP#constructor} */
+      describe("#constructor", () => {
+        it("should expose a passed events instance", () => {
+          if (emitter) {
+            const events = emitter();
+            const http = new HTTP(events);
+            expect(http.events).to.eql(events);
+          }
+        });
+
+        it("should accept a requestMode option", () => {
+          expect(
+            new HTTP(events, {
+              requestMode: "no-cors",
+            }).requestMode
+          ).eql("no-cors");
+        });
+
+        it("should not complain if an events handler is not provided", () => {
+          expect(() => {
+            new HTTP();
+          }).not.to.Throw(Error, /No events handler provided/);
+        });
+      });
+
+      /** @test {HTTP#request} */
+      describe("#request()", () => {
+        describe("Request headers", () => {
+          let fetchStub: sinon.SinonStub;
+          beforeEach(() => {
+            fetchStub = sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(fakeServerResponse(200, {}, {}));
+          });
+
+          it("should set default headers", () => {
+            http.request("/");
+
+            expect(fetchStub.firstCall.args[1].headers).eql(
+              HTTP.DEFAULT_REQUEST_HEADERS
+            );
+          });
+
+          it("should merge custom headers with default ones", () => {
+            http.request("/", { headers: { Foo: "Bar" } });
+
+            expect(fetchStub.firstCall.args[1].headers.Foo).eql("Bar");
+          });
+
+          it("should drop custom content-type header for multipart body", () => {
+            http.request("/", {
+              headers: { "Content-Type": "application/foo" },
+              body: new FormData(),
+            });
+
+            expect(fetchStub.firstCall.args[1].headers["Content-Type"]).to.be
+              .undefined;
+          });
+        });
+
+        describe("Request CORS mode", () => {
+          let fetchStub: sinon.SinonStub;
+
+          it("should use default CORS mode", () => {
+            const http = new HTTP(events);
+            fetchStub = sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(fakeServerResponse(200, {}, {}));
+
+            http.request("/");
+
+            expect(fetchStub.firstCall.args[1].mode).eql("cors");
+          });
+
+          it("should use configured custom CORS mode", () => {
+            const http = new HTTP(events, { requestMode: "no-cors" });
+            fetchStub = sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(fakeServerResponse(200, {}, {}));
+
+            http.request("/");
+
+            expect(fetchStub.firstCall.args[1].mode).eql("no-cors");
+          });
+        });
+
+        describe("Succesful request", () => {
+          beforeEach(() => {
+            sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(fakeServerResponse(200, { a: 1 }, { b: 2 }));
+          });
+
+          it("should resolve with HTTP status", async () => {
+            const { status } = await http.request("/");
+            status.should.equal(200);
+          });
+
+          it("should resolve with JSON body", async () => {
+            const { json } = await http.request("/");
+            (json as { a: number }).should.deep.equal({ a: 1 });
+          });
+
+          it("should resolve with headers", async () => {
+            const { headers } = await http.request("/");
+            headers.get("b")!.should.equal("2");
+          });
+        });
+
+        describe("Request timeout", () => {
+          beforeEach(() => {
+            sandbox.stub(http as any, "fetchFunc").returns(
+              new Promise((resolve) => {
+                setTimeout(resolve, 20000);
+              })
+            );
+          });
+
+          it("should timeout the request", async () => {
+            await expectAsyncError(
+              () => http.request("/"),
+              undefined,
+              NetworkTimeoutError
+            );
+          });
+
+          it("should show request properties in error", async () => {
+            await expectAsyncError(
+              () =>
+                http.request("/", {
+                  mode: "cors",
+                  headers: {
+                    Authorization: "XXX",
+                    "User-agent": "mocha-test",
+                  },
+                }),
+              'Timeout while trying to access / with {"mode":"cors","headers":{"accept":"application/json","authorization":"**** (suppressed)","content-type":"application/json","user-agent":"mocha-test"}}'
+            );
+          });
+        });
+
+        describe("No content response", () => {
+          it("should resolve with null JSON if Content-Length header is missing", async () => {
+            sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(fakeServerResponse(200, null, {}));
+
+            const { json } = await http.request("/");
+            expect(json).to.be.null;
+          });
+        });
+
+        describe("Malformed JSON response", () => {
+          it("should reject with an appropriate message", async () => {
+            sandbox.stub(http as any, "fetchFunc").returns(
+              Promise.resolve({
+                status: 200,
+                headers: {
+                  get(name: string) {
+                    if (name !== "Alert") {
+                      return "fake";
+                    }
+                  },
+                },
+                text() {
+                  return Promise.resolve("an example of invalid JSON");
+                },
+              })
+            );
+
+            await expectAsyncError(
+              () => http.request("/"),
+              /Response from server unparseable/,
+              UnparseableResponseError
+            );
+          });
+        });
+
+        describe("Business error responses", () => {
+          it("should reject on status code > 400", async () => {
+            sandbox.stub(http as any, "fetchFunc").returns(
+              fakeServerResponse(400, {
+                code: 400,
+                details: [
+                  {
+                    description: "data is missing",
+                    location: "body",
+                    name: "data",
+                  },
+                ],
+                errno: 107,
+                error: "Invalid parameters",
+                message: "data is missing",
+              })
+            );
+
+            await expectAsyncError(
+              () => http.request("/"),
+              /HTTP 400 Invalid parameters: Invalid request parameter \(data is missing\)/,
+              ServerResponse
+            );
+          });
+
+          it("should expose JSON error bodies", async () => {
+            const errorBody = {
+              code: 400,
+              details: [
+                {
+                  description: "data is missing",
+                  location: "body",
+                  name: "data",
+                },
+              ],
+              errno: 107,
+              error: "Invalid parameters",
+              message: "data is missing",
+            };
+            sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(fakeServerResponse(400, errorBody));
+
+            const error = await expectAsyncError(
+              () => http.request("/"),
+              undefined,
+              ServerResponse
+            );
+            error.should.have.deep.property("data", errorBody);
+          });
+
+          it("should reject on status code > 400 even with empty body", async () => {
+            sandbox.stub(http as any, "fetchFunc").resolves({
+              status: 400,
+              statusText: "Cake Is A Lie",
+              headers: {
+                get(name: string) {
+                  if (name === "Content-Length") {
+                    return 0;
+                  }
+                },
+              },
+              text() {
+                return Promise.resolve("");
+              },
+            });
+
+            await expectAsyncError(
+              () => http.request("/"),
+              /HTTP 400 Cake Is A Lie$/,
+              ServerResponse
+            );
+          });
+        });
+
+        describe("Deprecation header", () => {
+          const eolObject = {
+            code: "soft-eol",
+            url: "http://eos-url",
+            message: "This service will soon be decommissioned",
+          };
+
+          let consoleWarnStub: Stub<typeof console.warn>;
+          let eventsEmitStub: Stub<Emitter["emit"]> | null;
+
+          beforeEach(() => {
+            consoleWarnStub = sandbox.stub(console, "warn");
+            eventsEmitStub = events ? sandbox.stub(events, "emit") : null;
+          });
+
+          it("should handle deprecation header", async () => {
+            sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(
+                fakeServerResponse(
+                  200,
+                  {},
+                  { Alert: JSON.stringify(eolObject) }
+                )
+              );
+
+            await http.request("/");
+            sinon.assert.calledOnce(consoleWarnStub);
+            sinon.assert.calledWithExactly(
+              consoleWarnStub,
+              eolObject.message,
+              eolObject.url
+            );
+          });
+
+          it("should handle deprecation header parse error", async () => {
+            sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(fakeServerResponse(200, {}, { Alert: "dafuq" }));
+
+            await http.request("/");
+            sinon.assert.calledOnce(consoleWarnStub);
+            sinon.assert.calledWithExactly(
+              consoleWarnStub,
+              "Unable to parse Alert header message",
+              "dafuq"
+            );
+          });
+
+          it("should emit a deprecated event on Alert header", async () => {
+            sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(
+                fakeServerResponse(
+                  200,
+                  {},
+                  { Alert: JSON.stringify(eolObject) }
+                )
+              );
+
+            await http.request("/");
+            if (events && eventsEmitStub) {
+              expect(eventsEmitStub.firstCall.args[0]).eql("deprecated");
+              expect(eventsEmitStub.firstCall.args[1]).eql(eolObject);
+            }
+          });
+        });
+
+        describe("Backoff header handling", () => {
+          let eventsEmitStub: Stub<Emitter["emit"]> | null;
+          beforeEach(() => {
+            // Make Date#getTime always returning 1000000, for predictability
+            sandbox.stub(Date.prototype, "getTime").returns(1000 * 1000);
+            eventsEmitStub = events ? sandbox.stub(events, "emit") : null;
+          });
+
+          it("should emit a backoff event on set Backoff header", async () => {
+            sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(fakeServerResponse(200, {}, { Backoff: "1000" }));
+
+            await http.request("/");
+            if (events && eventsEmitStub) {
+              expect(eventsEmitStub.firstCall.args[0]).eql("backoff");
+              expect(eventsEmitStub.firstCall.args[1]).eql(2000000);
+            }
+          });
+
+          it("should emit a backoff event even on error responses", async () => {
+            sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(fakeServerResponse(503, {}, { Backoff: "1000" }));
+
+            try {
+              await http.request("/");
+            } catch (err) {}
+            if (events && eventsEmitStub) {
+              expect(eventsEmitStub.firstCall.args[0]).eql("backoff");
+              expect(eventsEmitStub.firstCall.args[1]).eql(2000000);
+            }
+          });
+
+          it("should emit a backoff event on missing Backoff header", async () => {
+            sandbox
+              .stub(http as any, "fetchFunc")
+              .returns(fakeServerResponse(200, {}, {}));
+
+            await http.request("/");
+            if (events && eventsEmitStub) {
+              expect(eventsEmitStub.firstCall.args[0]).eql("backoff");
+              expect(eventsEmitStub.firstCall.args[1]).eql(0);
+            }
+          });
+        });
+
+        describe("Retry-After header handling", () => {
+          let eventsEmitStub: Stub<Emitter["emit"]> | null;
+          describe("Event", () => {
+            beforeEach(() => {
+              // Make Date#getTime always returning 1000000, for predictability
+              sandbox.stub(Date.prototype, "getTime").returns(1000 * 1000);
+              eventsEmitStub = events ? sandbox.stub(events, "emit") : null;
+            });
+
+            it("should emit a retry-after event when Retry-After is set", async () => {
+              sandbox
+                .stub(http as any, "fetchFunc")
+                .returns(
+                  fakeServerResponse(200, {}, { "Retry-After": "1000" })
+                );
+
+              await http.request("/", {}, { retry: 0 });
+              if (events && eventsEmitStub) {
+                expect(eventsEmitStub.lastCall.args[0]).eql("retry-after");
+                expect(eventsEmitStub.lastCall.args[1]).eql(2000000);
+              }
+            });
+          });
+
+          describe("Retry loop", () => {
+            let fetch: sinon.SinonStub;
+
+            beforeEach(() => {
+              fetch = sandbox.stub(http as any, "fetchFunc");
+            });
+
+            it("should not retry the request by default", async () => {
+              fetch.returns(
+                fakeServerResponse(503, {}, { "Retry-After": "1" })
+              );
+
+              await expectAsyncError(() => http.request("/"), /HTTP 503/);
+            });
+
+            it("should retry the request if specified", async () => {
+              const success = { success: true };
+              fetch
+                .onCall(0)
+                .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
+              fetch.onCall(1).returns(fakeServerResponse(200, success));
+
+              const { json } = await http.request("/", {}, { retry: 1 });
+              (json as { success: boolean }).should.deep.equal(success);
+            });
+
+            it("should error when retries are exhausted", async () => {
+              fetch
+                .onCall(0)
+                .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
+              fetch
+                .onCall(1)
+                .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
+              fetch
+                .onCall(2)
+                .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
+
+              await expectAsyncError(
+                () => http.request("/", {}, { retry: 2 }),
+                /HTTP 503/
+              );
+            });
+          });
+        });
+      });
+    });
+  }
+
+  runSuite("with EventEmitter", () => new EventEmitter());
+  runSuite("with mitt", () => mitt());
+  runSuite("without EventEmitter");
+});

--- a/test/http/integration_test.ts
+++ b/test/http/integration_test.ts
@@ -1,0 +1,2033 @@
+import sinon from "sinon";
+
+import Api from "../../src/http";
+import KintoClientBase, { KintoClientOptions } from "../../src/http/base";
+import { EventEmitter } from "events";
+import KintoServer from "kinto-node-test-server";
+import { delayedPromise, Stub, btoa, expectAsyncError } from "./test_utils";
+import Bucket from "../../src/http/bucket";
+import Collection from "../../src/http/collection";
+import {
+  PermissionData,
+  OperationResponse,
+  KintoObject,
+  Attachment,
+  KintoResponse,
+  Group,
+} from "../../src/http/types";
+import { AggregateResponse } from "../../src/http/batch";
+
+interface TitleRecord extends KintoObject {
+  title: string;
+}
+
+const { expect } = intern.getPlugin("chai");
+intern.getPlugin("chai").should();
+const { describe, it, before, after, beforeEach, afterEach } =
+  intern.getPlugin("interface.bdd");
+
+const skipLocalServer = !!process.env.TEST_KINTO_SERVER;
+const TEST_KINTO_SERVER =
+  process.env.TEST_KINTO_SERVER || "http://0.0.0.0:8888/v1";
+const KINTO_PROXY_SERVER = process.env.KINTO_PROXY_SERVER || TEST_KINTO_SERVER;
+
+async function startServer(
+  server: KintoServer,
+  options: { [key: string]: string } = {}
+) {
+  if (!skipLocalServer) {
+    await server.start(options);
+  }
+}
+
+async function stopServer(server: KintoServer) {
+  if (!skipLocalServer) {
+    await server.stop();
+  }
+}
+
+describe("HTTP Integration tests", function (__test) {
+  let sandbox: sinon.SinonSandbox, server: KintoServer, api: Api;
+
+  // Disabling test timeouts until pserve gets decent startup time.
+  __test.timeout = 0;
+
+  before(async () => {
+    if (skipLocalServer) {
+      return;
+    }
+    let kintoConfigPath = __dirname + "/kinto.ini";
+    if (process.env.SERVER && process.env.SERVER !== "master") {
+      kintoConfigPath = `${__dirname}/kinto-${process.env.SERVER}.ini`;
+    }
+    server = new KintoServer(KINTO_PROXY_SERVER, {
+      maxAttempts: 200,
+      kintoConfigPath,
+    });
+    await server.loadConfig(kintoConfigPath);
+  });
+
+  after(() => {
+    if (skipLocalServer) {
+      return;
+    }
+    const logLines = server.logs.toString().split("\n");
+    const serverDidCrash = logLines.some((l) => l.startsWith("Traceback"));
+    if (serverDidCrash) {
+      // Server errors have been encountered, raise to break the build
+      const trace = logLines.join("\n");
+      throw new Error(
+        `Kinto server crashed while running the test suite.\n\n${trace}`
+      );
+    }
+    return server.killAll();
+  });
+
+  function createClient(options: Partial<KintoClientOptions> = {}) {
+    return new Api(TEST_KINTO_SERVER, options);
+  }
+
+  beforeEach((__test) => {
+    __test.timeout = 12500;
+
+    sandbox = sinon.createSandbox();
+    const events = new EventEmitter();
+    api = createClient({
+      events,
+      headers: { Authorization: "Basic " + btoa("user:pass") },
+    });
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe("Default server configuration", () => {
+    before(async () => {
+      await startServer(server);
+    });
+
+    after(async () => {
+      await stopServer(server);
+    });
+
+    beforeEach(async () => {
+      await server.flush();
+    });
+
+    // XXX move this to batch tests
+    describe("new batch", () => {
+      it("should support root batch", async function () {
+        await api.batch((batch: KintoClientBase) => {
+          const bucket = batch.bucket("default");
+          bucket.createCollection("posts");
+          const coll = bucket.collection("posts");
+          coll.createRecord({ a: 1 });
+          coll.createRecord({ a: 2 });
+        });
+        const res = await api
+          .bucket("default")
+          .collection("posts")
+          .listRecords();
+        res.data.should.have.lengthOf(2);
+      });
+
+      it("should support bucket batch", async function () {
+        await api.bucket("default").batch((batch) => {
+          batch.createCollection("posts");
+          const coll = batch.collection("posts");
+          coll.createRecord({ a: 1 });
+          coll.createRecord({ a: 2 });
+        });
+        const res = await api
+          .bucket("default")
+          .collection("posts")
+          .listRecords();
+        res.data.should.have.lengthOf(2);
+      });
+    });
+
+    describe("Server properties", () => {
+      it("should retrieve server settings", async () => {
+        (await api.fetchServerSettings()).should.have
+          .property("batch_max_requests")
+          .eql(25);
+      });
+
+      it("should retrieve server capabilities", async () => {
+        const capabilities = await api.fetchServerCapabilities();
+        expect(capabilities).to.be.an("object");
+        // Kinto protocol 1.4 exposes capability descriptions
+        Object.keys(capabilities).forEach((capability) => {
+          const capabilityObj = capabilities[capability];
+          expect(capabilityObj).to.include.keys("url", "description");
+        });
+      });
+
+      it("should retrieve user information", async () => {
+        const user = await api.fetchUser();
+        expect(user!.id).to.match(/^basicauth:/);
+        expect(user!.bucket).to.have.lengthOf(36);
+      });
+
+      it("should retrieve current API version", async () => {
+        (await api.fetchHTTPApiVersion()).should.match(/^\d\.\d+$/);
+      });
+    });
+
+    describe("#createBucket", () => {
+      let result: KintoResponse;
+
+      describe("Default options", () => {
+        describe("Autogenerated id", () => {
+          beforeEach(async () => {
+            const res = await api.createBucket(null);
+            return (result = res as KintoResponse);
+          });
+
+          it("should create a bucket", () => {
+            expect(result)
+              .to.have.property("data")
+              .to.have.property("id")
+              .to.be.a("string");
+          });
+        });
+
+        describe("Custom id", () => {
+          beforeEach(async () => {
+            const res = await api.createBucket("foo");
+            return (result = res as KintoResponse);
+          });
+
+          it("should create a bucket with the passed id", () => {
+            expect(result)
+              .to.have.property("data")
+              .to.have.property("id")
+              .eql("foo");
+          });
+
+          it("should create a bucket having a list of write permissions", () => {
+            expect(result)
+              .to.have.property("permissions")
+              .to.have.property("write")
+              .to.be.a("array");
+          });
+
+          describe("data option", () => {
+            it("should create bucket data", async () => {
+              (await api.createBucket("foo", { data: { a: 1 } })).should.have
+                .property("data")
+                .to.have.property("a")
+                .eql(1);
+            });
+          });
+
+          describe("Safe option", () => {
+            it("should not override existing bucket", async () => {
+              await expectAsyncError(
+                () => api.createBucket("foo", { safe: true }),
+                /412 Precondition Failed/
+              );
+            });
+          });
+        });
+      });
+
+      describe("permissions option", () => {
+        beforeEach(async () => {
+          const res = await api.createBucket("foo", {
+            permissions: { read: ["github:n1k0"] },
+          });
+          return (result = res as KintoResponse);
+        });
+
+        it("should create a bucket having a list of write permissions", () => {
+          expect(result)
+            .to.have.property("permissions")
+            .to.have.property("read")
+            .to.eql(["github:n1k0"]);
+        });
+      });
+    });
+
+    describe("#deleteBucket()", () => {
+      let last_modified: number;
+
+      beforeEach(async () => {
+        const res = await api.createBucket("foo");
+        return (last_modified = (res as KintoResponse).data.last_modified);
+      });
+
+      it("should delete a bucket", async () => {
+        await api.deleteBucket("foo");
+        const { data } = await api.listBuckets();
+        data.map((bucket) => bucket.id).should.not.include("foo");
+      });
+
+      describe("Safe option", () => {
+        it("should raise a conflict error when resource has changed", async () => {
+          await expectAsyncError(
+            () =>
+              api.deleteBucket("foo", {
+                last_modified: last_modified - 1000,
+                safe: true,
+              }),
+            /412 Precondition Failed/
+          );
+        });
+      });
+    });
+
+    describe("#deleteBuckets()", () => {
+      beforeEach(() => {
+        return api.batch((batch: KintoClientBase) => {
+          batch.createBucket("b1");
+          batch.createBucket("b2");
+        });
+      });
+
+      it("should delete all buckets", async () => {
+        await api.deleteBuckets();
+        await delayedPromise(50);
+        const { data } = await api.listBuckets();
+        data.should.deep.equal([]);
+      });
+    });
+
+    describe("#listPermissions", () => {
+      // FIXME: this feature was introduced between 8.2 and 8.3, and
+      // these tests run against master as well as an older Kinto
+      // version (see .travis.yml). If we ever bump the older version
+      // up to one where it also has bucket:create, we can clean this
+      // up.
+      const shouldHaveCreatePermission =
+        // People developing don't always set SERVER. Let's assume
+        // that means "master".
+        !process.env.SERVER ||
+        // "master" is greater than 8.3 but let's just be explicit here.
+        process.env.SERVER == "master" ||
+        process.env.SERVER > "8.3" ||
+        (process.env.SERVER > "8.2" && process.env.SERVER.includes("dev"));
+      describe("Single page of permissions", () => {
+        beforeEach(() => {
+          return api.batch((batch: KintoClientBase) => {
+            batch.createBucket("b1");
+            batch.bucket("b1").createCollection("c1");
+          });
+        });
+
+        it("should retrieve the list of permissions", async () => {
+          let { data } = await api.listPermissions();
+          if (shouldHaveCreatePermission) {
+            // One element is for the root element which has
+            // `bucket:create` as well as `account:create`. Remove
+            // it.
+            const isBucketCreate = (p_1: PermissionData) =>
+              p_1.permissions.includes("bucket:create");
+            const bucketCreate = data.filter(isBucketCreate);
+            expect(bucketCreate.length).eql(1);
+            data = data.filter((p_2) => !isBucketCreate(p_2));
+          }
+          expect(data).to.have.lengthOf(2);
+          expect(data.map((p_3) => p_3.id).sort()).eql(["b1", "c1"]);
+        });
+      });
+
+      describe("Paginated list of permissions", () => {
+        beforeEach(() => {
+          return api.batch((batch: KintoClientBase) => {
+            for (let i = 1; i <= 15; i++) {
+              batch.createBucket("b" + i);
+            }
+          });
+        });
+
+        it("should retrieve the list of permissions", async () => {
+          const results = await api.listPermissions({ pages: Infinity });
+          let expectedRecords = 15;
+          if (shouldHaveCreatePermission) {
+            expectedRecords++;
+          }
+          expect(results.data).to.have.lengthOf(expectedRecords);
+        });
+      });
+    });
+
+    describe("#listBuckets", () => {
+      beforeEach(() => {
+        return api.batch((batch: KintoClientBase) => {
+          batch.createBucket("b1", { data: { size: 24 } });
+          batch.createBucket("b2", { data: { size: 13 } });
+          batch.createBucket("b3", { data: { size: 38 } });
+          batch.createBucket("b4", { data: { size: -4 } });
+        });
+      });
+
+      it("should retrieve the list of buckets", async () => {
+        const { data } = await api.listBuckets();
+        data
+          .map((bucket) => bucket.id)
+          .sort()
+          .should.deep.equal(["b1", "b2", "b3", "b4"]);
+      });
+
+      it("should order buckets by field", async () => {
+        const { data } = await api.listBuckets({ sort: "-size" });
+        data
+          .map((bucket) => bucket.id)
+          .should.deep.equal(["b3", "b1", "b2", "b4"]);
+      });
+
+      describe("Filtering", () => {
+        it("should filter buckets", async () => {
+          const { data } = await api.listBuckets({
+            sort: "size",
+            filters: { min_size: 20 },
+          });
+          data.map((bucket) => bucket.id).should.deep.equal(["b1", "b3"]);
+        });
+
+        it("should resolve with buckets last_modified value", async () => {
+          (await api.listBuckets()).should.have
+            .property("last_modified")
+            .to.be.a("string");
+        });
+
+        it("should retrieve only buckets after provided timestamp", async () => {
+          const timestamp = (await api.listBuckets()).last_modified!;
+          await api.createBucket("b5");
+          (await api.listBuckets({ since: timestamp })).should.have
+            .property("data")
+            .to.have.lengthOf(1);
+        });
+      });
+
+      describe("Pagination", () => {
+        it("should not paginate by default", async () => {
+          const { data } = await api.listBuckets();
+          data
+            .map((bucket) => bucket.id)
+            .should.deep.equal(["b4", "b3", "b2", "b1"]);
+        });
+
+        it("should paginate by chunks", async () => {
+          const { data } = await api.listBuckets({ limit: 2 });
+          data.map((bucket) => bucket.id).should.deep.equal(["b4", "b3"]);
+        });
+
+        it("should expose a hasNextPage boolean prop", async () => {
+          (await api.listBuckets({ limit: 2 })).should.have
+            .property("hasNextPage")
+            .eql(true);
+        });
+
+        it("should provide a next method to load next page", async () => {
+          const res = await api.listBuckets({ limit: 2 });
+          const { data } = await res.next();
+          data.map((bucket) => bucket.id).should.deep.equal(["b2", "b1"]);
+        });
+      });
+    });
+
+    describe("#createAccount", () => {
+      it("should create an account", async () => {
+        await api.createAccount("testuser", "testpw");
+        const user = await createClient({
+          headers: { Authorization: "Basic " + btoa("testuser:testpw") },
+        }).fetchUser();
+        expect(user!.id).equal("account:testuser");
+      });
+    });
+
+    describe("#batch", () => {
+      describe("No chunked requests", () => {
+        it("should allow batching operations", async () => {
+          await api.batch((batch: KintoClientBase) => {
+            batch.createBucket("custom");
+            const bucket = batch.bucket("custom");
+            bucket.createCollection("blog");
+            const coll = bucket.collection("blog");
+            coll.createRecord({ title: "art1" });
+            coll.createRecord({ title: "art2" });
+          });
+
+          const { data } = await api
+            .bucket("custom")
+            .collection("blog")
+            .listRecords<TitleRecord>();
+          data
+            .map((record) => record.title)
+            .should.deep.equal(["art2", "art1"]);
+        });
+      });
+
+      describe("Chunked requests", () => {
+        it("should allow batching by chunks", async () => {
+          // Note: kinto server configuration has kinto.paginated_by set to 10.
+          await api.batch((batch: KintoClientBase) => {
+            batch.createBucket("custom");
+            const bucket = batch.bucket("custom");
+            bucket.createCollection("blog");
+            const coll = bucket.collection("blog");
+            for (let i = 1; i <= 27; i++) {
+              coll.createRecord({ title: "art" + i });
+            }
+          });
+
+          (
+            await api.bucket("custom").collection("blog").listRecords()
+          ).should.have
+            .property("data")
+            .to.have.lengthOf(10);
+        });
+      });
+
+      describe("aggregate option", () => {
+        describe("Succesful publication", () => {
+          describe("No chunking", () => {
+            let results: AggregateResponse;
+
+            beforeEach(async () => {
+              const _results = await api.batch(
+                (batch: KintoClientBase) => {
+                  batch.createBucket("custom");
+                  const bucket = batch.bucket("custom");
+                  bucket.createCollection("blog");
+                  const coll = bucket.collection("blog");
+                  coll.createRecord({ title: "art1" });
+                  coll.createRecord({ title: "art2" });
+                },
+                { aggregate: true }
+              );
+              return (results = _results as AggregateResponse);
+            });
+
+            it("should return an aggregated result object", () => {
+              expect(results).to.include.keys([
+                "errors",
+                "conflicts",
+                "published",
+                "skipped",
+              ]);
+            });
+
+            it("should contain the list of succesful publications", () => {
+              expect(
+                results.published.map((body) => body.data)
+              ).to.have.lengthOf(4);
+            });
+          });
+
+          describe("Chunked response", () => {
+            let results: AggregateResponse;
+
+            beforeEach(async () => {
+              const _results = await api
+                .bucket("default")
+                .collection("blog")
+                .batch(
+                  (batch) => {
+                    for (let i = 1; i <= 26; i++) {
+                      batch.createRecord({ title: "art" + i });
+                    }
+                  },
+                  { aggregate: true }
+                );
+              return (results = _results as AggregateResponse);
+            });
+
+            it("should return an aggregated result object", () => {
+              expect(results).to.include.keys([
+                "errors",
+                "conflicts",
+                "published",
+                "skipped",
+              ]);
+            });
+
+            it("should contain the list of succesful publications", () => {
+              expect(results.published).to.have.lengthOf(26);
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe("Backed off server", () => {
+    const backoffSeconds = 10;
+
+    before(async () => {
+      await startServer(server, { KINTO_BACKOFF: backoffSeconds.toString() });
+    });
+
+    after(async () => {
+      await stopServer(server);
+    });
+
+    beforeEach(async () => {
+      await server.flush();
+    });
+
+    it("should appropriately populate the backoff property", async () => {
+      // Issuing a first api call to retrieve backoff information
+      await api.listBuckets();
+      return expect(Math.round(api.backoff / 1000)).eql(backoffSeconds);
+    });
+  });
+
+  describe("Deprecated protocol version", () => {
+    beforeEach(async () => {
+      await server.flush();
+    });
+
+    describe("Soft EOL", () => {
+      let consoleWarnStub: Stub<typeof console.warn>;
+
+      before(() => {
+        const tomorrow = new Date(new Date().getTime() + 86400000)
+          .toJSON()
+          .slice(0, 10);
+        return startServer(server, {
+          KINTO_EOS: `"${tomorrow}"`,
+          KINTO_EOS_URL: "http://www.perdu.com",
+          KINTO_EOS_MESSAGE: "Boom",
+        });
+      });
+
+      after(async () => {
+        await stopServer(server);
+      });
+
+      beforeEach(() => {
+        consoleWarnStub = sandbox.stub(console, "warn");
+      });
+
+      it("should warn when the server sends a deprecation Alert header", async () => {
+        await api.fetchServerSettings();
+        sinon.assert.calledWithExactly(
+          consoleWarnStub,
+          "Boom",
+          "http://www.perdu.com"
+        );
+      });
+    });
+
+    describe("Hard EOL", () => {
+      before(() => {
+        const lastWeek = new Date(new Date().getTime() - 7 * 86400000)
+          .toJSON()
+          .slice(0, 10);
+        return startServer(server, {
+          KINTO_EOS: `"${lastWeek}"`,
+          KINTO_EOS_URL: "http://www.perdu.com",
+          KINTO_EOS_MESSAGE: "Boom",
+        });
+      });
+
+      after(() => stopServer(server));
+
+      beforeEach(() => {
+        sandbox.stub(console, "warn");
+      });
+
+      it("should reject with a 410 Gone when hard EOL is received", async () => {
+        // As of Kinto 13.6.2, EOL responses don't contain CORS headers, so we
+        // can only assert than an error is throw.
+        await expectAsyncError(
+          () => api.fetchServerSettings()
+          // /HTTP 410 Gone: Service deprecated/,
+          // ServerResponse
+        );
+      });
+    });
+  });
+
+  describe("Limited pagination", () => {
+    before(() => {
+      return startServer(server, { KINTO_PAGINATE_BY: "1" });
+    });
+
+    after(() => stopServer(server));
+
+    beforeEach(() => server.flush());
+
+    describe("Limited configured server pagination", () => {
+      let collection: Collection;
+
+      beforeEach(() => {
+        collection = api.bucket("default").collection("posts");
+        return collection.batch((batch) => {
+          batch.createRecord({ n: 1 });
+          batch.createRecord({ n: 2 });
+        });
+      });
+
+      it("should fetch one results page", async () => {
+        const { data } = await collection.listRecords();
+        data.map((record) => record.id).should.have.lengthOf(1);
+      });
+
+      it("should fetch all available pages", async () => {
+        const { data } = await collection.listRecords({ pages: Infinity });
+        data.map((record) => record.id).should.have.lengthOf(2);
+      });
+    });
+  });
+
+  describe("Chainable API", () => {
+    before(() => startServer(server));
+
+    after(() => stopServer(server));
+
+    beforeEach(() => server.flush());
+
+    describe(".bucket()", () => {
+      let bucket: Bucket;
+
+      beforeEach(async () => {
+        bucket = api.bucket("custom");
+        await api.createBucket("custom");
+        return await bucket.batch((batch) => {
+          batch.createCollection("c1", { data: { size: 24 } });
+          batch.createCollection("c2", { data: { size: 13 } });
+          batch.createCollection("c3", { data: { size: 38 } });
+          batch.createCollection("c4", { data: { size: -4 } });
+          batch.createGroup("g1", [], { data: { size: 24 } });
+          batch.createGroup("g2", [], { data: { size: 13 } });
+          batch.createGroup("g3", [], { data: { size: 38 } });
+          batch.createGroup("g4", [], { data: { size: -4 } });
+        });
+      });
+
+      describe(".getData()", () => {
+        let result: KintoObject;
+
+        beforeEach(async () => {
+          const res = await bucket.getData<KintoObject>();
+          return (result = res);
+        });
+
+        it("should retrieve the bucket identifier", () => {
+          expect(result).to.have.property("id").eql("custom");
+        });
+
+        it("should retrieve bucket last_modified value", () => {
+          expect(result).to.have.property("last_modified").to.be.gt(1);
+        });
+      });
+
+      describe(".setData()", () => {
+        beforeEach(() => {
+          return bucket.setPermissions({ read: ["github:jon"] });
+        });
+
+        it("should post data to the bucket", async () => {
+          const res = await bucket.setData({ a: 1 });
+          expect((res as KintoResponse).data.a).eql(1);
+          expect((res as KintoResponse).permissions.read).to.include(
+            "github:jon"
+          );
+        });
+
+        it("should patch existing data for the bucket", async () => {
+          await bucket.setData({ a: 1 });
+          const res = await bucket.setData({ b: 2 }, { patch: true });
+          expect((res as KintoResponse).data.a).eql(1);
+          expect((res as KintoResponse).data.b).eql(2);
+          expect((res as KintoResponse).permissions.read).to.include(
+            "github:jon"
+          );
+        });
+
+        it("should post data to the default bucket", async () => {
+          const { data } = await api.bucket("default").setData({ a: 1 });
+          data.should.have.property("a").eql(1);
+        });
+      });
+
+      describe(".getPermissions()", () => {
+        it("should retrieve bucket permissions", async () => {
+          (await bucket.getPermissions()).should.have
+            .property("write")
+            .to.have.lengthOf(1);
+        });
+      });
+
+      describe(".setPermissions()", () => {
+        beforeEach(() => {
+          return bucket.setData({ a: 1 });
+        });
+
+        it("should set bucket permissions", async () => {
+          const res = await bucket.setPermissions({ read: ["github:n1k0"] });
+          expect((res as KintoResponse).data.a).eql(1);
+          expect((res as KintoResponse).permissions.read).eql(["github:n1k0"]);
+        });
+
+        describe("Safe option", () => {
+          it("should check for concurrency", async () => {
+            await expectAsyncError(
+              () =>
+                bucket.setPermissions(
+                  { read: ["github:n1k0"] },
+                  { safe: true, last_modified: 1 }
+                ),
+              /412 Precondition Failed/
+            );
+          });
+        });
+      });
+
+      describe(".addPermissions()", () => {
+        beforeEach(async () => {
+          await bucket.setPermissions({ read: ["github:n1k0"] });
+          return await bucket.setData({ a: 1 });
+        });
+
+        it("should append bucket permissions", async () => {
+          const res = await bucket.addPermissions({ read: ["accounts:gabi"] });
+          expect((res as KintoResponse).data.a).eql(1);
+          expect((res as KintoResponse).permissions.read!.sort()).eql([
+            "accounts:gabi",
+            "github:n1k0",
+          ]);
+        });
+      });
+
+      describe(".removePermissions()", () => {
+        beforeEach(async () => {
+          await bucket.setPermissions({ read: ["github:n1k0"] });
+          return await bucket.setData({ a: 1 });
+        });
+
+        it("should pop bucket permissions", async () => {
+          const res = await bucket.removePermissions({ read: ["github:n1k0"] });
+          expect((res as KintoResponse).data.a).eql(1);
+          expect((res as KintoResponse).permissions.read).eql(undefined);
+        });
+      });
+
+      describe(".listHistory()", () => {
+        it("should retrieve the list of history entries", async () => {
+          const { data } = await bucket.listHistory();
+          data
+            .map((entry) => entry.target.data.id)
+            .should.deep.equal([
+              "g4",
+              "g3",
+              "g2",
+              "g1",
+              "c4",
+              "c3",
+              "c2",
+              "c1",
+              "custom",
+            ]);
+        });
+
+        it("should order entries by field", async () => {
+          const { data } = await bucket.listHistory({ sort: "last_modified" });
+          data
+            .map((entry) => entry.target.data.id)
+            .should.deep.equal([
+              "custom",
+              "c1",
+              "c2",
+              "c3",
+              "c4",
+              "g1",
+              "g2",
+              "g3",
+              "g4",
+            ]);
+        });
+
+        describe("Filtering", () => {
+          it("should filter entries by top-level attributes", async () => {
+            const { data } = await bucket.listHistory({
+              filters: { resource_name: "bucket" },
+            });
+            data
+              .map((entry) => entry.target.data.id)
+              .should.deep.equal(["custom"]);
+          });
+
+          it("should filter entries by target attributes", async () => {
+            const { data } = await bucket.listHistory({
+              filters: { "target.data.id": "custom" },
+            });
+            data
+              .map((entry) => entry.target.data.id)
+              .should.deep.equal(["custom"]);
+          });
+
+          it("should resolve with entries last_modified value", async () => {
+            (await bucket.listHistory()).should.have
+              .property("last_modified")
+              .to.be.a("string");
+          });
+
+          it("should retrieve only entries after provided timestamp", async () => {
+            const timestamp = (await bucket.listHistory()).last_modified!;
+            await bucket.createCollection("c5");
+            (await bucket.listHistory({ since: timestamp })).should.have
+              .property("data")
+              .to.have.lengthOf(1);
+          });
+        });
+
+        describe("Pagination", () => {
+          it("should not paginate by default", async () => {
+            const { data } = await bucket.listHistory();
+            data.map((entry) => entry.target.data.id).should.have.lengthOf(9);
+          });
+
+          it("should paginate by chunks", async () => {
+            const { data } = await bucket.listHistory({ limit: 2 });
+            data
+              .map((entry) => entry.target.data.id)
+              .should.deep.equal(["g4", "g3"]);
+          });
+
+          it("should provide a next method to load next page", async () => {
+            const res = await bucket.listHistory({ limit: 2 });
+            const { data } = await res.next();
+            data
+              .map((entry) => entry.target.data.id)
+              .should.deep.equal(["g2", "g1"]);
+          });
+        });
+      });
+
+      describe(".listCollections()", () => {
+        it("should retrieve the list of collections", async () => {
+          const { data } = await bucket.listCollections();
+          data
+            .map((collection) => collection.id)
+            .sort()
+            .should.deep.equal(["c1", "c2", "c3", "c4"]);
+        });
+
+        it("should order collections by field", async () => {
+          const { data } = await bucket.listCollections({ sort: "-size" });
+          data
+            .map((collection) => collection.id)
+            .should.deep.equal(["c3", "c1", "c2", "c4"]);
+        });
+
+        it("should work in a batch", async () => {
+          const res = (await api.batch((batch: KintoClientBase) => {
+            batch.bucket("custom").listCollections();
+          })) as unknown as OperationResponse<KintoObject[]>[];
+          res[0].body.data
+            .map((r) => r.id)
+            .should.deep.equal(["c4", "c3", "c2", "c1"]);
+        });
+
+        describe("Filtering", () => {
+          it("should filter collections", async () => {
+            const { data } = await bucket.listCollections({
+              sort: "size",
+              filters: { min_size: 20 },
+            });
+            data
+              .map((collection) => collection.id)
+              .should.deep.equal(["c1", "c3"]);
+          });
+
+          it("should resolve with collections last_modified value", async () => {
+            (await bucket.listCollections()).should.have
+              .property("last_modified")
+              .to.be.a("string");
+          });
+
+          it("should retrieve only collections after provided timestamp", async () => {
+            const timestamp = (await bucket.listCollections()).last_modified!;
+            await bucket.createCollection("c5");
+            (await bucket.listCollections({ since: timestamp })).should.have
+              .property("data")
+              .to.have.lengthOf(1);
+          });
+        });
+
+        describe("Pagination", () => {
+          it("should not paginate by default", async () => {
+            const { data } = await bucket.listCollections();
+            data
+              .map((collection) => collection.id)
+              .should.deep.equal(["c4", "c3", "c2", "c1"]);
+          });
+
+          it("should paginate by chunks", async () => {
+            const { data } = await bucket.listCollections({ limit: 2 });
+            data
+              .map((collection) => collection.id)
+              .should.deep.equal(["c4", "c3"]);
+          });
+
+          it("should provide a next method to load next page", async () => {
+            const res = await bucket.listCollections({ limit: 2 });
+            const { data } = await res.next();
+            data
+              .map((collection) => collection.id)
+              .should.deep.equal(["c2", "c1"]);
+          });
+        });
+      });
+
+      describe(".createCollection()", () => {
+        it("should create a named collection", async () => {
+          await bucket.createCollection("foo");
+          const { data } = await bucket.listCollections();
+          data.map((coll) => coll.id).should.include("foo");
+        });
+
+        it("should create an automatically named collection", async () => {
+          const res = await bucket.createCollection();
+          const generated = (res as KintoResponse).data.id;
+          const { data } = await bucket.listCollections();
+          return expect(data.some((x) => x.id === generated)).eql(true);
+        });
+
+        describe("Safe option", () => {
+          it("should not override existing collection", async () => {
+            await bucket.createCollection("posts");
+
+            await expectAsyncError(
+              () => bucket.createCollection("posts", { safe: true }),
+              /412 Precondition Failed/
+            );
+          });
+        });
+
+        describe("Permissions option", () => {
+          let result: KintoResponse;
+
+          beforeEach(async () => {
+            const res = await bucket.createCollection("posts", {
+              permissions: {
+                read: ["github:n1k0"],
+              },
+            });
+            return (result = res as KintoResponse);
+          });
+
+          it("should create a collection having a list of write permissions", () => {
+            expect(result)
+              .to.have.property("permissions")
+              .to.have.property("read")
+              .to.eql(["github:n1k0"]);
+          });
+        });
+
+        describe("Data option", () => {
+          let result: KintoResponse;
+
+          beforeEach(async () => {
+            const res = await bucket.createCollection("posts", {
+              data: { foo: "bar" },
+            });
+            return (result = res as KintoResponse);
+          });
+
+          it("should create a collection having the expected data attached", () => {
+            expect(result)
+              .to.have.property("data")
+              .to.have.property("foo")
+              .eql("bar");
+          });
+        });
+      });
+
+      describe(".deleteCollection()", () => {
+        it("should delete a collection", async () => {
+          await bucket.createCollection("foo");
+          await bucket.deleteCollection("foo");
+          const { data } = await bucket.listCollections();
+          data.map((coll) => coll.id).should.not.include("foo");
+        });
+
+        describe("Safe option", () => {
+          it("should check for concurrency", async () => {
+            const res = await bucket.createCollection("posts");
+
+            expectAsyncError(
+              () =>
+                bucket.deleteCollection("posts", {
+                  safe: true,
+                  last_modified: res.data.last_modified - 1000,
+                }),
+              /412 Precondition Failed/
+            );
+          });
+        });
+      });
+
+      describe(".listGroups()", () => {
+        it("should retrieve the list of groups", async () => {
+          const { data } = await bucket.listGroups();
+          data
+            .map((group) => group.id)
+            .sort()
+            .should.deep.equal(["g1", "g2", "g3", "g4"]);
+        });
+
+        it("should order groups by field", async () => {
+          const { data } = await bucket.listGroups({ sort: "-size" });
+          data
+            .map((group) => group.id)
+            .should.deep.equal(["g3", "g1", "g2", "g4"]);
+        });
+
+        describe("Filtering", () => {
+          it("should filter groups", async () => {
+            const { data } = await bucket.listGroups({
+              sort: "size",
+              filters: { min_size: 20 },
+            });
+            data.map((group) => group.id).should.deep.equal(["g1", "g3"]);
+          });
+
+          it("should resolve with groups last_modified value", async () => {
+            (await bucket.listGroups()).should.have
+              .property("last_modified")
+              .to.be.a("string");
+          });
+
+          it("should retrieve only groups after provided timestamp", async () => {
+            const timestamp = (await bucket.listGroups()).last_modified!;
+            await bucket.createGroup("g5", []);
+            (await bucket.listGroups({ since: timestamp })).should.have
+              .property("data")
+              .to.have.lengthOf(1);
+          });
+        });
+
+        describe("Pagination", () => {
+          it("should not paginate by default", async () => {
+            const { data } = await bucket.listGroups();
+            data
+              .map((group) => group.id)
+              .should.deep.equal(["g4", "g3", "g2", "g1"]);
+          });
+
+          it("should paginate by chunks", async () => {
+            const { data } = await bucket.listGroups({ limit: 2 });
+            data.map((group) => group.id).should.deep.equal(["g4", "g3"]);
+          });
+
+          it("should provide a next method to load next page", async () => {
+            const res = await bucket.listGroups({ limit: 2 });
+            const { data } = await res.next();
+            data.map((group) => group.id).should.deep.equal(["g2", "g1"]);
+          });
+        });
+      });
+
+      describe(".createGroup()", () => {
+        it("should create a named group", async () => {
+          await bucket.createGroup("foo");
+          const { data } = await bucket.listGroups();
+          data.map((group) => group.id).should.include("foo");
+        });
+
+        it("should create an automatically named group", async () => {
+          const res = await bucket.createGroup();
+          const generated = (res as KintoResponse<Group>).data.id;
+          const { data } = await bucket.listGroups();
+          return expect(data.some((x) => x.id === generated)).eql(true);
+        });
+
+        describe("Safe option", () => {
+          it("should not override existing group", async () => {
+            await bucket.createGroup("admins");
+
+            await expectAsyncError(
+              () => bucket.createGroup("admins", [], { safe: true }),
+              /412 Precondition Failed/
+            );
+          });
+        });
+
+        describe("Permissions option", () => {
+          let result: KintoResponse<Group>;
+
+          beforeEach(async () => {
+            const res = await bucket.createGroup(
+              "admins",
+              ["twitter:leplatrem"],
+              {
+                permissions: {
+                  read: ["github:n1k0"],
+                },
+              }
+            );
+            return (result = res as KintoResponse<Group>);
+          });
+
+          it("should create a collection having a list of write permissions", () => {
+            expect(result)
+              .to.have.property("permissions")
+              .to.have.property("read")
+              .to.eql(["github:n1k0"]);
+            expect(result.data.members).to.include("twitter:leplatrem");
+          });
+        });
+
+        describe("Data option", () => {
+          let result: KintoResponse<Group>;
+
+          beforeEach(async () => {
+            const res = await bucket.createGroup(
+              "admins",
+              ["twitter:leplatrem"],
+              {
+                data: { foo: "bar" },
+              }
+            );
+            return (result = res as KintoResponse<Group>);
+          });
+
+          it("should create a collection having the expected data attached", () => {
+            expect(result)
+              .to.have.property("data")
+              .to.have.property("foo")
+              .eql("bar");
+            expect(result.data.members).to.include("twitter:leplatrem");
+          });
+        });
+      });
+
+      describe(".getGroup()", () => {
+        it("should get a group", async () => {
+          await bucket.createGroup("foo");
+          const res = await bucket.getGroup("foo");
+          expect((res as KintoResponse<Group>).data.id).eql("foo");
+          expect((res as KintoResponse<Group>).data.members).eql([]);
+          expect(
+            (res as KintoResponse<Group>).permissions.write
+          ).to.have.lengthOf(1);
+        });
+      });
+
+      describe(".updateGroup()", () => {
+        it("should update a group", async () => {
+          const res = await bucket.createGroup("foo");
+          await bucket.updateGroup({ ...res.data, title: "mod" });
+          const { data } = await bucket.listGroups();
+
+          // type Group doesn't have a title property, so we create an
+          // intersection type that does
+          const firstGroup = data[0] as Group & { title: string };
+          firstGroup.title.should.equal("mod");
+        });
+
+        it("should patch a group", async () => {
+          const res = await bucket.createGroup("foo", ["github:me"], {
+            data: { title: "foo", blah: 42 },
+          });
+          await bucket.updateGroup(
+            { id: (res as KintoResponse<Group>).data.id, blah: 43 },
+            { patch: true }
+          );
+          const { data } = await bucket.listGroups();
+          expect(data[0].title).eql("foo");
+          expect(data[0].members).eql(["github:me"]);
+          expect(data[0].blah).eql(43);
+        });
+
+        describe("Safe option", () => {
+          const id = "2dcd0e65-468c-4655-8015-30c8b3a1c8f8";
+
+          it("should perform concurrency checks with last_modified", async () => {
+            const { data } = await bucket.createGroup("foo");
+
+            await expectAsyncError(
+              () =>
+                bucket.updateGroup(
+                  {
+                    id: data.id,
+                    members: ["github:me"],
+                    title: "foo",
+                    last_modified: 1,
+                  },
+                  { safe: true }
+                ),
+              /412 Precondition Failed/
+            );
+          });
+
+          it("should create a non-existent resource when safe is true", async () => {
+            (
+              await bucket.updateGroup({ id, members: ["all"] }, { safe: true })
+            ).should.have
+              .property("data")
+              .to.have.property("members")
+              .eql(["all"]);
+          });
+
+          it("should not override existing data with no last_modified", async () => {
+            const { data } = await bucket.createGroup("foo");
+
+            await expectAsyncError(
+              () =>
+                bucket.updateGroup(
+                  { id: data.id, members: [], title: "foo" },
+                  { safe: true }
+                ),
+              /412 Precondition Failed/
+            );
+          });
+        });
+      });
+
+      describe(".deleteGroup()", () => {
+        it("should delete a group", async () => {
+          await bucket.createGroup("foo");
+          await bucket.deleteGroup("foo");
+          const { data } = await bucket.listGroups();
+          data.map((coll) => coll.id).should.not.include("foo");
+        });
+
+        describe("Safe option", () => {
+          it("should check for concurrency", async () => {
+            const { data } = await bucket.createGroup("posts");
+
+            await expectAsyncError(
+              () =>
+                bucket.deleteGroup("posts", {
+                  safe: true,
+                  last_modified: data.last_modified - 1000,
+                }),
+              /412 Precondition Failed/
+            );
+          });
+        });
+      });
+
+      describe(".batch()", () => {
+        it("should allow batching operations for current bucket", async () => {
+          await bucket.batch((batch) => {
+            batch.createCollection("comments");
+            const coll = batch.collection("comments");
+            coll.createRecord({ content: "plop" });
+            coll.createRecord({ content: "yo" });
+          });
+
+          const { data } = await bucket.collection("comments").listRecords();
+          data
+            .map((comment) => comment.content)
+            .sort()
+            .should.deep.equal(["plop", "yo"]);
+        });
+
+        describe("Safe option", () => {
+          it("should allow batching operations for current bucket", async () => {
+            (
+              await bucket.batch(
+                (batch) => {
+                  batch.createCollection("comments");
+                  batch.createCollection("comments");
+                },
+                { safe: true, aggregate: true }
+              )
+            ).should.have
+              .property("conflicts")
+              .to.have.lengthOf(1);
+          });
+        });
+      });
+    });
+
+    describe(".collection()", () => {
+      function runSuite(label: string, collPromise: () => Promise<Collection>) {
+        describe(label, () => {
+          let coll: Collection;
+
+          beforeEach(async () => {
+            const _coll = await collPromise();
+            return (coll = _coll);
+          });
+
+          describe(".getTotalRecords()", () => {
+            it("should retrieve the initial total number of records", async () => {
+              (await coll.getTotalRecords()).should.equal(0);
+            });
+
+            it("should retrieve the updated total number of records", async () => {
+              await coll.batch((batch) => {
+                batch.createRecord({ a: 1 });
+                batch.createRecord({ a: 2 });
+              });
+              (await coll.getTotalRecords()).should.equal(2);
+            });
+          });
+
+          describe(".getPermissions()", () => {
+            it("should retrieve permissions", async () => {
+              (await coll.getPermissions()).should.have
+                .property("write")
+                .to.have.lengthOf(1);
+            });
+          });
+
+          describe(".setPermissions()", () => {
+            beforeEach(() => {
+              return coll.setData({ a: 1 });
+            });
+
+            it("should set typed permissions", async () => {
+              const res = await coll.setPermissions({ read: ["github:n1k0"] });
+              expect((res as KintoResponse).data.a).eql(1);
+              expect((res as KintoResponse).permissions.read).eql([
+                "github:n1k0",
+              ]);
+            });
+
+            describe("Safe option", () => {
+              it("should perform concurrency checks", async () => {
+                await expectAsyncError(
+                  () =>
+                    coll.setPermissions(
+                      { read: ["github:n1k0"] },
+                      { safe: true, last_modified: 1 }
+                    ),
+                  /412 Precondition Failed/
+                );
+              });
+            });
+          });
+
+          describe(".addPermissions()", () => {
+            beforeEach(async () => {
+              await coll.setPermissions({ read: ["github:n1k0"] });
+              return await coll.setData({ a: 1 });
+            });
+
+            it("should append collection permissions", async () => {
+              const res = await coll.addPermissions({
+                read: ["accounts:gabi"],
+              });
+              expect((res as KintoResponse).data.a).eql(1);
+              expect((res as KintoResponse).permissions.read!.sort()).eql([
+                "accounts:gabi",
+                "github:n1k0",
+              ]);
+            });
+          });
+
+          describe(".removePermissions()", () => {
+            beforeEach(async () => {
+              await coll.setPermissions({ read: ["github:n1k0"] });
+              return await coll.setData({ a: 1 });
+            });
+
+            it("should pop collection permissions", async () => {
+              const res = await coll.removePermissions({
+                read: ["github:n1k0"],
+              });
+              expect((res as KintoResponse).data.a).eql(1);
+              expect((res as KintoResponse).permissions.read).eql(undefined);
+            });
+          });
+
+          describe(".getData()", () => {
+            it("should retrieve collection data", async () => {
+              await coll.setData({ signed: true });
+              const data = (await coll.getData()) as { signed: boolean };
+              data.should.have.property("signed").eql(true);
+            });
+          });
+
+          describe(".setData()", () => {
+            beforeEach(() => {
+              return coll.setPermissions({ read: ["github:n1k0"] });
+            });
+
+            it("should set collection data", async () => {
+              const res = await coll.setData({ signed: true });
+              expect((res as KintoResponse).data.signed).eql(true);
+              expect((res as KintoResponse).permissions.read).to.include(
+                "github:n1k0"
+              );
+            });
+
+            describe("Safe option", () => {
+              it("should perform concurrency checks", async () => {
+                await expectAsyncError(
+                  () =>
+                    coll.setData(
+                      { signed: true },
+                      { safe: true, last_modified: 1 }
+                    ),
+                  /412 Precondition Failed/
+                );
+              });
+            });
+          });
+
+          describe(".createRecord()", () => {
+            describe("No record id provided", () => {
+              it("should create a record", async () => {
+                (await coll.createRecord({ title: "foo" })).should.have
+                  .property("data")
+                  .to.have.property("title")
+                  .eql("foo");
+              });
+
+              describe("Safe option", () => {
+                it("should check for existing record", async () => {
+                  const { data } = await coll.createRecord({ title: "foo" });
+
+                  await expectAsyncError(
+                    () =>
+                      coll.createRecord(
+                        { id: data.id, title: "foo" },
+                        { safe: true }
+                      ),
+                    /412 Precondition Failed/
+                  );
+                });
+              });
+            });
+
+            describe("Record id provided", () => {
+              const record = {
+                id: "37f727ed-c8c4-461b-80ac-de874992165c",
+                title: "foo",
+              };
+
+              it("should create a record", async () => {
+                (await coll.createRecord(record)).should.have
+                  .property("data")
+                  .to.have.property("title")
+                  .eql("foo");
+              });
+            });
+          });
+
+          describe(".updateRecord()", () => {
+            it("should update a record", async () => {
+              const res = await coll.createRecord({ title: "foo" });
+              await coll.updateRecord({ ...res.data, title: "mod" });
+              const { data } = await coll.listRecords();
+              // type KintoObject doesn't have a title property, so we create
+              // an intersection type that does
+              const record = data[0] as KintoObject & { title: string };
+              record.title.should.equal("mod");
+            });
+
+            it("should patch a record", async () => {
+              const res = await coll.createRecord({ title: "foo", blah: 42 });
+              await coll.updateRecord(
+                { id: (res as KintoResponse).data.id, blah: 43 },
+                { patch: true }
+              );
+              const { data } = await coll.listRecords();
+              expect(data[0].title).eql("foo");
+              expect(data[0].blah).eql(43);
+            });
+
+            it("should create the record if it doesn't exist yet", async () => {
+              const id = "2dcd0e65-468c-4655-8015-30c8b3a1c8f8";
+
+              const { data } = await coll.updateRecord({ id, title: "blah" });
+              (await coll.getRecord(data.id)).should.have
+                .property("data")
+                .to.have.property("title")
+                .eql("blah");
+            });
+
+            describe("Safe option", () => {
+              const id = "2dcd0e65-468c-4655-8015-30c8b3a1c8f8";
+
+              it("should perform concurrency checks with last_modified", async () => {
+                const { data } = await coll.createRecord({ title: "foo" });
+
+                await expectAsyncError(
+                  () =>
+                    coll.updateRecord(
+                      { id: data.id, title: "foo", last_modified: 1 },
+                      { safe: true }
+                    ),
+                  /412 Precondition Failed/
+                );
+              });
+
+              it("should create a non-existent resource when safe is true", async () => {
+                (
+                  await coll.updateRecord({ id, title: "foo" }, { safe: true })
+                ).should.have
+                  .property("data")
+                  .to.have.property("title")
+                  .eql("foo");
+              });
+
+              it("should not override existing data with no last_modified", async () => {
+                const { data } = await coll.createRecord({ title: "foo" });
+
+                await expectAsyncError(
+                  () =>
+                    coll.updateRecord(
+                      { id: data.id, title: "foo" },
+                      { safe: true }
+                    ),
+                  /412 Precondition Failed/
+                );
+              });
+            });
+          });
+
+          describe(".deleteRecord()", () => {
+            it("should delete a record", async () => {
+              const { data } = await coll.createRecord({ title: "foo" });
+              await coll.deleteRecord(data.id);
+              (await coll.listRecords()).should.have
+                .property("data")
+                .deep.equals([]);
+            });
+
+            describe("Safe option", () => {
+              it("should perform concurrency checks", async () => {
+                const { data } = await coll.createRecord({ title: "foo" });
+
+                await expectAsyncError(
+                  () =>
+                    coll.deleteRecord(data.id, {
+                      last_modified: 1,
+                      safe: true,
+                    }),
+                  /412 Precondition Failed/
+                );
+              });
+            });
+          });
+
+          describe(".addAttachment()", () => {
+            describe("With filename", () => {
+              const input = "test";
+              const dataURL =
+                "data:text/plain;name=test.txt;base64," + btoa(input);
+
+              let result: KintoResponse<{ attachment: Attachment }>;
+
+              beforeEach(async () => {
+                const res = await coll.addAttachment(
+                  dataURL,
+                  { foo: "bar" },
+                  { permissions: { write: ["github:n1k0"] } }
+                );
+                return (result = res as KintoResponse<{
+                  attachment: Attachment;
+                }>);
+              });
+
+              it("should create a record with an attachment", () => {
+                expect(result)
+                  .to.have.property("data")
+                  .to.have.property("attachment")
+                  .to.have.property("size")
+                  .eql(input.length);
+              });
+
+              it("should create a record with provided record data", () => {
+                expect(result)
+                  .to.have.property("data")
+                  .to.have.property("foo")
+                  .eql("bar");
+              });
+
+              it("should create a record with provided permissions", () => {
+                expect(result)
+                  .to.have.property("permissions")
+                  .to.have.property("write")
+                  .contains("github:n1k0");
+              });
+            });
+
+            describe("Without filename", () => {
+              const dataURL = "data:text/plain;base64," + btoa("blah");
+
+              it("should default filename to 'untitled' if not specified", async () => {
+                (await coll.addAttachment(dataURL)).should.have
+                  .property("data")
+                  .have.property("attachment")
+                  .have.property("filename")
+                  .eql("untitled");
+              });
+
+              it("should allow to specify safe in options", async () => {
+                (
+                  await coll.addAttachment(dataURL, undefined, { safe: true })
+                ).should.to.have
+                  .property("data")
+                  .to.have.property("attachment")
+                  .to.have.property("size")
+                  .eql(4);
+              });
+
+              it("should allow to specify a filename in options", async () => {
+                (
+                  await coll.addAttachment(dataURL, undefined, {
+                    filename: "MYFILE.DAT",
+                  })
+                ).should.have
+                  .property("data")
+                  .have.property("attachment")
+                  .have.property("filename")
+                  .eql("MYFILE.DAT");
+              });
+            });
+          });
+
+          describe(".removeAttachment()", () => {
+            const input = "test";
+            const dataURL =
+              "data:text/plain;name=test.txt;base64," + btoa(input);
+
+            let recordId: string;
+
+            beforeEach(async () => {
+              const res = await coll.addAttachment(dataURL);
+              return (recordId = (
+                res as KintoResponse<{
+                  attachment: Attachment;
+                }>
+              ).data.id);
+            });
+
+            it("should remove an attachment from a record", async () => {
+              await coll.removeAttachment(recordId);
+              (await coll.getRecord(recordId)).should.have
+                .property("data")
+                .to.have.property("attachment")
+                .eql(null);
+            });
+          });
+
+          describe(".getRecord()", () => {
+            it("should retrieve a record by its id", async () => {
+              const { data } = await coll.createRecord({ title: "blah" });
+
+              (await coll.getRecord(data.id)).should.have
+                .property("data")
+                .to.have.property("title")
+                .eql("blah");
+            });
+          });
+
+          describe(".listRecords()", () => {
+            it("should list records", async () => {
+              await coll.createRecord({ title: "foo" });
+
+              const { data } = await coll.listRecords();
+              data.map((record) => record.title).should.deep.equal(["foo"]);
+            });
+
+            it("should order records by field", async () => {
+              await Promise.all(
+                ["art3", "art1", "art2"].map((title) => {
+                  return coll.createRecord({ title });
+                })
+              );
+
+              const { data } = await coll.listRecords({ sort: "title" });
+              data
+                .map((record) => record.title)
+                .should.deep.equal(["art1", "art2", "art3"]);
+            });
+
+            describe("Filtering", () => {
+              beforeEach(() => {
+                return coll.batch((batch) => {
+                  batch.createRecord({ name: "paul", age: 28 });
+                  batch.createRecord({ name: "jess", age: 54 });
+                  batch.createRecord({ name: "john", age: 33 });
+                  batch.createRecord({ name: "rené", age: 24 });
+                });
+              });
+
+              it("should filter records", async () => {
+                const { data } = await coll.listRecords({
+                  sort: "age",
+                  filters: { min_age: 30 },
+                });
+                data
+                  .map((record) => record.name)
+                  .should.deep.equal(["john", "jess"]);
+              });
+
+              it("should properly escape unicode filters", async () => {
+                const { data } = await coll.listRecords({
+                  filters: { name: "rené" },
+                });
+                data.map((record) => record.name).should.deep.equal(["rené"]);
+              });
+
+              it("should resolve with collection last_modified value", async () => {
+                (await coll.listRecords()).should.have
+                  .property("last_modified")
+                  .to.be.a("string");
+              });
+            });
+
+            describe("since", () => {
+              let ts1: string, ts2: string;
+
+              beforeEach(async () => {
+                ts1 = (await coll.listRecords()).last_modified!;
+                await coll.createRecord({ n: 1 });
+                ts2 = (await coll.listRecords()).last_modified!;
+                return await coll.createRecord({ n: 2 });
+              });
+
+              it("should retrieve all records modified since provided timestamp", async () => {
+                (await coll.listRecords({ since: ts1 })).should.have
+                  .property("data")
+                  .to.have.lengthOf(2);
+              });
+
+              it("should only list changes made after the provided timestamp", async () => {
+                (await coll.listRecords({ since: ts2 })).should.have
+                  .property("data")
+                  .to.have.lengthOf(1);
+              });
+            });
+
+            describe("'at' retrieves a snapshot at a given timestamp", () => {
+              let rec1: KintoObject, rec2: KintoObject, rec3: KintoObject;
+
+              beforeEach(async () => {
+                const resp = await coll.createRecord({ n: 1 });
+                rec1 = (resp as KintoResponse).data;
+                const res = await coll.createRecord({ n: 2 });
+                rec2 = (res as KintoResponse).data;
+                const res_1 = await coll.createRecord({ n: 3 });
+                return (rec3 = (res_1 as KintoResponse).data);
+              });
+
+              it("should resolve with a regular list result object", async () => {
+                const result = await coll.listRecords({
+                  at: rec3.last_modified,
+                });
+                const expectedSnapshot = [rec3, rec2, rec1];
+                expect(result.data).to.eql(expectedSnapshot);
+                expect(result.last_modified).eql(String(rec3.last_modified));
+                expect(result.hasNextPage).eql(false);
+                expect(result.totalRecords).eql(expectedSnapshot.length);
+                expect(() => result.next()).to.Throw(Error, /pagination/);
+              });
+
+              it("should handle creations", async () => {
+                (await coll.listRecords({ at: rec1.last_modified })).should.have
+                  .property("data")
+                  .eql([rec1]);
+              });
+
+              it("should handle updates", async () => {
+                const res = await coll.updateRecord({ ...rec2, n: 42 });
+                const updatedRec2 = (res as KintoResponse).data;
+                const { data } = await coll.listRecords({
+                  at: updatedRec2.last_modified,
+                });
+                expect(data).eql([updatedRec2, rec3, rec1]);
+              });
+
+              it("should handle deletions", async () => {
+                const res = await coll.deleteRecord(rec1.id);
+                const { data } = await coll.listRecords({
+                  at: (res as KintoResponse).data.last_modified,
+                });
+                expect(data).eql([rec3, rec2]);
+              });
+
+              it("should handle re-creations", async () => {
+                await coll.deleteRecord(rec1.id);
+                await coll.createRecord({ id: rec1.id, n: 1 });
+                const { data } = await coll.listRecords({
+                  at: rec3.last_modified,
+                });
+                expect(data).eql([rec3, rec2, rec1]);
+              });
+
+              it("should handle plural delete before timestamp", async () => {
+                await coll.createRecord({ n: 3 });
+                await coll.deleteRecords({
+                  filters: {
+                    eq_n: 3,
+                  },
+                });
+                const { data: rec4 } = await coll.createRecord({ n: 4 });
+                const { data } = await coll.listRecords({
+                  at: rec4.last_modified,
+                });
+                expect(data).eql([rec4, rec2, rec1]);
+              });
+
+              it("should handle plural delete after timestamp", async () => {
+                const { data: rec33 } = await coll.createRecord({ n: 3 });
+                await coll.createRecord({ n: 4 });
+                await coll.deleteRecords({
+                  filters: {
+                    eq_n: 3,
+                  },
+                });
+                const { data } = await coll.listRecords({
+                  at: rec33.last_modified,
+                });
+                expect(data).eql([rec33, rec3, rec2, rec1]);
+              });
+
+              it("should handle long list of changes", async () => {
+                const res = await coll.batch((batch) => {
+                  for (let n = 4; n <= 100; n++) {
+                    batch.createRecord({ n });
+                  }
+                });
+                const at = (res as OperationResponse[])[50].body.data
+                  .last_modified;
+                (await coll.listRecords({ at })).should.have
+                  .property("data")
+                  .to.lengthOf(54);
+              });
+
+              describe("Mixed CRUD operations", () => {
+                let rec4: KintoObject;
+                let s1: KintoObject[] = [],
+                  s2: KintoObject[] = [],
+                  s3: KintoObject[] = [],
+                  s4: KintoObject[] = [];
+                let rec1up: KintoObject;
+
+                beforeEach(async () => {
+                  const responses = await coll.batch((batch) => {
+                    batch.deleteRecord(rec2.id);
+                    batch.updateRecord({
+                      ...rec1,
+                      foo: "bar",
+                    });
+                    batch.createRecord({ n: 4 });
+                  });
+                  rec1up = (responses as OperationResponse[])[1].body.data;
+                  rec4 = (responses as OperationResponse[])[
+                    (responses as OperationResponse[]).length - 1
+                  ].body.data;
+                  const results = await Promise.all([
+                    coll.listRecords({ at: rec1.last_modified }),
+                    coll.listRecords({ at: rec2.last_modified }),
+                    coll.listRecords({ at: rec3.last_modified }),
+                    coll.listRecords({ at: rec4.last_modified }),
+                  ]);
+                  const snapshots = results.map(({ data }) => data);
+                  s1 = snapshots[0];
+                  s2 = snapshots[1];
+                  s3 = snapshots[2];
+                  s4 = snapshots[3];
+                });
+
+                it("should compute snapshot1 as expected", () => {
+                  expect(s1).eql([rec1]);
+                });
+
+                it("should compute snapshot2 as expected", () => {
+                  expect(s2).eql([rec2, rec1]);
+                });
+
+                it("should compute snapshot3 as expected", () => {
+                  expect(s3).eql([rec3, rec2, rec1]);
+                });
+
+                it("should compute snapshot4 as expected", () => {
+                  expect(s4).eql([rec4, rec1up, rec3]);
+                });
+              });
+            });
+
+            describe("Pagination", () => {
+              beforeEach(() => {
+                return coll.batch((batch) => {
+                  for (let i = 1; i <= 3; i++) {
+                    batch.createRecord({ n: i });
+                  }
+                });
+              });
+
+              it("should not paginate by default", async () => {
+                const { data } = await coll.listRecords();
+                data.map((record) => record.n).should.deep.equal([3, 2, 1]);
+              });
+
+              it("should paginate by chunks", async () => {
+                const { data } = await coll.listRecords({ limit: 2 });
+                data.map((record) => record.n).should.deep.equal([3, 2]);
+              });
+
+              it("should provide a next method to load next page", async () => {
+                const res = await coll.listRecords({ limit: 2 });
+                const { data } = await res.next();
+                data.map((record) => record.n).should.deep.equal([1]);
+              });
+
+              it("should resolve with an empty array on exhausted pagination", async () => {
+                const res1 = await coll.listRecords({ limit: 2 });
+                const res2 = await res1.next();
+
+                await expectAsyncError(
+                  () => res2.next(),
+                  /Pagination exhausted./
+                );
+              });
+
+              it("should retrieve all pages", async () => {
+                // Note: Server has no limit by default, so here we get all the
+                // records.
+                const { data } = await coll.listRecords();
+                data.map((record) => record.n).should.deep.equal([3, 2, 1]);
+              });
+
+              it("should retrieve specified number of pages", async () => {
+                const { data } = await coll.listRecords({ limit: 1, pages: 2 });
+                data.map((record) => record.n).should.deep.equal([3, 2]);
+              });
+
+              it("should allow fetching next page after last page if any", async () => {
+                const { next } = await coll.listRecords({ limit: 1, pages: 1 });
+                const { data } = await next();
+                data.map((record) => record.n).should.deep.equal([3, 2]);
+              });
+
+              it("should should retrieve all existing pages", async () => {
+                const { data } = await coll.listRecords({
+                  limit: 1,
+                  pages: Infinity,
+                });
+                data.map((record) => record.n).should.deep.equal([3, 2, 1]);
+              });
+            });
+          });
+
+          describe(".batch()", () => {
+            it("should allow batching operations in the current collection", async () => {
+              await coll.batch((batch) => {
+                batch.createRecord({ title: "a" });
+                batch.createRecord({ title: "b" });
+              });
+              const { data } = await coll.listRecords({ sort: "title" });
+              data.map((record) => record.title).should.deep.equal(["a", "b"]);
+            });
+          });
+        });
+      }
+
+      runSuite("default bucket", async () => {
+        await api.bucket("default").createCollection("plop");
+        return api.bucket("default").collection("plop");
+      });
+
+      runSuite("custom bucket", async () => {
+        await api.createBucket("custom");
+        await api.bucket("custom").createCollection("plop");
+        return api.bucket("custom").collection("plop");
+      });
+    });
+  });
+});

--- a/test/http/kinto-8.1.2.ini
+++ b/test/http/kinto-8.1.2.ini
@@ -1,27 +1,18 @@
 [app:main]
 use = egg:kinto
 
-# Required by integration tests
-kinto.flush_endpoint_enabled = true
-
 # Required by basic auth
 kinto.userid_hmac_secret = a-secret-string
 
 # Allow browsing all buckets
 kinto.bucket_read_principals = system.Authenticated
 
-# Add default bucket
+# Plugins registration
 kinto.includes = kinto.plugins.default_bucket
                  kinto.plugins.history
                  kinto_attachment
                  kinto.plugins.accounts
                  kinto.plugins.flush
-multiauth.policies = account basicauth
-multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
-kinto.account_create_principals = system.Everyone
-
-# Force pagination
-kinto.paginate_by = 10
 
 # Kinto-attachment
 kinto.attachment.base_url = http://0.0.0.0:8888/attachments
@@ -32,6 +23,13 @@ kinto.attachment.extensions = any
 
 # Enable permissions endpoint
 kinto.experimental_permissions_endpoint = True
+
+# Force accounts (not default until 10.2)
+multiauth.policies = account basicauth
+multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
+kinto.account_create_principals = system.Everyone
+
+kinto.paginate_by = 10
 
 [server:main]
 use = egg:waitress#main

--- a/test/http/kinto.ini
+++ b/test/http/kinto.ini
@@ -10,18 +10,12 @@ kinto.userid_hmac_secret = a-secret-string
 # Allow browsing all buckets
 kinto.bucket_read_principals = system.Authenticated
 
-# Add default bucket
+# Plugins registration
 kinto.includes = kinto.plugins.default_bucket
                  kinto.plugins.history
                  kinto_attachment
                  kinto.plugins.accounts
                  kinto.plugins.flush
-multiauth.policies = account basicauth
-multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
-kinto.account_create_principals = system.Everyone
-
-# Force pagination
-kinto.paginate_by = 10
 
 # Kinto-attachment
 kinto.attachment.base_url = http://0.0.0.0:8888/attachments
@@ -32,6 +26,12 @@ kinto.attachment.extensions = any
 
 # Enable permissions endpoint
 kinto.experimental_permissions_endpoint = True
+
+multiauth.policies = account basicauth
+multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
+kinto.account_create_principals = system.Everyone
+
+kinto.paginate_by = 10
 
 [server:main]
 use = egg:waitress#main

--- a/test/http/requests_test.ts
+++ b/test/http/requests_test.ts
@@ -1,0 +1,248 @@
+import { btoa } from "./test_utils";
+import * as requests from "../../src/http/requests";
+
+const { expect } = intern.getPlugin("chai");
+intern.getPlugin("chai").should();
+const { describe, it } = intern.getPlugin("interface.bdd");
+
+describe("requests module", () => {
+  describe("createRequest()", () => {
+    it("should return a POST creation request", () => {
+      expect(requests.createRequest("/foo", {})).eql({
+        body: {
+          data: undefined,
+          permissions: undefined,
+        },
+        headers: {},
+        method: "POST",
+        path: "/foo",
+      });
+    });
+
+    it("should return a PUT creation request when an id is provided", () => {
+      expect(
+        requests.createRequest("/foo", {
+          data: { id: "foo" },
+        })
+      ).eql({
+        body: {
+          data: {
+            id: "foo",
+          },
+          permissions: undefined,
+        },
+        headers: {},
+        method: "PUT",
+        path: "/foo",
+      });
+    });
+
+    it("should accept a headers option", () => {
+      expect(requests.createRequest("/foo", {}, { headers: { Foo: "Bar" } }))
+        .to.have.property("headers")
+        .eql({ Foo: "Bar" });
+    });
+
+    it("should accept a permissions option", () => {
+      const permissions = { read: ["github:n1k0"] };
+      expect(requests.createRequest("/foo", { permissions }))
+        .to.have.property("body")
+        .to.have.property("permissions")
+        .eql(permissions);
+    });
+
+    it("should support a safe option", () => {
+      expect(
+        requests.createRequest("/foo", { data: { id: "foo" } }, { safe: true })
+      )
+        .to.have.property("headers")
+        .to.have.property("If-None-Match")
+        .eql("*");
+    });
+  });
+
+  describe("deleteRequest()", () => {
+    it("should return a deletion request", () => {
+      expect(requests.deleteRequest("/foo")).eql({
+        headers: {},
+        method: "DELETE",
+        path: "/foo",
+      });
+    });
+
+    it("should accept a headers option", () => {
+      expect(requests.deleteRequest("/foo", { headers: { Foo: "Bar" } }))
+        .to.have.property("headers")
+        .eql({ Foo: "Bar" });
+    });
+
+    it("should raise for safe with no last_modified passed", () => {
+      expect(() => requests.deleteRequest("/foo", { safe: true })).to.Throw(
+        Error,
+        /requires a last_modified/
+      );
+    });
+
+    it("should support a safe option with a last_modified option", () => {
+      expect(requests.deleteRequest("/foo", { safe: true, last_modified: 42 }))
+        .to.have.property("headers")
+        .to.have.property("If-Match")
+        .eql('"42"');
+    });
+  });
+
+  describe("updateRequest()", () => {
+    it("should return a update request", () => {
+      expect(
+        requests.updateRequest("/foo", {
+          data: { id: "foo", age: 42 },
+        })
+      ).eql({
+        body: {
+          data: { id: "foo", age: 42 },
+          permissions: undefined,
+        },
+        headers: {},
+        method: "PUT",
+        path: "/foo",
+      });
+    });
+
+    it("should accept a headers option", () => {
+      expect(
+        requests.updateRequest(
+          "/foo",
+          { data: { id: "foo" } },
+          { headers: { Foo: "Bar" } }
+        )
+      )
+        .to.have.property("headers")
+        .eql({ Foo: "Bar" });
+    });
+
+    it("should accept a permissions option", () => {
+      const permissions = { read: ["github:n1k0"] };
+      expect(
+        requests.updateRequest("/foo", {
+          data: { id: "foo" },
+          permissions,
+        })
+      )
+        .to.have.property("body")
+        .to.have.property("permissions")
+        .eql(permissions);
+    });
+
+    it("should accept a patch option", () => {
+      expect(
+        requests.updateRequest("/foo", { data: { id: "foo" } }, { patch: true })
+      )
+        .to.have.property("method")
+        .eql("PATCH");
+    });
+
+    it("should handle data", () => {
+      expect(requests.updateRequest("/foo", { data: { id: "foo", a: 1 } }))
+        .to.have.property("body")
+        .to.have.property("data")
+        .eql({ id: "foo", a: 1 });
+    });
+
+    it("should support a safe option with no last_modified passed", () => {
+      expect(
+        requests.updateRequest(
+          "/foo",
+          { data: { id: "foo", a: 1 } },
+          { safe: true }
+        )
+      )
+        .to.have.property("headers")
+        .to.have.property("If-None-Match")
+        .eql("*");
+    });
+
+    it("should support a safe option with a last_modified passed", () => {
+      expect(
+        requests.updateRequest(
+          "/foo",
+          { data: { id: "foo", last_modified: 42 } },
+          { safe: true }
+        )
+      )
+        .to.have.property("headers")
+        .to.have.property("If-Match")
+        .eql('"42"');
+    });
+  });
+
+  it("should accept a patch option", () => {
+    expect(
+      requests.updateRequest(
+        "/foo",
+        { data: { id: "foo", last_modified: 42 } },
+        { patch: true }
+      )
+    )
+      .to.have.property("method")
+      .eql("PATCH");
+  });
+
+  describe("addAttachmentRequest()", () => {
+    const dataURL = "data:text/plain;name=test.txt;base64," + btoa("hola");
+    it("should return a post request", () => {
+      expect(requests.addAttachmentRequest("/foo", dataURL))
+        .to.have.property("method")
+        .eql("POST");
+    });
+
+    it("should accept a headers option", () => {
+      expect(
+        requests.addAttachmentRequest(
+          "/foo",
+          dataURL,
+          {},
+          { headers: { Foo: "Bar" } }
+        )
+      )
+        .to.have.property("headers")
+        .eql({ Foo: "Bar" });
+    });
+
+    it("should support a safe with no last_modified passed", () => {
+      expect(requests.addAttachmentRequest("/foo", dataURL, {}, { safe: true }))
+        .to.have.property("headers")
+        .to.have.property("If-None-Match")
+        .eql("*");
+    });
+
+    it("should support a safe option with a last_modified option", () => {
+      expect(
+        requests.addAttachmentRequest(
+          "/foo",
+          dataURL,
+          {},
+          { safe: true, last_modified: 42 }
+        )
+      )
+        .to.have.property("headers")
+        .to.have.property("If-Match")
+        .eql('"42"');
+    });
+
+    it("should support a gzipped option passed with true", () => {
+      expect(
+        requests.addAttachmentRequest("/foo", dataURL, {}, { gzipped: true })
+      )
+        .to.have.property("path")
+        .eql("/foo?gzipped=true");
+    });
+
+    it("should support a gzipped option passed with false", () => {
+      expect(
+        requests.addAttachmentRequest("/foo", dataURL, {}, { gzipped: false })
+      )
+        .to.have.property("path")
+        .eql("/foo?gzipped=false");
+    });
+  });
+});

--- a/test/http/server.ts
+++ b/test/http/server.ts
@@ -1,0 +1,27 @@
+import { KintoProxyServer } from "kinto-node-test-server";
+
+function willRunBrowserTests() {
+  const { environments } = intern.config;
+  for (const env of environments) {
+    if (env.browserName !== "node") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+let server: KintoProxyServer = null;
+
+intern.on("runStart", async () => {
+  if (willRunBrowserTests()) {
+    server = new KintoProxyServer();
+    await server.startServer();
+  }
+});
+
+intern.on("runEnd", async () => {
+  if (server) {
+    await server.stopServer();
+  }
+});

--- a/test/http/test_utils.ts
+++ b/test/http/test_utils.ts
@@ -1,0 +1,78 @@
+import sinon from "sinon";
+
+const { expect } = intern.getPlugin("chai");
+
+export function fakeHeaders(headers: { [key: string]: string | number } = {}) {
+  const h = new Headers();
+  Object.entries(headers).forEach(([k, v]) => h.set(k, v.toString()));
+  return h;
+}
+
+export function fakeServerResponse(
+  status: number,
+  json: any,
+  headers: { [key: string]: string | number } = {}
+) {
+  const respHeaders = fakeHeaders(headers);
+  if (!respHeaders.has("Content-Length")) {
+    respHeaders.set("Content-Length", JSON.stringify(json).length.toString());
+  }
+  return Promise.resolve({
+    status: status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: respHeaders,
+    text() {
+      return Promise.resolve(JSON.stringify(json));
+    },
+  });
+}
+
+export function delayedPromise(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => resolve(), ms);
+  });
+}
+
+export type Stub<T extends (...args: any[]) => any> = sinon.SinonStub<
+  Parameters<T>,
+  ReturnType<T>
+>;
+
+export type Spy<T extends (...args: any[]) => any> = sinon.SinonSpy<
+  Parameters<T>,
+  ReturnType<T>
+>;
+
+export async function expectAsyncError<T>(
+  fn: () => Promise<T>,
+  message?: string | RegExp,
+  baseClass: any = Error
+): Promise<Error> {
+  let error: Error;
+
+  try {
+    await fn();
+  } catch (err) {
+    error = err as Error;
+  }
+
+  expect(error!).not.to.be.undefined;
+  expect(error!).to.be.instanceOf(baseClass);
+  if (message) {
+    if (typeof message === "string") {
+      expect(error!).to.have.property("message").equal(message);
+    } else {
+      expect(error!).to.have.property("message").match(message);
+    }
+  }
+
+  return error!;
+}
+
+export function btoa(str: string): string {
+  if (globalThis.btoa) {
+    return globalThis.btoa(str);
+  }
+
+  return Buffer.from(str, "binary").toString("base64");
+}

--- a/test/http/tsconfig.json
+++ b/test/http/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "types": ["intern"],
+    "inlineSourceMap": true,
+    "strictNullChecks": false
+  },
+  "include": ["./**/*.ts"]
+}

--- a/test/http/utils_test.ts
+++ b/test/http/utils_test.ts
@@ -1,0 +1,332 @@
+import { btoa } from "./test_utils";
+import {
+  partition,
+  delay,
+  qsify,
+  checkVersion,
+  support,
+  capable,
+  nobatch,
+  parseDataURL,
+  extractFileInfo,
+  cleanUndefinedProperties,
+  addEndpointOptions,
+} from "../../src/http/utils";
+import { expectAsyncError } from "./test_utils";
+
+const { expect } = intern.getPlugin("chai");
+intern.getPlugin("chai").should();
+const { describe, it } = intern.getPlugin("interface.bdd");
+
+describe("HTTP Utils", () => {
+  /** @test {partition} */
+  describe("#partition", () => {
+    it("should chunk array", () => {
+      expect(partition([1, 2, 3], 2)).eql([[1, 2], [3]]);
+      expect(partition([1, 2, 3], 1)).eql([[1], [2], [3]]);
+      expect(partition([1, 2, 3, 4, 5], 3)).eql([
+        [1, 2, 3],
+        [4, 5],
+      ]);
+      expect(partition([1, 2], 2)).eql([[1, 2]]);
+    });
+
+    it("should still chunk array with n<=0", () => {
+      expect(partition([1, 2, 3], 0)).eql([[1, 2, 3]]);
+      expect(partition([1, 2, 3], -1)).eql([[1, 2, 3]]);
+    });
+  });
+
+  /** @test {delay} */
+  describe("#delay", () => {
+    it("should delay resolution after the specified amount of time", () => {
+      const start = new Date().getTime();
+      return delay(10).then(() => {
+        expect(new Date().getTime() - start).to.be.at.least(9);
+      });
+    });
+  });
+
+  /** @test {qsify} */
+  describe("#qsify", () => {
+    it("should generate a query string from an object", () => {
+      expect(qsify({ a: 1, b: 2 })).eql("a=1&b=2");
+    });
+
+    it("should strip out undefined values", () => {
+      expect(qsify({ a: undefined, b: 2 })).eql("b=2");
+    });
+
+    it("should join comma-separated values", () => {
+      expect(qsify({ a: [1, 2], b: 2 })).eql("a=1,2&b=2");
+    });
+
+    it("should map boolean as lowercase string", () => {
+      expect(qsify({ a: [true, 2], b: false })).eql("a=true,2&b=false");
+    });
+
+    it("should escaped values", () => {
+      expect(qsify({ a: ["é", "ə"], b: "&" })).eql("a=%C3%A9,%C9%99&b=%26");
+    });
+  });
+
+  /** @test {addEndpointOptions} */
+  describe("#addEndpointOptions", () => {
+    it("should add query options", () => {
+      expect(addEndpointOptions("/a", { query: { a: '"123"' } })).eql(
+        "/a?a=%22123%22"
+      );
+    });
+
+    it("should understand _fields", () => {
+      expect(addEndpointOptions("/a", { fields: ["a", "b"] })).eql(
+        "/a?_fields=a,b"
+      );
+    });
+
+    it("should not add ? if no options", () => {
+      expect(addEndpointOptions("/a")).eql("/a");
+    });
+  });
+
+  describe("#checkVersion", () => {
+    it("should accept a version within provided range", () => {
+      checkVersion("1.0", "1.0", "2.0");
+      checkVersion("1.10", "1.0", "2.0");
+      checkVersion("1.10", "1.9", "2.0");
+      checkVersion("2.1", "1.0", "2.2");
+      checkVersion("2.1", "1.2", "2.2");
+      checkVersion("1.4", "1.4", "2.0");
+    });
+
+    it("should not accept a version oustide provided range", () => {
+      expect(() => checkVersion("0.9", "1.0", "2.0")).to.Throw(Error);
+      expect(() => checkVersion("2.0", "1.0", "2.0")).to.Throw(Error);
+      expect(() => checkVersion("2.1", "1.0", "2.0")).to.Throw(Error);
+      expect(() => checkVersion("3.9", "1.0", "2.10")).to.Throw(Error);
+      expect(() => checkVersion("1.3", "1.4", "2.0")).to.Throw(Error);
+    });
+  });
+
+  describe("@support", () => {
+    it("should return a function", () => {
+      expect(support("", "")).to.be.a("function");
+    });
+
+    it("should make decorated method resolve on version match", () => {
+      class FakeClient {
+        fetchHTTPApiVersion() {
+          return Promise.resolve("1.4"); // simulates a successful checkVersion call
+        }
+
+        @support("1.0", "2.0")
+        test() {
+          return Promise.resolve();
+        }
+      }
+
+      return new FakeClient().test();
+    });
+
+    it("should make decorated method rejecting on version mismatch", () => {
+      class FakeClient {
+        fetchHTTPApiVersion() {
+          return Promise.resolve("1.4"); // simulates a failing checkVersion call
+        }
+
+        @support("1.5", "2.0")
+        test() {
+          return Promise.resolve();
+        }
+      }
+
+      return new FakeClient().test().then(
+        () => {
+          throw new Error("Should be rejected");
+        },
+        (err) => {
+          err.should.not.be.undefined;
+        }
+      );
+    });
+
+    it("should check for an attached client instance", () => {
+      class FakeClient {
+        // @ts-ignore
+        private client: { fetchHTTPApiVersion: () => Promise<void> };
+        constructor() {
+          this.client = {
+            fetchHTTPApiVersion() {
+              return Promise.reject(); // simulates a failing checkVersion call
+            },
+          };
+        }
+
+        @support("", "")
+        test() {
+          return Promise.resolve();
+        }
+      }
+
+      return new FakeClient().test().then(
+        () => {
+          throw new Error("Should be rejected");
+        },
+        (err) => {
+          expect(err).to.be.undefined;
+        }
+      );
+    });
+  });
+
+  describe("@capable", () => {
+    it("should return a function", () => {
+      expect(capable([])).to.be.a("function");
+    });
+
+    it("should make decorated method checking the capabilities", () => {
+      class FakeClient {
+        fetchServerCapabilities() {
+          return Promise.resolve({}); // simulates a successful checkVersion call
+        }
+
+        @capable([])
+        test() {
+          return Promise.resolve();
+        }
+      }
+
+      return new FakeClient().test();
+    });
+
+    it("should make decorated method resolve on capability match", () => {
+      class FakeClient {
+        fetchServerCapabilities() {
+          return Promise.resolve({
+            attachments: {},
+            default: {},
+            "auth:fxa": {},
+          });
+        }
+
+        @capable(["default", "attachments"])
+        test() {
+          return Promise.resolve();
+        }
+      }
+
+      return new FakeClient().test();
+    });
+
+    it("should make decorated method rejecting on missing capability", async () => {
+      class FakeClient {
+        fetchServerCapabilities() {
+          return Promise.resolve({ attachments: {} });
+        }
+
+        @capable(["attachments", "default"])
+        test() {
+          return Promise.resolve();
+        }
+      }
+
+      await expectAsyncError(
+        () => new FakeClient().test(),
+        /default not present/
+      );
+    });
+  });
+
+  describe("@nobatch", () => {
+    it("should return a function", () => {
+      expect(nobatch("")).to.be.a("function");
+    });
+
+    it("should make decorated method pass when not in batch", () => {
+      class FakeClient {
+        // @ts-ignore
+        private _isBatch: boolean;
+        constructor() {
+          this._isBatch = false;
+        }
+
+        @nobatch("error")
+        test() {
+          return Promise.resolve();
+        }
+      }
+
+      return new FakeClient().test();
+    });
+
+    it("should make decorated method to throw if in batch", () => {
+      class FakeClient {
+        // @ts-ignore
+        private _isBatch: boolean;
+        constructor() {
+          this._isBatch = true;
+        }
+
+        @nobatch("error")
+        test() {
+          return Promise.resolve();
+        }
+      }
+
+      expect(() => new FakeClient().test()).to.Throw(Error, "error");
+    });
+  });
+
+  describe("parseDataURL()", () => {
+    it("should extract expected properties", () => {
+      expect(
+        parseDataURL("data:image/png;encoding=utf-8;name=a.png;base64,b64")
+      ).eql({
+        type: "image/png",
+        name: "a.png",
+        base64: "b64",
+        encoding: "utf-8",
+      });
+    });
+
+    it("should support dataURL without name", () => {
+      expect(parseDataURL("data:image/png;base64,b64")).eql({
+        type: "image/png",
+        base64: "b64",
+      });
+    });
+
+    it("should throw an error when the data url is invalid", () => {
+      expect(() => expect(parseDataURL("gni"))).to.throw(
+        Error,
+        "Invalid data-url: gni..."
+      );
+    });
+  });
+
+  describe("extractFileInfo()", () => {
+    it("should extract file information from a data url", () => {
+      const dataURL = "data:text/plain;name=t.txt;base64," + btoa("test");
+
+      const { blob, name } = extractFileInfo(dataURL);
+
+      if ("size" in blob) {
+        expect(blob.size).eql(4);
+      } else {
+        // In Node, `blob` is actually a Buffer
+        expect((blob as any).length).eql(4);
+      }
+      expect(name).eql("t.txt");
+    });
+  });
+
+  describe("cleanUndefinedProperties()", () => {
+    it("should remove undefined properties from an object", () => {
+      const obj1 = cleanUndefinedProperties({ a: 1, b: undefined });
+      /* eslint-disable no-prototype-builtins */
+      expect(obj1.hasOwnProperty("a")).eql(true);
+      expect(obj1.hasOwnProperty("b")).eql(false);
+      /* eslint-enable no-prototype-builtins */
+    });
+  });
+});

--- a/test/index_test.ts
+++ b/test/index_test.ts
@@ -1,6 +1,6 @@
 import sinon from "sinon";
 import { EventEmitter } from "events";
-import { SUPPORTED_PROTOCOL_VERSION as SPV } from "kinto-http";
+import { SUPPORTED_PROTOCOL_VERSION as SPV } from "../src/http";
 
 import Collection from "../src/collection";
 import BaseAdapter from "../src/adapters/base";

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -1,7 +1,10 @@
 import { v4 as uuid4 } from "uuid";
 import sinon from "sinon";
 import KintoServer from "kinto-node-test-server";
-import { Collection as KintoClientCollection, KintoIdObject } from "kinto-http";
+import {
+  Collection as KintoClientCollection,
+  KintoIdObject,
+} from "../src/http";
 import { EventEmitter } from "events";
 import Kinto from "../src";
 import Collection, {

--- a/test/setup-globals.ts
+++ b/test/setup-globals.ts
@@ -1,4 +1,5 @@
 import fetch, { Headers } from "node-fetch";
+import Blob from "../blob";
 
 // Expose a global fetch polyfill
 (global as any).fetch = fetch;
@@ -6,7 +7,10 @@ import fetch, { Headers } from "node-fetch";
 
 (global as any).FormData = require("form-data");
 
+(global as any).atob = require("atob");
 (global as any).btoa = require("btoa");
+
+(global as any).Blob = Blob;
 
 /**
  * In FakeIndexedDB, symbols are exposed using ``FDB`` prefixes in names.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,9 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "isolatedModules": true,
     "experimentalDecorators": true,
+    "downlevelIteration": true,
+    "isolatedModules": true,
     "typeRoots": ["./node_modules/@types", "./@types"]
   },
   "ts-node": {


### PR DESCRIPTION
As described in [this RFC](https://github.com/Kinto/kinto.js/issues/1725), this PR merges the source for `kinto-http` into this repo, thus reunifying the `kinto` and `kinto-http` npm packages! :tada:

This PR has tests passing, and correctly produces the `moz-kinto-http-client.js` file necessary for Firefox.

It also pins python to `3.10` and ensures the latest version of `pip` is installed in workflows that require a Kinto server.

Before we merge this, I'd like to:
- [x] Update the documentation published on [Read the Docs](https://kintojs.readthedocs.io/en/latest/) with the [README from `kinto-http`](https://github.com/Kinto/kinto-http.js/blob/master/README.md) (cc @leplatrem do you know where this is configured?)
- [x] Update the above mentioned docs with how to import just the HTTP client

Shortly after we merge, and before we release a new version of `kinto` on npm, I'd like to:
- [ ] Merge the utility functions in `src/utils.ts` and `src/http/utils.ts` (and update their tests accordingly)
- [ ] Merge the types in `src/types.ts` and `src/http/types.ts`
- [ ] Bring our various dependencies up-to-date
- [ ] Figure out a better solution than using `__dirname` to point to the `kinto.ini` used for testing