### PR TITLE
Drop gzipped option when uploading attachments

### DIFF
--- a/src/http/collection.ts
+++ b/src/http/collection.ts
@@ -445,7 +445,6 @@ export default class Collection {
    * @param  {Number}  [options.last_modified] The last_modified option.
    * @param  {Object}  [options.permissions]   The permissions option.
    * @param  {String}  [options.filename]      Force the attachment filename.
-   * @param  {String}  [options.gzipped]       Force the attachment to be gzipped or not.
    * @return {Promise<Object, Error>}
    */
   @capable(["attachments"])
@@ -459,7 +458,6 @@ export default class Collection {
       last_modified?: number;
       permissions?: { [key in Permission]?: string[] };
       filename?: string;
-      gzipped?: boolean;
     } = {}
   ): Promise<
     KintoResponse<{
@@ -477,7 +475,6 @@ export default class Collection {
       {
         last_modified,
         filename: options.filename,
-        gzipped: options.gzipped,
         headers: this._getHeaders(options),
         safe: this._getSafe(options),
       }

--- a/src/http/requests.ts
+++ b/src/http/requests.ts
@@ -5,7 +5,6 @@ interface RequestOptions {
   safe?: boolean;
   headers?: Headers | Record<string, string> | string[][];
   method?: HttpMethod;
-  gzipped?: boolean | null;
   last_modified?: number;
   patch?: boolean;
 }
@@ -159,19 +158,15 @@ export function addAttachmentRequest(
   { data, permissions }: RecordRequestBody = {},
   options: AddAttachmentRequestOptions = {}
 ): KintoRequest {
-  const { headers, safe, gzipped } = { ...requestDefaults, ...options };
+  const { headers, safe } = { ...requestDefaults, ...options };
   const { last_modified } = { ...data, ...options };
 
   const body = { data, permissions };
   const formData = createFormData(dataURI, body, options);
 
-  const customPath = `${path}${
-    gzipped !== null ? "?gzipped=" + (gzipped ? "true" : "false") : ""
-  }`;
-
   return {
     method: "POST",
-    path: customPath,
+    path,
     headers: { ...headers, ...safeHeader(safe, last_modified) },
     body: formData,
   };

--- a/test/http/requests_test.ts
+++ b/test/http/requests_test.ts
@@ -228,21 +228,5 @@ describe("requests module", () => {
         .to.have.property("If-Match")
         .eql('"42"');
     });
-
-    it("should support a gzipped option passed with true", () => {
-      expect(
-        requests.addAttachmentRequest("/foo", dataURL, {}, { gzipped: true })
-      )
-        .to.have.property("path")
-        .eql("/foo?gzipped=true");
-    });
-
-    it("should support a gzipped option passed with false", () => {
-      expect(
-        requests.addAttachmentRequest("/foo", dataURL, {}, { gzipped: false })
-      )
-        .to.have.property("path")
-        .eql("/foo?gzipped=false");
-    });
   });
 });


### PR DESCRIPTION
Option was dropped on the server https://github.com/Kinto/kinto-attachment/pull/724