### PR TITLE
fix(deps): pin ts-node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5350,57 +5350,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/intern/node_modules/ts-node": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
-      "integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
-      "dev": true,
-      "dependencies": {
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.45",
-        "@swc/wasm": ">=1.2.45",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/intern/node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/intern/node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -13904,7 +13853,7 @@
         "resolve": "~1.20.0",
         "shell-quote": "~1.7.2",
         "source-map": "~0.6.1",
-        "ts-node": "~10.0.0",
+        "ts-node": "^10.4.0",
         "tslib": "~2.3.0",
         "ws": "~7.5.2"
       },
@@ -13928,32 +13877,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        },
-        "ts-node": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
-          "integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
-          "dev": true,
-          "requires": {
-            "@tsconfig/node10": "^1.0.7",
-            "@tsconfig/node12": "^1.0.7",
-            "@tsconfig/node14": "^1.0.0",
-            "@tsconfig/node16": "^1.0.1",
-            "arg": "^4.1.0",
-            "create-require": "^1.1.0",
-            "diff": "^4.0.1",
-            "make-error": "^1.1.1",
-            "source-map-support": "^0.5.17",
-            "yn": "3.1.1"
-          },
-          "dependencies": {
-            "diff": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-              "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-              "dev": true
-            }
-          }
         },
         "tslib": {
           "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -200,5 +200,8 @@
     "tslib": "^2.3.1",
     "typescript": "^4.5.2",
     "uglifyify": "^5.0.2"
+  },
+  "overrides": {
+    "ts-node": "$ts-node"
   }
 }


### PR DESCRIPTION
This PR ensures that one of our dependencies, `intern`, is provided with an up-to-date version of `ts-node` that's compatible with recent versions of TypeScript. It accomplishes this by using the new npm v8 feature `overrides` to ensure that the version of `ts-node` provided to `intern` is always the same version as specified in our dependencies. This is necessary since TypeScript 4.7 introduced a breaking change that was fixed in `ts-node` `v10.6.0`, which is not compatible with the version requested by `intern` (`~10.0.0`).