### PR TITLE
update dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 99


### PR DESCRIPTION
This PR switches our Dependabot config from updating weekly to updating monthly. This is mainly because the `@typescript-eslint` packages are updated weekly on an automated schedule, so that guarantees that there will be PRs every week. Given the amount of attention maintainers can pay, I think it's better that we get monthly Dependabot updates and a full month to resolve them before the next round of PRs.