### PR TITLE
ci: disable browser tests for chrome

### DIFF
--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -42,13 +42,5 @@ jobs:
       - name: Install Python dependencies
         run: pip install kinto kinto-attachment
 
-      - name: Pin ChromeDriver version
-        shell: pwsh
-        run: |
-          $ver = chromedriver --version | Out-String | Select-String -Pattern "ChromeDriver (\d+(\.\d+)+)" | % { $_.Matches.Groups[1].Value }
-          $con = Get-Content (Join-Path -Path '.' -ChildPath 'intern.json') | Out-String | ConvertFrom-Json
-          $con | Add-Member -MemberType NoteProperty -Name "tunnelOptions" -Value @{drivers=@(@{name="chrome"; version=$ver.trim()})}
-          $con | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path -Path '.' -ChildPath 'intern.json')
-
       - name: Run tests
         run: npm run test:${{ matrix.browser }}

--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        browser: [chrome, firefox]
+        browser: [firefox]
 
     steps:
       # Disabling IPv6 is necessary since Selenium doesn't listen on the IPv6

--- a/intern.json
+++ b/intern.json
@@ -24,18 +24,6 @@
           "fixSessionCapabilities": "no-detect"
         }
       ]
-    },
-    "chrome": {
-      "bail": true,
-      "environments": [
-        {
-          "browserName": "chrome",
-          "goog:chromeOptions": {
-            "args": ["disk-cache-dir=/dev/null", "headless", "disable-gpu"]
-          },
-          "fixSessionCapabilities": "no-detect"
-        }
-      ]
     }
   }
 }


### PR DESCRIPTION
This PR disables Chrome browser tests since Intern is unable to download the appropriate chromedriver due to the recent introduction of the [Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) program.