### PR TITLE
Pin Node version used in browser tests

### DIFF
--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           python-version: "3.10"
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 


### PR DESCRIPTION
Intern, our testing library, is not currently compatible with the latest LTS release of Node (v18) which is included by default in GitHub Actions runners. This PR pins the version of Node used for our browser tests to v16 to get them working again. Other workflows are unaffected as the bug only impacts the Selenium-based browser testing flow in Intern.