### PR TITLE
Update `ChromeUtils` module imports

### DIFF
--- a/fx-src/jsm_prefix.js
+++ b/fx-src/jsm_prefix.js
@@ -23,6 +23,6 @@ const globalThis = this;
 
 var EXPORTED_SYMBOLS = ["KintoHttpClient"];
 
-const { setTimeout, clearTimeout } = ChromeUtils.import("resource://gre/modules/Timer.jsm");
-const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+const { setTimeout, clearTimeout } = ChromeUtils.importESModule("resource://gre/modules/Timer.sys.mjs");
+const { XPCOMUtils } = ChromeUtils.importESModule("resource://gre/modules/XPCOMUtils.sys.mjs");
 XPCOMUtils.defineLazyGlobalGetters(global, ["fetch"]);

--- a/src/http/index.fx.ts
+++ b/src/http/index.fx.ts
@@ -18,8 +18,8 @@ import * as errors from "./errors";
 import { EventEmitter as ee } from "events";
 
 declare const ChromeUtils: any;
-const { EventEmitter } = ChromeUtils.import(
-  "resource://gre/modules/EventEmitter.jsm"
+const { EventEmitter } = ChromeUtils.importESModule(
+  "resource://gre/modules/EventEmitter.sys.mjs"
 ) as { EventEmitter: any };
 
 export default class KintoHttpClient extends KintoClientBase {


### PR DESCRIPTION
There've been several patches landed in Moz Central that have directly updated `kinto-http-client.js`. These changes all have to do with the way `ChromeUtils` modules are imported.

This commit makes it so our generated files contain these changes.

See also:
https://bugzilla.mozilla.org/show_bug.cgi?id=1777486
https://bugzilla.mozilla.org/show_bug.cgi?id=1792341
