### PR TITLE
ci: disable ipv6 for browser tests

### DIFF
--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -14,15 +14,17 @@ jobs:
         browser: [chrome, firefox]
 
     steps:
+      # Disabling IPv6 is necessary since Selenium doesn't listen on the IPv6
+      # interface, but node versions >16 resolve `localhost` to the IPv6
+      # loopback address (::1) by default.
+      - name: Disable IPv6
+        run: sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=1
+
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip


### PR DESCRIPTION
This PR disables IPv6 for our browser tests since Selenium only binds to the IPv4 interface, but Node 17 and up default to resolving `localhost` to the IPv6 loopback address (`::1`).